### PR TITLE
Inline parsing extensible

### DIFF
--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/ParseBenchmark.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/ParseBenchmark.java
@@ -1,0 +1,67 @@
+package org.commonmark.integration;
+
+import org.commonmark.node.Image;
+import org.commonmark.node.Node;
+import org.commonmark.parser.InlineParser;
+import org.commonmark.parser.Parser;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Measurement(batchSize = 10000, iterations = 5)
+@Warmup(batchSize = 10000, iterations = 5)
+public class ParseBenchmark {
+    private static final Parser regularParser = Parser.builder().build();
+
+    private static final InlineParser.NodeExtension nodeExtensionWithRegex = new InlineParser.NodeExtension() {
+        private final Pattern pattern = Pattern.compile("~(?<title>[a-zA-Z]+)~(?<destination>[\\/a-zA-Z.]+)");
+
+        @Override
+        public List<InlineBreakdown> lookup(String inline) {
+            List<InlineBreakdown> nodesBreakDown = new ArrayList<>();
+
+            Matcher matcher = pattern.matcher(inline);
+            while (matcher.find()) {
+                nodesBreakDown.add(InlineBreakdown.of(
+                        new Image(matcher.group("destination"), matcher.group("title")),
+                        matcher.start(),
+                        matcher.end()));
+            }
+            return nodesBreakDown;
+        }
+    };
+    private static final Parser parserExtension = Parser.builder().nodeExtension(nodeExtensionWithRegex).build();
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + ParseBenchmark.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public Node parseImageRegularUsage() {
+        return regularParser.parse("![text](/url.png)");
+    }
+
+    @Benchmark
+    public Node parseImageByNodeExtension() {
+        return parserExtension.parse("Some text ~image~/url.png");
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
@@ -63,6 +63,7 @@ public class DocumentParser implements ParserState {
     private final List<BlockParserFactory> blockParserFactories;
     private final InlineParserFactory inlineParserFactory;
     private final List<DelimiterProcessor> delimiterProcessors;
+    private final List<InlineParser.NodeExtension> nodeExtensions;
     private final DocumentBlockParser documentBlockParser;
     private final Map<String, LinkReferenceDefinition> definitions = new LinkedHashMap<>();
 
@@ -71,10 +72,12 @@ public class DocumentParser implements ParserState {
     private Set<BlockParser> allBlockParsers = new LinkedHashSet<>();
 
     public DocumentParser(List<BlockParserFactory> blockParserFactories, InlineParserFactory inlineParserFactory,
-                          List<DelimiterProcessor> delimiterProcessors) {
+                          List<DelimiterProcessor> delimiterProcessors,
+                          List<InlineParser.NodeExtension> nodeExtensions) {
         this.blockParserFactories = blockParserFactories;
         this.inlineParserFactory = inlineParserFactory;
         this.delimiterProcessors = delimiterProcessors;
+        this.nodeExtensions = nodeExtensions;
 
         this.documentBlockParser = new DocumentBlockParser();
         activateBlockParser(this.documentBlockParser);
@@ -415,7 +418,7 @@ public class DocumentParser implements ParserState {
      * Walk through a block & children recursively, parsing string content into inline content where appropriate.
      */
     private void processInlines() {
-        InlineParserContextImpl context = new InlineParserContextImpl(delimiterProcessors, definitions);
+        InlineParserContextImpl context = new InlineParserContextImpl(delimiterProcessors, definitions, nodeExtensions);
         InlineParser inlineParser = inlineParserFactory.create(context);
 
         for (BlockParser blockParser : allBlockParsers) {

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserContextImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserContextImpl.java
@@ -1,6 +1,7 @@
 package org.commonmark.internal;
 
 import org.commonmark.node.LinkReferenceDefinition;
+import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.InlineParserContext;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 
@@ -11,11 +12,14 @@ public class InlineParserContextImpl implements InlineParserContext {
 
     private final List<DelimiterProcessor> delimiterProcessors;
     private final Map<String, LinkReferenceDefinition> linkReferenceDefinitions;
+    private final List<InlineParser.NodeExtension> nodeExtensions;
 
     public InlineParserContextImpl(List<DelimiterProcessor> delimiterProcessors,
-                                   Map<String, LinkReferenceDefinition> linkReferenceDefinitions) {
+                                   Map<String, LinkReferenceDefinition> linkReferenceDefinitions,
+                                   List<InlineParser.NodeExtension> nodeExtensions) {
         this.delimiterProcessors = delimiterProcessors;
         this.linkReferenceDefinitions = linkReferenceDefinitions;
+        this.nodeExtensions = nodeExtensions;
     }
 
     @Override
@@ -26,5 +30,10 @@ public class InlineParserContextImpl implements InlineParserContext {
     @Override
     public LinkReferenceDefinition getLinkReferenceDefinition(String label) {
         return linkReferenceDefinitions.get(label);
+    }
+
+    @Override
+    public List<InlineParser.NodeExtension> nodeExtensions() {
+        return nodeExtensions;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -167,11 +167,7 @@ public class InlineParserImpl implements InlineParser {
     public void parse(String content, Node block) {
         reset(content.trim());
 
-        ArrayDeque<NodeExtension.InlineBreakdown> customNodes = new ArrayDeque<>();
-
-        for (NodeExtension.InlineBreakdown inlineBreakdownNode : customNodesByExtensions()) {
-            customNodes.add(inlineBreakdownNode);
-        }
+        ArrayDeque<NodeExtension.InlineBreakdown> customNodes = new ArrayDeque<>(customNodesByExtensions());
 
         Node previous = null;
         while (true) {

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -213,15 +213,17 @@ public class InlineParserImpl implements InlineParser {
         NodeExtension.InlineBreakdown inlineBreakdown = customNodes.isEmpty()
                 ? NodeExtension.InlineBreakdown.EMPTY
                 : customNodes.getFirst();
+        int nextBeginIndexForCustomNode = inlineBreakdown.getBeginIndex();
 
         if (inlineBreakdown.getBeginIndex() == index) {
-            while (index <= inlineBreakdown.getEndIndex()) {
+            while (index < inlineBreakdown.getEndIndex()) {
                 index++;
             }
             return customNodes.pollFirst().getNode();
+        } else if (inlineBreakdown.getBeginIndex() < index) {
+            customNodes.pollFirst();
+            nextBeginIndexForCustomNode = input.length();
         }
-
-        int nextBeginIndexForCustomNode = inlineBreakdown.getBeginIndex();
 
         char c = peek();
         if (c == '\0') {

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -6,12 +6,26 @@ import org.commonmark.internal.util.Escaping;
 import org.commonmark.internal.util.Html5Entities;
 import org.commonmark.internal.util.LinkScanner;
 import org.commonmark.internal.util.Parsing;
-import org.commonmark.node.*;
+import org.commonmark.node.Code;
+import org.commonmark.node.HardLineBreak;
+import org.commonmark.node.HtmlInline;
+import org.commonmark.node.Image;
+import org.commonmark.node.Link;
+import org.commonmark.node.LinkReferenceDefinition;
+import org.commonmark.node.Node;
+import org.commonmark.node.SoftLineBreak;
+import org.commonmark.node.Text;
 import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.InlineParserContext;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -56,6 +70,7 @@ public class InlineParserImpl implements InlineParser {
     private final BitSet delimiterCharacters;
     private final Map<Character, DelimiterProcessor> delimiterProcessors;
     private final InlineParserContext context;
+    private final List<NodeExtension> nodeExtensions;
 
     private String input;
     private int index;
@@ -77,6 +92,7 @@ public class InlineParserImpl implements InlineParser {
         this.specialCharacters = calculateSpecialCharacters(delimiterCharacters);
 
         this.context = inlineParserContext;
+        this.nodeExtensions = inlineParserContext.nodeExtensions();
     }
 
     public static BitSet calculateDelimiterCharacters(Set<Character> characters) {
@@ -147,6 +163,11 @@ public class InlineParserImpl implements InlineParser {
     @Override
     public void parse(String content, Node block) {
         reset(content.trim());
+
+        List<Node> nodes = customNodesByExtensions();
+        for (Node node : nodes) {
+            block.appendChild(node);
+        }
 
         Node previous = null;
         while (true) {
@@ -382,6 +403,41 @@ public class InlineParserImpl implements InlineParser {
         }
 
         return node;
+    }
+
+    /**
+     * Attempt to parse delimiters like emphasis, strong emphasis or custom delimiters.
+     */
+    private List<Node> customNodesByExtensions() {
+//        DelimiterData res = scanDelimiters(delimiterProcessor, delimiterChar);
+//        if (res == null) {
+//            return null;
+//        }
+//        int length = res.count;
+        int startIndex = index;
+//
+//        index += length;
+        List<Node> nodes = new ArrayList<>();
+
+        for (NodeExtension nodeExtension : nodeExtensions) {
+            List<NodeExtension.InlineBreakdown> inlineBreakdowns = nodeExtension.lookup(input);
+
+            for (NodeExtension.InlineBreakdown breakdown : inlineBreakdowns) {
+                nodes.add(breakdown.getNode());
+            }
+        }
+
+//        Text node = text(input);
+
+        // Add entry to stack for this opener
+//        lastDelimiter = new Delimiter(node, delimiterChar, res.canOpen, res.canClose, lastDelimiter);
+//        lastDelimiter.length = length;
+//        lastDelimiter.originalLength = length;
+//        if (lastDelimiter.previous != null) {
+//            lastDelimiter.previous.next = lastDelimiter;
+//        }
+
+        return nodes;
     }
 
     /**

--- a/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
@@ -15,8 +15,17 @@ public interface InlineParser {
      */
     void parse(String input, Node node);
 
+    /**
+     *  Extension for inline content
+     */
     interface NodeExtension {
-        List<InlineBreakdown> lookup(String inline);
+        /**
+         * The listing contains the all nodes that should be applied to this current line with the respective line positions
+         *
+         * @param input is the content to be parsed as custom nodes
+         * @return list of nodes with their location in the current line
+         */
+        List<InlineBreakdown> lookup(String input);
 
         class InlineBreakdown {
             public static final InlineBreakdown EMPTY =
@@ -43,6 +52,16 @@ public interface InlineParser {
                 return endIndex;
             }
 
+
+            /**
+             * Inline Object to provide the {@code node} and node's line position
+             * @param node such as the {@code Image}, {@code Link}, etc.
+             * @param beginIndex as String.subString usage, the beginning index, inclusive.
+             * @param endIndex as String.subString usage, the ending index, exclusive.
+             * @exception  IllegalArgumentException  if the {@code endIndex} < {@code beginIndex}
+             * @return {@code InlineBreakdown} built,
+             *          if {@code beginIndex} == {@code endIndex} it will considered empty object
+             */
             public static InlineBreakdown of(Node node, int beginIndex, int endIndex) {
                 if (endIndex < beginIndex){
                     throw new IllegalArgumentException("beginIndex "+ beginIndex +" must be greater then endIndex " + endIndex);

--- a/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
@@ -2,6 +2,8 @@ package org.commonmark.parser;
 
 import org.commonmark.node.Node;
 
+import java.util.List;
+
 /**
  * Parser for inline content (text, links, emphasized text, etc).
  */
@@ -12,4 +14,22 @@ public interface InlineParser {
      * @param node the node to append resulting nodes to (as children)
      */
     void parse(String input, Node node);
+
+    interface NodeExtension {
+        List<InlineBreakdown> lookup(String inline);
+
+        class InlineBreakdown {
+            int startIndex;
+            int endIndex;
+            Node node;
+
+            public InlineBreakdown(Node node) {
+                this.node = node;
+            }
+
+            public Node getNode() {
+                return this.node;
+            }
+        }
+    }
 }

--- a/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
@@ -19,11 +19,13 @@ public interface InlineParser {
         List<InlineBreakdown> lookup(String inline);
 
         class InlineBreakdown {
+            public static final InlineBreakdown EMPTY =
+                    new InlineBreakdown(null, Integer.MAX_VALUE, Integer.MAX_VALUE);
             private final Node node;
             private final int beginIndex;
             private final int endIndex;
 
-            public InlineBreakdown(Node node, int beginIndex, int endIndex) {
+            private InlineBreakdown(Node node, int beginIndex, int endIndex) {
                 this.node = node;
                 this.beginIndex = beginIndex;
                 this.endIndex = endIndex;
@@ -39,6 +41,18 @@ public interface InlineParser {
 
             public int getEndIndex() {
                 return endIndex;
+            }
+
+            public static InlineBreakdown of(Node node, int beginIndex, int endIndex) {
+                if (endIndex < beginIndex){
+                    throw new IllegalArgumentException("beginIndex "+ beginIndex +" must be greater then endIndex " + endIndex);
+                }
+
+                if (beginIndex == endIndex) {
+                    return EMPTY;
+                }
+
+                return new InlineBreakdown(node, beginIndex, endIndex);
             }
         }
     }

--- a/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
@@ -19,16 +19,26 @@ public interface InlineParser {
         List<InlineBreakdown> lookup(String inline);
 
         class InlineBreakdown {
-            int startIndex;
-            int endIndex;
-            Node node;
+            private final Node node;
+            private final int beginIndex;
+            private final int endIndex;
 
-            public InlineBreakdown(Node node) {
+            public InlineBreakdown(Node node, int beginIndex, int endIndex) {
                 this.node = node;
+                this.beginIndex = beginIndex;
+                this.endIndex = endIndex;
             }
 
             public Node getNode() {
                 return this.node;
+            }
+
+            public int getBeginIndex() {
+                return beginIndex;
+            }
+
+            public int getEndIndex() {
+                return endIndex;
             }
         }
     }

--- a/commonmark/src/main/java/org/commonmark/parser/InlineParserContext.java
+++ b/commonmark/src/main/java/org/commonmark/parser/InlineParserContext.java
@@ -22,4 +22,6 @@ public interface InlineParserContext {
      * @return the definition if one exists, {@code null} otherwise
      */
     LinkReferenceDefinition getLinkReferenceDefinition(String label);
+
+    List<InlineParser.NodeExtension> nodeExtensions();
 }

--- a/commonmark/src/main/java/org/commonmark/parser/Parser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/Parser.java
@@ -31,17 +31,20 @@ public class Parser {
     private final List<DelimiterProcessor> delimiterProcessors;
     private final InlineParserFactory inlineParserFactory;
     private final List<PostProcessor> postProcessors;
+    private final List<InlineParser.NodeExtension> nodeExtensions;
 
     private Parser(Builder builder) {
         this.blockParserFactories = DocumentParser.calculateBlockParserFactories(builder.blockParserFactories, builder.enabledBlockTypes);
         this.inlineParserFactory = builder.getInlineParserFactory();
         this.postProcessors = builder.postProcessors;
         this.delimiterProcessors = builder.delimiterProcessors;
+        this.nodeExtensions = builder.nodeExtensions;
 
         // Try to construct an inline parser. Invalid configuration might result in an exception, which we want to
         // detect as soon as possible.
         this.inlineParserFactory.create(new InlineParserContextImpl(delimiterProcessors,
-                Collections.<String, LinkReferenceDefinition>emptyMap()));
+                Collections.<String, LinkReferenceDefinition>emptyMap(),
+                nodeExtensions));
     }
 
     /**
@@ -99,7 +102,7 @@ public class Parser {
     }
 
     private DocumentParser createDocumentParser() {
-        return new DocumentParser(blockParserFactories, inlineParserFactory, delimiterProcessors);
+        return new DocumentParser(blockParserFactories, inlineParserFactory, delimiterProcessors, nodeExtensions);
     }
 
     private Node postProcess(Node document) {
@@ -115,6 +118,7 @@ public class Parser {
     public static class Builder {
         private final List<BlockParserFactory> blockParserFactories = new ArrayList<>();
         private final List<DelimiterProcessor> delimiterProcessors = new ArrayList<>();
+        private final List<InlineParser.NodeExtension> nodeExtensions = new ArrayList<>();
         private final List<PostProcessor> postProcessors = new ArrayList<>();
         private Set<Class<? extends Block>> enabledBlockTypes = DocumentParser.getDefaultBlockParserTypes();
         private InlineParserFactory inlineParserFactory;
@@ -256,6 +260,11 @@ public class Parser {
                     return new InlineParserImpl(inlineParserContext);
                 }
             };
+        }
+
+        public Builder nodeExtension(InlineParser.NodeExtension nodeExtension) {
+            this.nodeExtensions.add(nodeExtension);
+            return this;
         }
     }
 

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -348,6 +348,26 @@ public class ParserTest {
     }
 
     @Test
+    public void convertLineByNodeExtensionShouldIgnoreTheNextComponentIfStartingEqualTheNextOneInTheList() {
+        final Node image1 = new Image();
+        InlineParser.NodeExtension nodeExtension = new InlineParser.NodeExtension() {
+            @Override
+            public List<InlineBreakdown> lookup(String inline) {
+                List<InlineBreakdown> inlinesBreakdown = new ArrayList<>();
+                inlinesBreakdown.add(InlineBreakdown.of(image1, 0, 3));
+                inlinesBreakdown.add(InlineBreakdown.of(new Image(), 0, 4));
+                return inlinesBreakdown;
+            }
+        };
+        Parser parser = Parser.builder().nodeExtension(nodeExtension).build();
+
+        Node document = parser.parse("foo jack some");
+        assertThat(document.getFirstChild().getFirstChild(), equalTo(image1));
+        assertThat(getLiteral(document.getFirstChild().getFirstChild().getNext()),
+                equalTo(" jack some"));
+    }
+
+    @Test
     public void threading() throws Exception {
         InlineParser.NodeExtension nodeExtension = new InlineParser.NodeExtension() {
             @Override

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -128,13 +128,12 @@ public class ParserTest {
         InlineParser.NodeExtension nodeExtension = new InlineParser.NodeExtension() {
             @Override
             public List<InlineBreakdown> lookup(String inline) {
-                return singletonList(new InlineBreakdown(new Image(), 0, 64));
+                return singletonList(new InlineBreakdown(new Image(), 0, 8));
             }
         };
         Parser parser = Parser.builder().nodeExtension(nodeExtension).build();
-        String input = "some text to be converted to image node by node extension handler";
 
-        Node document = parser.parse(input);
+        Node document = parser.parse("some text");
         assertThat(document.getFirstChild().getFirstChild(), instanceOf(Image.class));
     }
 
@@ -147,11 +146,11 @@ public class ParserTest {
             }
         };
         Parser parser = Parser.builder().nodeExtension(nodeExtension).build();
-        String input = "CONVERTED_TO_IMAGE some";
 
-        Node document = parser.parse(input);
+        Node document = parser.parse("CONVERTED_TO_IMAGE some");
         assertThat(document.getFirstChild().getFirstChild(), instanceOf(Image.class));
         assertThat(document.getFirstChild().getLastChild(), instanceOf(Text.class));
+        assertThat(getLiteral(document.getFirstChild().getLastChild()), equalTo(" some"));
     }
 
     @Test
@@ -163,10 +162,10 @@ public class ParserTest {
             }
         };
         Parser parser = Parser.builder().nodeExtension(nodeExtension).build();
-        String input = "some CONVERTED_TO_IMAGE";
 
-        Node document = parser.parse(input);
+        Node document = parser.parse("some CONVERTED_TO_IMAGE");
         assertThat(document.getFirstChild().getFirstChild(), instanceOf(Text.class));
+        assertThat(getLiteral(document.getFirstChild().getFirstChild()), equalTo("some "));
         assertThat(document.getFirstChild().getLastChild(), instanceOf(Image.class));
     }
 
@@ -182,6 +181,8 @@ public class ParserTest {
 
     // test to guarantee customExtension priority over DelimiterProcessor
 
+
+    // benchmark with custom vs without custom
 
 
 
@@ -217,7 +218,14 @@ public class ParserTest {
             assertThat(n, notNullValue());
             n = n.getFirstChild();
         }
-        return ((Text) n).getLiteral();
+        return getLiteral(n);
+    }
+
+    private String getLiteral(Node node) {
+        if (node instanceof Text) {
+            return ((Text)node).getLiteral();
+        }
+        return node.toString();
     }
 
     private static class DashBlock extends CustomBlock {

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -23,6 +24,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -120,6 +123,21 @@ public class ParserTest {
         String input = "**bold** **bold** ~~strikethrough~~";
 
         assertThat(parser.parse(input).getFirstChild().getFirstChild(), instanceOf(ThematicBreak.class));
+    }
+
+    @Test
+    public void convertLineToCustomNodeByNodeExtensionHandler() {
+        InlineParser.NodeExtension nodeExtension = new InlineParser.NodeExtension() {
+            @Override
+            public List<InlineBreakdown> lookup(String inline) {
+                return singletonList(new InlineBreakdown(new Image()));
+            }
+        };
+        Parser parser = Parser.builder().nodeExtension(nodeExtension).build();
+        String input = "some text to be converted to image node by node extension handler";
+
+        Node document = parser.parse(input);
+        assertThat(document.getFirstChild().getFirstChild(), instanceOf(Image.class));
     }
 
     @Test


### PR DESCRIPTION
This PR is one idea to make an **extensible inline process** through the interface `NodeExtension` where the client can implement how they want that the parser understanding the nodes in that line by the method `List<InlineBreakdown> lookup(String input);`.

So taking this case for example https://github.com/noties/Markwon/issues/67.
The user needs to make the inline parser understanding how to handle this new format `~bug ~"Multiple word fea"`

For this one is just needed one extension that based on the line provides the Nodes(or Custom Nodes) with their respective line positions:
```java
InlineParser.NodeExtension nodeExtension = new InlineParser.NodeExtension() {
    @Override
    public List<InlineBreakdown> lookup(String inline) {
        Matcher matcher = MAGIC_PATTERN.matcher(inline);
        List<InlineBreakdown> inlinesBreakdown = new ArrayList<>();
        while (matcher.find()) {
                inlinesBreakdown.add(InlineBreakdown.of(new Image(...), matcher.start(), matcher.end()));
        }
        return inlinesBreakdown;
    }
};
Parser parser = Parser.builder().nodeExtension(nodeExtension).build();
Node document = parser.parse("Some text ~bug ~\"Multiple word fea\"");
```

There are some conventions in the case of conflicts such as:

- If two nodes are in overlapping each other, the resolution will take the lowest beginIndex and the second it will be ignored;
- If two extensions registered to provide Node with the same beginIndex, the first registered will win respecting the ArrayList sort. (As suggested #113 we can have an enhancement to set rank by NodeExtension ahead;

Pls, let me know what do you think and about the terminologies that I tried. All feedback is very welcome. 

#113 