### PR TITLE
add dot match in metadata

### DIFF
--- a/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/internal/YamlFrontMatterBlockParser.java
+++ b/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/internal/YamlFrontMatterBlockParser.java
@@ -13,7 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class YamlFrontMatterBlockParser extends AbstractBlockParser {
-    private static final Pattern REGEX_METADATA = Pattern.compile("^[ ]{0,3}([A-Za-z0-9_-]+):\\s*(.*)");
+    private static final Pattern REGEX_METADATA = Pattern.compile("^[ ]{0,3}([A-Za-z0-9._-]+):\\s*(.*)");
     private static final Pattern REGEX_METADATA_LIST = Pattern.compile("^[ ]+-\\s*(.*)");
     private static final Pattern REGEX_METADATA_LITERAL = Pattern.compile("^\\s*(.*)");
     private static final Pattern REGEX_BEGIN = Pattern.compile("^-{3}(\\s.*)?");

--- a/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterTest.java
+++ b/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterTest.java
@@ -310,6 +310,25 @@ public class YamlFrontMatterTest extends RenderingTestCase {
         assertTrue(data.containsKey("see"));
         assertEquals(Collections.singletonList("you"), data.get("see"));
     }
+    
+    @Test
+    public void dotInKeys() {
+        final String input = "---" +
+                "\nms.author: author" +
+                "\n---" +
+                "\n";
+
+        YamlFrontMatterVisitor visitor = new YamlFrontMatterVisitor();
+        Node document = PARSER.parse(input);
+        document.accept(visitor);
+
+        Map<String, List<String>> data = visitor.getData();
+
+        assertEquals(1, data.size());
+        assertEquals("ms.author", data.keySet().iterator().next());
+        assertEquals(1, data.get("ms.author").size());
+        assertEquals("author", data.get("key").get(0));
+    }
 
     @Override
     protected String render(String source) {

--- a/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterTest.java
+++ b/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterTest.java
@@ -327,7 +327,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
         assertEquals(1, data.size());
         assertEquals("ms.author", data.keySet().iterator().next());
         assertEquals(1, data.get("ms.author").size());
-        assertEquals("author", data.get("key").get(0));
+        assertEquals("author", data.get("ms.author").get(0));
     }
 
     @Override


### PR DESCRIPTION
Sometimes we will have key like **a.b** in metadata, wish it will be support.

e.g. Below format:
```
---
ms.author: author
ms.date: yyyy/MM/dd
---
```