### PR TITLE
Fix Unicode handling in emphasis parsing (flanking rules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## [Unreleased]
+### Fixed
+- Fix emphasis surrounded by non-BMP punctuation/whitespace characters
+  (characters that are longer than one UTF-16 "char"). Note that this is
+  an edge case with rarely used Unicode characters, which a lot of other
+  implementations don't handle correctly.
+
 ## [0.17.0] - 2021-01-15
 ### Changed
 - **ACTION REQUIRED**: Maven groupId has changed from `com.atlassian.commonmark` to `org.commonmark`
@@ -314,6 +321,7 @@ Initial release of commonmark-java, a port of commonmark.js with extensions
 for autolinking URLs, GitHub flavored strikethrough and tables.
 
 
+[Unreleased]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.17.0...HEAD
 [0.17.0]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.16.1...commonmark-parent-0.17.0
 [0.16.1]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.15.2...commonmark-parent-0.16.1
 [0.15.2]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.15.1...commonmark-parent-0.15.2

--- a/commonmark/src/main/java/org/commonmark/internal/inline/Scanner.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/Scanner.java
@@ -57,10 +57,37 @@ public class Scanner {
         }
     }
 
-    public char peekPrevious() {
+    public int peekCodePoint() {
+        if (index < lineLength) {
+            char c = line.getContent().charAt(index);
+            if (Character.isHighSurrogate(c) && index + 1 < lineLength) {
+                char low = line.getContent().charAt(index + 1);
+                if (Character.isLowSurrogate(low)) {
+                    return Character.toCodePoint(c, low);
+                }
+            }
+            return c;
+        } else {
+            if (lineIndex < lines.size() - 1) {
+                return '\n';
+            } else {
+                // Don't return newline for end of last line
+                return END;
+            }
+        }
+    }
+
+    public int peekPreviousCodePoint() {
         if (index > 0) {
             int prev = index - 1;
-            return line.getContent().charAt(prev);
+            char c = line.getContent().charAt(prev);
+            if (Character.isLowSurrogate(c) && prev > 0) {
+                char high = line.getContent().charAt(prev - 1);
+                if (Character.isHighSurrogate(high)) {
+                    return Character.toCodePoint(high, c);
+                }
+            }
+            return c;
         } else {
             if (lineIndex > 0) {
                 return '\n';

--- a/commonmark/src/main/java/org/commonmark/internal/util/Parsing.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Parsing.java
@@ -111,6 +111,48 @@ public class Parsing {
         return false;
     }
 
+    // See https://spec.commonmark.org/0.29/#punctuation-character
+    public static boolean isPunctuationCodePoint(int codePoint) {
+        switch (Character.getType(codePoint)) {
+            case Character.CONNECTOR_PUNCTUATION:
+            case Character.DASH_PUNCTUATION:
+            case Character.END_PUNCTUATION:
+            case Character.FINAL_QUOTE_PUNCTUATION:
+            case Character.INITIAL_QUOTE_PUNCTUATION:
+            case Character.OTHER_PUNCTUATION:
+            case Character.START_PUNCTUATION:
+                return true;
+            default:
+                switch (codePoint) {
+                    case '$':
+                    case '+':
+                    case '<':
+                    case '=':
+                    case '>':
+                    case '^':
+                    case '`':
+                    case '|':
+                    case '~':
+                        return true;
+                    default:
+                        return false;
+                }
+        }
+    }
+
+    public static boolean isWhitespaceCodePoint(int codePoint) {
+        switch (codePoint) {
+            case ' ':
+            case '\t':
+            case '\r':
+            case '\n':
+            case '\f':
+                return true;
+            default:
+                return Character.getType(codePoint) == Character.SPACE_SEPARATOR;
+        }
+    }
+
     /**
      * Prepares the input line replacing {@code \0}
      */

--- a/commonmark/src/test/java/org/commonmark/internal/inline/ScannerTest.java
+++ b/commonmark/src/test/java/org/commonmark/internal/inline/ScannerTest.java
@@ -33,40 +33,55 @@ public class ScannerTest {
                 SourceLine.of("cde", null)),
                 0, 0);
         assertTrue(scanner.hasNext());
-        assertEquals('\0', scanner.peekPrevious());
+        assertEquals('\0', scanner.peekPreviousCodePoint());
         assertEquals('a', scanner.peek());
         scanner.next();
 
         assertTrue(scanner.hasNext());
-        assertEquals('a', scanner.peekPrevious());
+        assertEquals('a', scanner.peekPreviousCodePoint());
         assertEquals('b', scanner.peek());
         scanner.next();
 
         assertTrue(scanner.hasNext());
-        assertEquals('b', scanner.peekPrevious());
+        assertEquals('b', scanner.peekPreviousCodePoint());
         assertEquals('\n', scanner.peek());
         scanner.next();
 
         assertTrue(scanner.hasNext());
-        assertEquals('\n', scanner.peekPrevious());
+        assertEquals('\n', scanner.peekPreviousCodePoint());
         assertEquals('c', scanner.peek());
         scanner.next();
 
         assertTrue(scanner.hasNext());
-        assertEquals('c', scanner.peekPrevious());
+        assertEquals('c', scanner.peekPreviousCodePoint());
         assertEquals('d', scanner.peek());
         scanner.next();
 
         assertTrue(scanner.hasNext());
-        assertEquals('d', scanner.peekPrevious());
+        assertEquals('d', scanner.peekPreviousCodePoint());
         assertEquals('e', scanner.peek());
         scanner.next();
 
         assertFalse(scanner.hasNext());
-        assertEquals('e', scanner.peekPrevious());
+        assertEquals('e', scanner.peekPreviousCodePoint());
         assertEquals('\0', scanner.peek());
     }
 
+    @Test
+    public void testCodePoints() {
+        Scanner scanner = new Scanner(Arrays.asList(SourceLine.of("\uD83D\uDE0A", null)), 0, 0);
+
+        assertTrue(scanner.hasNext());
+        assertEquals('\0', scanner.peekPreviousCodePoint());
+        assertEquals(128522, scanner.peekCodePoint());
+        scanner.next();
+        // This jumps chars, not code points. So jump two here
+        scanner.next();
+
+        assertFalse(scanner.hasNext());
+        assertEquals(128522, scanner.peekPreviousCodePoint());
+        assertEquals('\0', scanner.peekCodePoint());
+    }
 
     @Test
     public void testTextBetween() {

--- a/commonmark/src/test/java/org/commonmark/internal/util/ParsingTest.java
+++ b/commonmark/src/test/java/org/commonmark/internal/util/ParsingTest.java
@@ -1,0 +1,23 @@
+package org.commonmark.internal.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class ParsingTest {
+
+    @Test
+    public void isPunctuation() {
+        // From https://spec.commonmark.org/0.29/#ascii-punctuation-character
+        char[] chars = {
+                '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', // (U+0021–2F)
+                ':', ';', '<', '=', '>', '?', '@', // (U+003A–0040)
+                '[', '\\', ']', '^', '_', '`', // (U+005B–0060)
+                '{', '|', '}', '~' // (U+007B–007E)
+        };
+
+        for (char c : chars) {
+            assertTrue("Expected to be punctuation: " + c, Parsing.isPunctuationCodePoint(c));
+        }
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
@@ -176,7 +176,11 @@ public class SpecialInputTest extends CoreRenderingTestCase {
     }
 
     @Test
-    public void emph() {
-        assertRendering("*foo bar*\n", "<p><em>foo bar</em></p>\n");
+    public void unicodePunctuationEmphasis() {
+        // The character here is: U+12470 CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER
+        // Which is in Unicode category "Po" and needs 2 code units in UTF-16. That means to implement
+        // it correctly, we need to check code points, not Java chars.
+        // Note that currently the reference implementation doesn't implement this correctly (resulting in no <em>).
+        assertRendering("foo\uD809\uDC70_(bar)_", "<p>foo\uD809\uDC70<em>(bar)</em></p>\n");
     }
 }


### PR DESCRIPTION
Unicode characters before/after delimiters that use more than one UTF-16
code unit were not handled correctly.

This change fixes it by using code points instead of chars. It also
removes another unnecessary usage of regexes. Before:

    Benchmark                      Mode  Cnt    Score   Error  Units
    SpecBenchmark.parseExamples   thrpt  100  573.528 ± 3.119  ops/s

After:

    SpecBenchmark.parseExamples   thrpt  100  639.922 ± 2.627  ops/s