### PR TITLE
Fix tables with spaces before an initial `|`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ with the exception that 0.x versions can break between minor versions.
   (characters that are longer than one UTF-16 "char"). Note that this is
   an edge case with rarely used Unicode characters, which a lot of other
   implementations don't handle correctly.
+- Fix tables where the row starts with spaces and then the first `|` -
+  rows that didn't have spaces before were not affected (#199). This bug
+  is present in 0.16.1 and 0.17.0.
 
 ## [0.17.0] - 2021-01-15
 ### Changed

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
@@ -121,7 +121,8 @@ public class TableBlockParser extends AbstractBlockParser {
 
     private static List<SourceLine> split(SourceLine line) {
         CharSequence row = line.getContent();
-        int cellStart = row.charAt(0) == '|' ? 1 : 0;
+        int nonSpace = Parsing.skipSpaceTab(row, 0, row.length());
+        int cellStart = row.charAt(nonSpace) == '|' ? nonSpace + 1 : nonSpace;
         List<SourceLine> cells = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
         for (int i = cellStart; i < row.length(); i++) {

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -159,6 +159,24 @@ public class TablesTest extends RenderingTestCase {
     }
 
     @Test
+    public void spaceBeforeSeparator() {
+        assertRendering("  |Abc|Def|\n  |---|---|\n  |1|2|", "<table>\n" +
+                "<thead>\n" +
+                "<tr>\n" +
+                "<th>Abc</th>\n" +
+                "<th>Def</th>\n" +
+                "</tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr>\n" +
+                "<td>1</td>\n" +
+                "<td>2</td>\n" +
+                "</tr>\n" +
+                "</tbody>\n" +
+                "</table>\n");
+    }
+
+    @Test
     public void separatorMustNotHaveLessPartsThanHead() {
         assertRendering("Abc|Def|Ghi\n---|---\n1|2|3", "<p>Abc|Def|Ghi\n---|---\n1|2|3</p>\n");
     }
@@ -688,7 +706,7 @@ public class TablesTest extends RenderingTestCase {
         assertEquals(Arrays.asList(SourceSpan.of(3, 0, 8)), bodyRow2.getSourceSpans());
         TableCell bodyRow2Cell1 = (TableCell) bodyRow2.getFirstChild();
         TableCell bodyRow2Cell2 = (TableCell) bodyRow2.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(3, 0, 2)), bodyRow2Cell1.getSourceSpans());
+        assertEquals(Arrays.asList(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getSourceSpans());
         assertEquals(Arrays.asList(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getFirstChild().getSourceSpans());
         assertEquals(Arrays.asList(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getSourceSpans());
         assertEquals(Arrays.asList(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getFirstChild().getSourceSpans());


### PR DESCRIPTION
This bug is present in 0.16.1 and 0.17.0 and was introduced with the
source span refactorings.

Fixes #199.