### PR TITLE
Updates for CommonMark spec version 0.30

### DIFF
--- a/commonmark-test-util/src/main/resources/cmark-regression.txt
+++ b/commonmark-test-util/src/main/resources/cmark-regression.txt
@@ -4,7 +4,8 @@ Issue #113: EOL character weirdness on Windows
 (Important: first line ends with CR + CR + LF)
 
 ```````````````````````````````` example
-line1
+line1
+
 line2
 .
 <p>line1</p>
@@ -154,3 +155,39 @@ Issue #289.
 .
 <p>[a](&lt;b) c&gt;</p>
 ````````````````````````````````
+
+Issue #334 - UTF-8 BOM
+
+```````````````````````````````` example
+﻿# Hi
+.
+<h1>Hi</h1>
+````````````````````````````````
+
+Issue commonmark.js#213 - type 7 blocks can't interrupt
+paragraph
+
+```````````````````````````````` example
+- <script>
+- some text
+some other text
+</script>
+.
+<ul>
+<li>
+<script>
+</li>
+<li>some text
+some other text
+</script></li>
+</ul>
+````````````````````````````````
+
+Issue #383 - emphasis parsing.
+
+```````````````````````````````` example
+*****Hello*world****
+.
+<p>**<em><strong>Hello<em>world</em></strong></em></p>
+````````````````````````````````
+

--- a/commonmark-test-util/src/main/resources/commonmark.js-regression.txt
+++ b/commonmark-test-util/src/main/resources/commonmark.js-regression.txt
@@ -80,7 +80,7 @@ Issue jgm/CommonMark#468 - backslash at end of link definition
 <p>[]: test</p>
 ````````````````````````````````
 
-Issue jgm/commonmark.js#121 - punctuation set different
+Issue commonmark/commonmark.js#121 - punctuation set different
 
 ```````````````````````````````` example
 ^_test_
@@ -122,7 +122,15 @@ Double-encoding.
 ```````````````````````````````` example
 [XSS](javascript&amp;colon;alert%28&#039;XSS&#039;%29)
 .
-<p><a href="javascript&amp;colon;alert('XSS')">XSS</a></p>
+<p><a href="javascript&amp;colon;alert%28'XSS'%29">XSS</a></p>
+````````````````````````````````
+
+PR #179
+
+```````````````````````````````` example
+[link](https://www.example.com/home/%25batty)
+.
+<p><a href="https://www.example.com/home/%25batty">link</a></p>
 ````````````````````````````````
 
 Issue commonamrk#517 - script, pre, style close tag without
@@ -158,4 +166,53 @@ text
 text</p>
 ````````````````````````````````
 
+Issue #196.
+
+```````````````````````````````` example
+a <?
+?>
+.
+<p>a <?
+?></p>
+````````````````````````````````
+
+Issue #211
+
+```````````````````````````````` example
+[\
+foo]: /uri
+
+[\
+foo]
+.
+<p><a href="/uri"><br />
+foo</a></p>
+````````````````````````````````
+
+Issue #213 - type 7 blocks can't interrupt
+paragraph
+
+```````````````````````````````` example
+- <script>
+- some text
+some other text
+</script>
+.
+<ul>
+<li>
+<script>
+</li>
+<li>some text
+some other text
+</script></li>
+</ul>
+````````````````````````````````
+
+Issue cmark/#383 - emphasis parsing.
+
+```````````````````````````````` example
+*****Hello*world****
+.
+<p>**<em><strong>Hello<em>world</em></strong></em></p>
+````````````````````````````````
 

--- a/commonmark/src/main/java/org/commonmark/internal/HtmlBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HtmlBlockParser.java
@@ -112,8 +112,10 @@ public class HtmlBlockParser extends AbstractBlockParser {
 
             if (state.getIndent() < 4 && line.charAt(nextNonSpace) == '<') {
                 for (int blockType = 1; blockType <= 7; blockType++) {
-                    // Type 7 can not interrupt a paragraph
-                    if (blockType == 7 && matchedBlockParser.getMatchedBlockParser().getBlock() instanceof Paragraph) {
+                    // Type 7 can not interrupt a paragraph (not even a lazy one)
+                    if (blockType == 7 && (
+                            matchedBlockParser.getMatchedBlockParser().getBlock() instanceof Paragraph ||
+                                    state.getActiveBlockParser().canHaveLazyContinuationLines())) {
                         continue;
                     }
                     Pattern opener = BLOCK_PATTERNS[blockType][0];

--- a/commonmark/src/main/java/org/commonmark/internal/HtmlBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HtmlBlockParser.java
@@ -14,8 +14,8 @@ public class HtmlBlockParser extends AbstractBlockParser {
     private static final Pattern[][] BLOCK_PATTERNS = new Pattern[][]{
             {null, null}, // not used (no type 0)
             {
-                    Pattern.compile("^<(?:script|pre|style)(?:\\s|>|$)", Pattern.CASE_INSENSITIVE),
-                    Pattern.compile("</(?:script|pre|style)>", Pattern.CASE_INSENSITIVE)
+                    Pattern.compile("^<(?:script|pre|style|textarea)(?:\\s|>|$)", Pattern.CASE_INSENSITIVE),
+                    Pattern.compile("</(?:script|pre|style|textarea)>", Pattern.CASE_INSENSITIVE)
             },
             {
                     Pattern.compile("^<!--"),

--- a/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
@@ -26,7 +26,6 @@ public class LinkReferenceDefinitionParser {
     private final List<SourceSpan> sourceSpans = new ArrayList<>();
 
     private StringBuilder label;
-    private String normalizedLabel;
     private String destination;
     private char titleDelimiter;
     private StringBuilder title;
@@ -143,7 +142,6 @@ public class LinkReferenceDefinitionParser {
                 return false;
             }
 
-            this.normalizedLabel = normalizedLabel;
             state = State.DESTINATION;
 
             scanner.whitespace();
@@ -252,14 +250,13 @@ public class LinkReferenceDefinitionParser {
 
         String d = Escaping.unescapeString(destination);
         String t = title != null ? Escaping.unescapeString(title.toString()) : null;
-        LinkReferenceDefinition definition = new LinkReferenceDefinition(normalizedLabel, d, t);
+        LinkReferenceDefinition definition = new LinkReferenceDefinition(label.toString(), d, t);
         definition.setSourceSpans(sourceSpans);
         sourceSpans.clear();
         definitions.add(definition);
 
         label = null;
         referenceValid = false;
-        normalizedLabel = null;
         destination = null;
         title = null;
     }

--- a/commonmark/src/main/java/org/commonmark/internal/ListItemParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ListItemParser.java
@@ -66,6 +66,7 @@ public class ListItemParser extends AbstractBlockParser {
         if (state.getIndent() >= contentIndent) {
             return BlockContinue.atColumn(state.getColumn() + contentIndent);
         } else {
+            // Note: We'll hit this case for lazy continuation lines, they will get added later.
             return BlockContinue.none();
         }
     }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/HtmlInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/HtmlInlineParser.java
@@ -24,8 +24,6 @@ public class HtmlInlineParser implements InlineContentParser {
             .c('"').c('\'').c('=').c('<').c('>').c('`')
             .build();
 
-    private static final AsciiMatcher declaration = AsciiMatcher.builder().range('A', 'Z').build();
-
     @Override
     public ParsedInline tryParse(InlineParserState inlineParserState) {
         Scanner scanner = inlineParserState.scanner();
@@ -58,7 +56,7 @@ public class HtmlInlineParser implements InlineContentParser {
                 if (tryCdata(scanner)) {
                     return htmlInline(start, scanner);
                 }
-            } else if (declaration.matches(c)) {
+            } else if (asciiLetter.matches(c)) {
                 if (tryDeclaration(scanner)) {
                     return htmlInline(start, scanner);
                 }
@@ -187,9 +185,9 @@ public class HtmlInlineParser implements InlineContentParser {
     }
 
     private static boolean tryDeclaration(Scanner scanner) {
-        // spec: A declaration consists of the string <!, a name consisting of one or more uppercase ASCII letters,
-        // whitespace, a string of characters not including the character >, and the character >.
-        scanner.match(declaration);
+        // spec: A declaration consists of the string <!, an ASCII letter, zero or more characters not including
+        // the character >, and the character >.
+        scanner.match(asciiLetter);
         if (scanner.whitespace() <= 0) {
             return false;
         }

--- a/commonmark/src/main/java/org/commonmark/internal/util/Escaping.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Escaping.java
@@ -113,8 +113,15 @@ public class Escaping {
 
     public static String normalizeLabelContent(String input) {
         String trimmed = input.trim();
-        String lowercase = trimmed.toLowerCase(Locale.ROOT);
-        return WHITESPACE.matcher(lowercase).replaceAll(" ");
+
+        // This is necessary to correctly case fold "ẞ" to "SS":
+        // "ẞ".toLowerCase(Locale.ROOT)  -> "ß"
+        // "ß".toUpperCase(Locale.ROOT)  -> "SS"
+        // Note that doing upper first (or only upper without lower) wouldn't work because:
+        // "ẞ".toUpperCase(Locale.ROOT)  -> "ẞ"
+        String caseFolded = trimmed.toLowerCase(Locale.ROOT).toUpperCase(Locale.ROOT);
+
+        return WHITESPACE.matcher(caseFolded).replaceAll(" ");
     }
 
     private static String replaceAll(Pattern p, String s, Replacer replacer) {

--- a/commonmark/src/test/java/org/commonmark/internal/LinkReferenceDefinitionParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/internal/LinkReferenceDefinitionParserTest.java
@@ -58,7 +58,7 @@ public class LinkReferenceDefinitionParserTest {
         assertEquals(State.DESTINATION, parser.getState());
         parse("/url");
         assertEquals(State.START_TITLE, parser.getState());
-        assertDef(parser.getDefinitions().get(0), "two lines", "/url", null);
+        assertDef(parser.getDefinitions().get(0), "two\nlines", "/url", null);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class LinkReferenceDefinitionParserTest {
         assertEquals(State.DESTINATION, parser.getState());
         parse("/url");
         assertEquals(State.START_TITLE, parser.getState());
-        assertDef(parser.getDefinitions().get(0), "weird", "/url", null);
+        assertDef(parser.getDefinitions().get(0), "\nweird", "/url", null);
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/test/HtmlInlineParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/HtmlInlineParserTest.java
@@ -23,5 +23,8 @@ public class HtmlInlineParserTest extends CoreRenderingTestCase {
         assertRendering("inline <!FOO>", "<p>inline &lt;!FOO&gt;</p>\n");
         assertRendering("inline <!FOO >", "<p>inline <!FOO ></p>\n");
         assertRendering("inline <!FOO 'bar'>", "<p>inline <!FOO 'bar'></p>\n");
+
+        // Lowercase
+        assertRendering("inline <!foo bar>", "<p>inline <!foo bar></p>\n");
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/LinkReferenceDefinitionNodeTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/LinkReferenceDefinitionNodeTest.java
@@ -105,6 +105,16 @@ public class LinkReferenceDefinitionNodeTest {
         assertThat(item2.getFirstChild(), instanceOf(Paragraph.class));
     }
 
+    @Test
+    public void testDefinitionLabelCaseIsPreserved() {
+        Node document = parse("This is a paragraph with a [foo] link.\n\n[fOo]: /url 'title'");
+        List<Node> nodes = Nodes.getChildren(document);
+
+        assertThat(nodes.size(), is(2));
+        assertThat(nodes.get(0), instanceOf(Paragraph.class));
+        assertDef(nodes.get(1), "fOo");
+    }
+
     private static Node parse(String input) {
         Parser parser = Parser.builder().build();
         return parser.parse(input);

--- a/commonmark/src/test/java/org/commonmark/test/RegressionTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/RegressionTest.java
@@ -64,6 +64,8 @@ public class RegressionTest extends RenderingTestCase {
         // The only difference is that we don't change `%28` and `%29` to `(` and `)` (percent encoding is preserved)
         m.put("[XSS](javascript&amp;colon;alert%28&#039;XSS&#039;%29)\n",
                 "<p><a href=\"javascript&amp;colon;alert%28'XSS'%29\">XSS</a></p>\n");
+        // Callers should handle BOMs
+        m.put("\uFEFF# Hi\n", "<p>\uFEFF# Hi</p>\n");
 
         return m;
     }

--- a/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
@@ -183,4 +183,32 @@ public class SpecialInputTest extends CoreRenderingTestCase {
         // Note that currently the reference implementation doesn't implement this correctly (resulting in no <em>).
         assertRendering("foo\uD809\uDC70_(bar)_", "<p>foo\uD809\uDC70<em>(bar)</em></p>\n");
     }
+
+    @Test
+    public void htmlBlockInterruptingList() {
+        assertRendering("- <script>\n" +
+                "- some text\n" +
+                "some other text\n" +
+                "</script>\n", "<ul>\n" +
+                "<li>\n" +
+                "<script>\n" +
+                "</li>\n" +
+                "<li>some text\n" +
+                "some other text\n" +
+                "</script></li>\n" +
+                "</ul>\n");
+
+        assertRendering("- <script>\n" +
+                "- some text\n" +
+                "some other text\n" +
+                "\n" +
+                "</script>\n", "<ul>\n" +
+                "<li>\n" +
+                "<script>\n" +
+                "</li>\n" +
+                "<li>some text\n" +
+                "some other text</li>\n" +
+                "</ul>\n" +
+                "</script>\n");
+    }
 }


### PR DESCRIPTION
See https://spec.commonmark.org/changelog.txt

Notable changes from the spec:

* Treat `textarea` like `script`, `pre` and `style`
* Fix case folding for link reference labels in some cases (e.g. `ẞ`)
* Allow lowercase ASCII in HTML declaration
* Don't let type 7 HTML blocks interrupt lazy paragraphs either

We now also preserve the original case for the label of `LinkReferenceDefinition`. Before, we used to store the lowercased and normalized version (collapsed whitespace, etc).