### PR TITLE
Add roundtrip parsing/rendering

### DIFF
--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
@@ -53,4 +53,10 @@ public class StrikethroughDelimiterProcessor implements DelimiterProcessor {
             return 0;
         }
     }
+
+    
+    @Override
+    public int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix) {
+        return process(openingRun, closingRun);
+    }
 }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
@@ -45,7 +45,7 @@ public class TableBlockParser extends AbstractBlockParser {
 
     @Override
     public void addLine(SourceLine line) {
-        rowLines.add(line);
+        rowLines.add(line.getLiteralLine());
     }
 
     @Override

--- a/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesDelimiterProcessor.java
+++ b/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesDelimiterProcessor.java
@@ -85,4 +85,9 @@ public class ImageAttributesDelimiterProcessor implements DelimiterProcessor {
 
         return 1;
     }
+
+    @Override
+    public int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix) {
+        return process(openingRun, closingRun);
+    }
 }

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsDelimiterProcessor.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsDelimiterProcessor.java
@@ -53,4 +53,9 @@ public class InsDelimiterProcessor implements DelimiterProcessor {
             return 0;
         }
     }
+
+    @Override
+    public int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix) {
+        return process(openingRun, closingRun);
+    }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/BlockQuoteParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/BlockQuoteParser.java
@@ -59,7 +59,7 @@ public class BlockQuoteParser extends AbstractBlockParser {
             String preBlockWhitespace = "";
             
             if(nextNonSpace > 0) {
-            	if(state.getLine().getContent().subSequence(0, nextNonSpace).toString().isBlank()) {
+            	if(state.getLine().getContent().subSequence(0, nextNonSpace).toString().trim().equals("")) {
             		preBlockWhitespace = state.getLine().getContent().subSequence(0, nextNonSpace).toString();
             	}else {
             		preBlockWhitespace = Parsing.collectWhitespaceBackwards(state.getLine().getContent(), nextNonSpace, 0);

--- a/commonmark/src/main/java/org/commonmark/internal/BlockQuoteParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/BlockQuoteParser.java
@@ -11,11 +11,12 @@ public class BlockQuoteParser extends AbstractBlockParser {
 
     // Preserve original default constructor by explicitly defining one
     public BlockQuoteParser() {
-    	super();
+        super();
     }
     
-    public BlockQuoteParser(String preBlockWhitespace, String postMarkerWhitespace) {
-    	block.setWhitespace(preBlockWhitespace, postMarkerWhitespace);
+    public BlockQuoteParser(String preMarkerWhitespace, String postMarkerWhitespace) {
+        block.setPreMarkerWhitespace(preMarkerWhitespace);
+        block.setPostMarkerWhitespace(postMarkerWhitespace);
     }
     
     @Override
@@ -56,28 +57,24 @@ public class BlockQuoteParser extends AbstractBlockParser {
     public static class Factory extends AbstractBlockParserFactory {
         public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
             int nextNonSpace = state.getNextNonSpaceIndex();
-            String preBlockWhitespace = "";
+            String preMarkerWhitespace = "";
             
             if(nextNonSpace > 0) {
-            	if(state.getLine().getContent().subSequence(0, nextNonSpace).toString().trim().equals("")) {
-            		preBlockWhitespace = state.getLine().getContent().subSequence(0, nextNonSpace).toString();
-            	}else {
-            		preBlockWhitespace = Parsing.collectWhitespaceBackwards(state.getLine().getContent(), nextNonSpace, 0);
-            	}
+                preMarkerWhitespace = Parsing.collectWhitespaceBackwards(state.getLine().getContent(), nextNonSpace - 1, 0);
             }
             
             if (isMarker(state, nextNonSpace)) {
                 int newColumn = state.getColumn() + state.getIndent() + 1;
                 
                 // optional following space or tab
-                String optionalWhitespace = "";
+                String postMarkerWhitespace = "";
                 
                 if (Parsing.isSpaceOrTab(state.getLine().getContent(), nextNonSpace + 1)) {
-                	optionalWhitespace = Parsing.collectWhitespace(state.getLine().getContent(), nextNonSpace + 1, state.getLine().getContent().length() - 1);
+                    postMarkerWhitespace = Parsing.collectWhitespace(state.getLine().getContent(), nextNonSpace + 1, state.getLine().getContent().length() - 1);
                     newColumn++;
                 }
                 
-                return BlockStart.of(new BlockQuoteParser(preBlockWhitespace, optionalWhitespace)).atColumn(newColumn);
+                return BlockStart.of(new BlockQuoteParser(preMarkerWhitespace, postMarkerWhitespace)).atColumn(newColumn);
             } else {
                 return BlockStart.none();
             }

--- a/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
@@ -309,13 +309,13 @@ public class DocumentParser implements ParserState {
             }
 
             if (!blockParser.isContainer()) {
-            	// Capture any blank lines within a separate node for roundtrip purposes
-            	// BlankLine nodes do _not_ interrupt the current node type's processor
-            	if(isBlank()) {
-            		BlankLineParser blankLineParser = new BlankLineParser(ln.toString());
-            		addChild(new OpenBlockParser(blankLineParser, lastIndex));
-            	}
-            	
+                // Capture any blank lines within a separate node for roundtrip purposes
+                // BlankLine nodes do _not_ interrupt the current node type's processor
+                if(isBlank()) {
+                    BlankLineParser blankLineParser = new BlankLineParser(ln.toString());
+                    addChild(new OpenBlockParser(blankLineParser, lastIndex));
+                }
+
                 addLine();
             } else if (!isBlank()) {
                 // create paragraph container for line
@@ -335,9 +335,9 @@ public class DocumentParser implements ParserState {
                 // Capture any blank lines within a separate node for roundtrip purposes
                 // BlankLine nodes do _not_ interrupt the current node type's processor
                 if(isBlank()) {
-            		BlankLineParser blankLineParser = new BlankLineParser(ln.toString());
-            		addChild(new OpenBlockParser(blankLineParser, lastIndex));
-            	}
+                    BlankLineParser blankLineParser = new BlankLineParser(ln.toString());
+                    addChild(new OpenBlockParser(blankLineParser, lastIndex));
+                }
             }
         }
     }
@@ -445,20 +445,20 @@ public class DocumentParser implements ParserState {
             sb.append(rest);
             content = sb.toString();
         } else {
-        	content = line.getContent().toString();
+            content = line.getContent().toString();
         }
         
         SourceSpan sourceSpan = null;
         if (includeSourceSpans == IncludeSourceSpans.BLOCKS_AND_INLINES) {
             // Note that if we're in a partially-consumed tab, the length here corresponds to the content but not to the
             // actual source length. That sounds like a problem, but I haven't found a test case where it matters (yet).
-        	sourceSpan = SourceSpan.of(lineIndex, index, line.getLiteralLine().getContent().length());
+            sourceSpan = SourceSpan.of(lineIndex, index, line.getLiteralLine().getContent().length());
         }
         
         if(!columnIsInTab) {
-        	getActiveBlockParser().addLine(SourceLine.of(content, sourceSpan, index));
+            getActiveBlockParser().addLine(SourceLine.of(content, sourceSpan, index));
         }else {
-        	getActiveBlockParser().addLine(SourceLine.of(content, sourceSpan, 0));
+            getActiveBlockParser().addLine(SourceLine.of(content, sourceSpan, 0));
         }
 
         addSourceSpans();
@@ -473,7 +473,7 @@ public class DocumentParser implements ParserState {
                 int length = line.getContent().length() - blockIndex;
                 
                 if(line.getLiteralIndex() != 0) {
-                	length = line.getLiteralLine().getContent().length() - blockIndex;
+                    length = line.getLiteralLine().getContent().length() - blockIndex;
                 }
                 
                 if (length != 0) {
@@ -532,20 +532,20 @@ public class DocumentParser implements ParserState {
      * its parent, and so on until we find a block that can accept children.
      */
     private void addChild(OpenBlockParser openBlockParser) {
-    	// BlankLine nodes do _not_ interrupt the current node type's processor, as
-    	//    they are non-standard CommonMark nodes meant only for roundtrip processing
-    	if(!(openBlockParser.blockParser instanceof BlankLineParser)) {
-	        while (!getActiveBlockParser().canContain(openBlockParser.blockParser.getBlock())) {
-	            closeBlockParsers(1);
-	        }
-    	}
+        // BlankLine nodes do _not_ interrupt the current node type's processor, as
+        //    they are non-standard CommonMark nodes meant only for roundtrip processing
+        if(!(openBlockParser.blockParser instanceof BlankLineParser)) {
+            while (!getActiveBlockParser().canContain(openBlockParser.blockParser.getBlock())) {
+                closeBlockParsers(1);
+            }
+        }
 
         getActiveBlockParser().getBlock().appendChild(openBlockParser.blockParser.getBlock());
         
         // BlankLine nodes do _not_ become the active parser, as this would interrupt the
         //    parser before it
         if(!(openBlockParser.blockParser instanceof BlankLineParser)) {
-        	activateBlockParser(openBlockParser);
+            activateBlockParser(openBlockParser);
         }
     }
 
@@ -581,16 +581,15 @@ public class DocumentParser implements ParserState {
         closeBlockParsers(openBlockParsers.size());
         processInlines();
         Document docNode = documentBlockParser.getBlock();
-        String postBlockWhitespace = "";
+        String whitespaceEndOfDocument = "";
         
         // CommonMark test cases end with newlines, indicating that this should be standard
-        //    in rountrip scenarios. If a post-document whitespace doesn't exist, add it.
-        if(postBlockWhitespace.isEmpty()) {
-    		postBlockWhitespace = "\n";
-    	}
+        //    in roundtrip scenarios. If a post-document whitespace doesn't exist, add it.
+        if(whitespaceEndOfDocument.isEmpty()) {
+            whitespaceEndOfDocument = "\n";
+        }
         
-        docNode.setWhitespace(docNode.whitespacePreBlock(), docNode.whitespacePreContent(),
-        		docNode.whitespacePostContent(), postBlockWhitespace);
+        docNode.setEndOfDocumentWhitespace(whitespaceEndOfDocument);
         return documentBlockParser.getBlock();
     }
 

--- a/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
@@ -25,7 +25,7 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
         
         // Fenced code blocks can't be indented by newlines or tabs, so it's safe to assume
         //    spaces for the indentation
-        block.setWhitespace(Parsing.generateSpaces(fenceIndent));
+        block.setPreStartFenceWhitespace(Parsing.generateSpaces(fenceIndent));
     }
 
     @Override
@@ -39,15 +39,15 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
         int newIndex = state.getIndex();
         CharSequence line = state.getLine().getContent();
         if (state.getIndent() < Parsing.CODE_BLOCK_INDENT && nextNonSpace < line.length() && line.charAt(nextNonSpace) == block.getFenceChar() && isClosing(line, nextNonSpace)) {
-        	// Capture whitespace before closing fence (if any) for roundtrip purposes
+            // Capture whitespace before closing fence (if any) for roundtrip purposes
             if(nextNonSpace > 0) {
-                block.setWhitespace(block.whitespacePreBlock(), block.whitespacePreContent(), Parsing.collectWhitespace(line, 0, nextNonSpace), block.whitespacePostBlock());
+                block.setPreEndFenceWhitespace(Parsing.collectWhitespace(line, 0, nextNonSpace));
             }
             
-        	// closing fence - we're at end of line, so we can finalize now
+            // closing fence - we're at end of line, so we can finalize now
             return BlockContinue.finished();
         } else {
-        	// Capture line before optional spaces are removed
+            // Capture line before optional spaces are removed
             rawLines.append(line.toString());
             rawLines.append('\n');
             
@@ -183,7 +183,7 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
         
         // Capture post-fence spaces (if any) for roundtrip purposes
         if(after > 0 && after != (index + fences)) {
-            block.setWhitespace(block.whitespacePreBlock(), block.whitespacePreContent(), block.whitespacePostContent(), Parsing.collectWhitespaceBackwards(line, line.length() - 1, 0));
+            block.setPostBlockWhitespace(Parsing.collectWhitespaceBackwards(line, line.length() - 1, 0));
         }
         
         return after == line.length();

--- a/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
@@ -21,27 +21,19 @@ public class HeadingParser extends AbstractBlockParser {
     private final SourceLines content;
 
     public HeadingParser(int level, SourceLines content) {
-    	block.setLevel(level);
+        block.setLevel(level);
         block.setSymbolType('#');
         this.content = content;
     }
     
-    public HeadingParser(int level, SourceLines content, char symbolType, int numEndingSymbols, String... whitespace) {
+    public HeadingParser(int level, SourceLines content, char symbolType, int numEndingSymbols, String whitespacePreBlock, String whitespacePreContent, String whitespacePostContent, String whitespacePostBlock) {
         this(level, content);
         block.setSymbolType(symbolType);
         block.setNumEndingSymbol(numEndingSymbols);
-        
-        if(whitespace.length == 4) {
-            block.setWhitespace(whitespace);
-        }else {
-            String[] tempArray = {"", "", "", ""};
-            
-            for(int i = 0; i < whitespace.length; i++) {
-                tempArray[i] = whitespace[i];
-            }
-            
-            block.setWhitespace(tempArray);
-        }
+        block.setPreBlockWhitespace(whitespacePreBlock);
+        block.setPreContentWhitespace(whitespacePreContent);
+        block.setPostContentWhitespace(whitespacePostContent);
+        block.setPostBlockWhitespace(whitespacePostBlock);
     }
 
     @Override
@@ -97,12 +89,8 @@ public class HeadingParser extends AbstractBlockParser {
             if (setextHeadingLevel > 0) {
                 int numEndingSymbols = line.getContent().toString().trim().length();
                 
-                // AST: Setext headings have a slightly different twist on whitespace:
-                //      Pre-block = Before setext text begins
-                //      Pre-content = Directly after setext text
-                //      Post-content = Before setext delimiting line
-                //      Post-block = After setext delimiting line
-                String preContentWhitespace = "";
+                // AST: Setext headings have a slightly different twist on
+                //      whitespace, see the <pre>Heading</pre> class for details
                 String postContentWhitespace = Parsing.collectWhitespace(line.getContent(), 0, line.getContent().length());
                 String postBlockWhitespace = Parsing.collectWhitespaceBackwards(line.getContent(), line.getContent().length() - 1, 0);
                 
@@ -134,7 +122,7 @@ public class HeadingParser extends AbstractBlockParser {
                 
                 SourceLines paragraph = matchedBlockParser.getParagraphLines();
                 if (!paragraph.isEmpty()) {
-                    return BlockStart.of(new HeadingParser(setextHeadingLevel, paragraph, symbolType, numEndingSymbols, preBlockWhitespace, preContentWhitespace, postContentWhitespace, postBlockWhitespace))
+                    return BlockStart.of(new HeadingParser(setextHeadingLevel, paragraph, symbolType, numEndingSymbols, preBlockWhitespace, "", postContentWhitespace, postBlockWhitespace))
                             .atIndex(line.getContent().length())
                             .replaceActiveBlockParser();
                 }

--- a/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
@@ -8,7 +8,12 @@ import org.commonmark.node.Heading;
 import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.SourceLines;
-import org.commonmark.parser.block.*;
+import org.commonmark.parser.block.AbstractBlockParser;
+import org.commonmark.parser.block.AbstractBlockParserFactory;
+import org.commonmark.parser.block.BlockContinue;
+import org.commonmark.parser.block.BlockStart;
+import org.commonmark.parser.block.MatchedBlockParser;
+import org.commonmark.parser.block.ParserState;
 
 public class HeadingParser extends AbstractBlockParser {
 
@@ -16,8 +21,27 @@ public class HeadingParser extends AbstractBlockParser {
     private final SourceLines content;
 
     public HeadingParser(int level, SourceLines content) {
-        block.setLevel(level);
+    	block.setLevel(level);
+        block.setSymbolType('#');
         this.content = content;
+    }
+    
+    public HeadingParser(int level, SourceLines content, char symbolType, int numEndingSymbols, String... whitespace) {
+        this(level, content);
+        block.setSymbolType(symbolType);
+        block.setNumEndingSymbol(numEndingSymbols);
+        
+        if(whitespace.length == 4) {
+            block.setWhitespace(whitespace);
+        }else {
+            String[] tempArray = {"", "", "", ""};
+            
+            for(int i = 0; i < whitespace.length; i++) {
+                tempArray[i] = whitespace[i];
+            }
+            
+            block.setWhitespace(tempArray);
+        }
     }
 
     @Override
@@ -46,8 +70,24 @@ public class HeadingParser extends AbstractBlockParser {
 
             SourceLine line = state.getLine();
             int nextNonSpace = state.getNextNonSpaceIndex();
+
+            String preBlockWhitespace = "";
+            
             if (line.getContent().charAt(nextNonSpace) == '#') {
-                HeadingParser atxHeading = getAtxHeading(line.substring(nextNonSpace, line.getContent().length()));
+                
+                // Account for block-in-a-block instances during roundtrips, like Heading inside a List
+                if(nextNonSpace > 0) {
+                    preBlockWhitespace = Parsing.collectWhitespaceBackwards(line.getContent(), nextNonSpace - 1, 0);
+                    
+                    // If these values don't match, it's a block-in-a-block scenario because
+                    //    there's another character before the whitespace
+                    if(preBlockWhitespace.length() != nextNonSpace) {
+                        preBlockWhitespace = "";
+                    }
+                }
+
+                HeadingParser atxHeading = getAtxHeading(line.substring(nextNonSpace - preBlockWhitespace.length(), line.getContent().length()), nextNonSpace);
+                
                 if (atxHeading != null) {
                     return BlockStart.of(atxHeading).atIndex(line.getContent().length());
                 }
@@ -55,9 +95,46 @@ public class HeadingParser extends AbstractBlockParser {
 
             int setextHeadingLevel = getSetextHeadingLevel(line.getContent(), nextNonSpace);
             if (setextHeadingLevel > 0) {
+                int numEndingSymbols = line.getContent().toString().trim().length();
+                
+                // AST: Setext headings have a slightly different twist on whitespace:
+                //      Pre-block = Before setext text begins
+                //      Pre-content = Directly after setext text
+                //      Post-content = Before setext delimiting line
+                //      Post-block = After setext delimiting line
+                String preContentWhitespace = "";
+                String postContentWhitespace = Parsing.collectWhitespace(line.getContent(), 0, line.getContent().length());
+                String postBlockWhitespace = Parsing.collectWhitespaceBackwards(line.getContent(), line.getContent().length() - 1, 0);
+                
+                // If the setext had valid content, the current matched block
+                //    parser will be the paragraph parser. Setext headings use
+                //    Text (not Paragraph) in the final output, but it's still
+                //    possible to gather the right whitespace from Paragraph.
+                boolean isMatchedParagraph = matchedBlockParser.getMatchedBlockParser() instanceof ParagraphParser;
+                
+                if(isMatchedParagraph) {
+                    SourceLines rawLines = ((ParagraphParser)matchedBlockParser.getMatchedBlockParser()).getRawParagraphLines();
+                    
+                    // In some instances, the paragraph object exists but has not yet been populated.
+                    //    However, the link reference definition parser will still have the paragraph's
+                    //    lines ready for capture. If no whitespace is available yet, capture any initial
+                    //    whitespace in the first paragraph line.
+                    if(preBlockWhitespace.isEmpty() && !rawLines.isEmpty()) {
+                        CharSequence rawParagraphSequence = rawLines.getLines().get(0).getContent();
+                        preBlockWhitespace = Parsing.collectWhitespace(rawParagraphSequence.toString(), 0, rawParagraphSequence.length());
+                    }
+                }
+                
+                char symbolType;
+                if(setextHeadingLevel == 1) {
+                    symbolType = '=';
+                }else {
+                    symbolType = '-';
+                }
+                
                 SourceLines paragraph = matchedBlockParser.getParagraphLines();
                 if (!paragraph.isEmpty()) {
-                    return BlockStart.of(new HeadingParser(setextHeadingLevel, paragraph))
+                    return BlockStart.of(new HeadingParser(setextHeadingLevel, paragraph, symbolType, numEndingSymbols, preBlockWhitespace, preContentWhitespace, postContentWhitespace, postBlockWhitespace))
                             .atIndex(line.getContent().length())
                             .replaceActiveBlockParser();
                 }
@@ -72,7 +149,14 @@ public class HeadingParser extends AbstractBlockParser {
     // sequence of # characters must be followed by a space or by the end of line. The optional closing sequence of #s
     // must be preceded by a space and may be followed by spaces only.
     private static HeadingParser getAtxHeading(SourceLine line) {
+        return getAtxHeading(line, 0);
+    }
+    
+    private static HeadingParser getAtxHeading(SourceLine line, int nextNonSpace) {
+        String preBlockWhitespace = "";
+        
         Scanner scanner = Scanner.of(SourceLines.of(line));
+        preBlockWhitespace = scanner.whitespaceAsString();
         int level = scanner.matchMultiple('#');
 
         if (level == 0 || level > 6) {
@@ -89,23 +173,28 @@ public class HeadingParser extends AbstractBlockParser {
             return null;
         }
 
-        scanner.whitespace();
+        String preContentWhitespace = scanner.whitespaceAsString();
         Position start = scanner.position();
         Position end = start;
         boolean hashCanEnd = true;
+        int numEndingSymbols = 0;
+        StringBuilder postContentWhitespace = new StringBuilder();
+        String postBlockWhitespace = "";
 
         while (scanner.hasNext()) {
             char c = scanner.peek();
             switch (c) {
                 case '#':
                     if (hashCanEnd) {
-                        scanner.matchMultiple('#');
-                        int whitespace = scanner.whitespace();
+                        numEndingSymbols = scanner.matchMultiple('#');
+                        String whitespace = scanner.whitespaceAsString();
                         // If there's other characters, the hashes and spaces were part of the heading
                         if (scanner.hasNext()) {
+                            numEndingSymbols = 0;
+                            postContentWhitespace.setLength(0);
                             end = scanner.position();
                         }
-                        hashCanEnd = whitespace > 0;
+                        hashCanEnd = whitespace.length() > 0;
                     } else {
                         scanner.next();
                         end = scanner.position();
@@ -114,21 +203,29 @@ public class HeadingParser extends AbstractBlockParser {
                 case ' ':
                 case '\t':
                     hashCanEnd = true;
+                    postContentWhitespace.append(c);
                     scanner.next();
                     break;
                 default:
                     hashCanEnd = false;
+                    postContentWhitespace.setLength(0);
                     scanner.next();
                     end = scanner.position();
             }
         }
+        
+        if(numEndingSymbols > 0) {
+            int beforePostBlockWhitespaceIndex = Parsing.skipSpaceTabBackwards(line.getContent(), line.getContent().length() - 1, 0);
+            postBlockWhitespace = line.getContent().subSequence(beforePostBlockWhitespaceIndex + 1, line.getContent().length()).toString();
+        }
 
         SourceLines source = scanner.getSource(start, end);
         String content = source.getContent();
-        if (content.isEmpty()) {
-            return new HeadingParser(level, SourceLines.empty());
+        
+        if(content.isEmpty()) {
+            return new HeadingParser(level, SourceLines.empty(), '#', numEndingSymbols, preBlockWhitespace, preContentWhitespace, postContentWhitespace.toString(), postBlockWhitespace);
         }
-        return new HeadingParser(level, source);
+        return new HeadingParser(level, source, '#', numEndingSymbols, preBlockWhitespace, preContentWhitespace, postContentWhitespace.toString(), postBlockWhitespace);
     }
 
     // spec: A setext heading underline is a sequence of = characters or a sequence of - characters, with no more than

--- a/commonmark/src/main/java/org/commonmark/internal/HtmlBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HtmlBlockParser.java
@@ -96,7 +96,7 @@ public class HtmlBlockParser extends AbstractBlockParser {
 
     @Override
     public void addLine(SourceLine line) {
-    	// Raw line and literal line are the same
+        // Raw line and literal line are the same
         if(line.getLiteralIndex() == 0) {
             content.add(line.getContent());
             rawContent.add(line.getContent());

--- a/commonmark/src/main/java/org/commonmark/internal/IndentedCodeBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/IndentedCodeBlockParser.java
@@ -26,8 +26,8 @@ public class IndentedCodeBlockParser extends AbstractBlockParser {
         super();
     }
     
-    public IndentedCodeBlockParser(String preBlockWhitespace, String preContentWhitespace) {
-        block.setWhitespace(preBlockWhitespace, preContentWhitespace);
+    public IndentedCodeBlockParser(String indentWhitespace) {
+        block.setIndentWhitespace(indentWhitespace);
     }
     
     @Override
@@ -48,7 +48,7 @@ public class IndentedCodeBlockParser extends AbstractBlockParser {
 
     @Override
     public void addLine(SourceLine line) {
-    	String prefix = "";
+        String prefix = "";
         
         // Capture the prefix (needed for roundtrip, but unnecessary for HTML processing)
         if(line.getLiteralIndex() != 0) {
@@ -113,9 +113,9 @@ public class IndentedCodeBlockParser extends AbstractBlockParser {
         public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
             // An indented code block cannot interrupt a paragraph.
             if (state.getIndent() >= Parsing.CODE_BLOCK_INDENT && !state.isBlank() && !(state.getActiveBlockParser().getBlock() instanceof Paragraph)) {
-                String preContentWhitespace = Parsing.collectWhitespace(state.getLine().getContent(), 0, state.getLine().getContent().length());
+                String indentWhitespace = Parsing.collectWhitespace(state.getLine().getContent(), 0, state.getLine().getContent().length());
                 
-                return BlockStart.of(new IndentedCodeBlockParser("", preContentWhitespace)).atColumn(state.getColumn() + Parsing.CODE_BLOCK_INDENT);
+                return BlockStart.of(new IndentedCodeBlockParser(indentWhitespace)).atColumn(state.getColumn() + Parsing.CODE_BLOCK_INDENT);
             } else {
                 return BlockStart.none();
             }

--- a/commonmark/src/main/java/org/commonmark/internal/IndentedCodeBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/IndentedCodeBlockParser.java
@@ -59,7 +59,7 @@ public class IndentedCodeBlockParser extends AbstractBlockParser {
         // Strip leading whitespace off first raw line (because it's already
         //    captured by the whitespace tracker)
         if(rawLines != null && rawLines.size() == 0) {
-            rawLines.add(line.getContent().toString().stripLeading());
+            rawLines.add(line.getContent().toString().replaceFirst("^\\s+", ""));
         }else {
             rawLines.add(prefix + line.getContent());
         }

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -364,12 +364,14 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
                 whitespacePreDestination = "";
             } else {
                 whitespacePreTitle = scanner.whitespaceAsString();
-                scanner.whitespace();
+
                 // title needs a whitespace before
                 if (whitespacePreTitle.length() >= 1) {
+                    Position titleStart = scanner.position();
                     // Capture the symbol used for the title
                     titleSymbol = scanner.peek();
                     rawTitle = parseLinkTitleRaw(scanner);
+                    scanner.setPosition(titleStart);
                     title = parseLinkTitle(scanner);
                     
                     // If title isn't valid, discard the captured value of its symbol
@@ -584,8 +586,6 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         }
         
         String rawTitle = scanner.getSource(start, scanner.position()).getContent();
-        
-        rawScanner.setPosition(start);
         
         return rawTitle;
     }

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -244,7 +244,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
             
             // Preserve a prefix which has _only_ whitespace, as this may be
             //    needed in the following "parseText" method
-            if(!prefix.isEmpty() && prefix.isBlank()) {
+            if(!prefix.isEmpty() && prefix.trim().equals("")) {
                 prefix = "";
             }
             
@@ -639,7 +639,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         
         if(!prefix.isEmpty()) {
             // Capture whitespace and anything that might be a block quote for roundtrip purposes
-            if(prefix.isBlank() || prefix.contains(">")) {
+            if(prefix.trim().equals("") || prefix.contains(">")) {
                 preContentWhitespace = prefix;
             }
         }
@@ -793,7 +793,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
                     usedDelims = delimiterProcessor.process(opener, closer, prefix);
                     
                     String openerWhitespace = opener.characters.get(0).whitespacePreContent();
-                    if(!openerWhitespace.isBlank()) {
+                    if(!openerWhitespace.trim().equals("")) {
                         closer.characters.get(0).setWhitespace(openerWhitespace, "");
                     }
                     

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -184,7 +184,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
      * On failure, return null.
      */
     private List<? extends Node> parseInline() {
-    	// AST: Capture raw information needed for roundtrip rendering
+        // AST: Capture raw information needed for roundtrip rendering
         String prefix = scanner.alignToLiteral();
         
         char c = scanner.peek();
@@ -206,7 +206,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
 
         // No inline parser, delimiter or other special handling.
         if (!specialCharacters.get(c)) {
-        	List<Node> nodeList = Collections.singletonList(parseText(prefix));
+            List<Node> nodeList = Collections.singletonList(parseText(prefix));
             prefix = "";
             return nodeList;
         }
@@ -215,14 +215,14 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         if (inlineParsers != null) {
             Position position = scanner.position();
             for (InlineContentParser inlineParser : inlineParsers) {
-            	ParsedInline parsedInline;
-            	if(inlineParser instanceof BackticksInlineParser) {
+                ParsedInline parsedInline;
+                if(inlineParser instanceof BackticksInlineParser) {
                     parsedInline = inlineParser.tryParse(this, prefix);
                     prefix = "";
                 }else {
                     parsedInline = inlineParser.tryParse(this);
                 }
-            	
+                
                 if (parsedInline instanceof ParsedInlineImpl) {
                     ParsedInlineImpl parsedInlineImpl = (ParsedInlineImpl) parsedInline;
                     Node node = parsedInlineImpl.getNode();
@@ -931,7 +931,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
     }
 
     private void mergeIfNeeded(Text first, Text last, int textLength) {
-    	if (first != null && last != null && first != last) {
+        if (first != null && last != null && first != last) {
             StringBuilder sb = new StringBuilder(textLength);
             StringBuilder sb2 = new StringBuilder(textLength);
             sb.append(first.getLiteral());

--- a/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
@@ -51,11 +51,6 @@ public class LinkReferenceDefinitionParser {
         }
 
         Scanner scanner = Scanner.of(SourceLines.of(line));
-        if(line.getSourceSpan() != null) {
-            // Ensure that LinkReferenceDefinition objects can have populated source spans
-            // Source spans track literal lines, not raw lines
-            addSourceSpan(line.getLiteralLine().getSourceSpan());
-        }
         
         while (scanner.hasNext()) {
             boolean success;

--- a/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
@@ -41,10 +41,10 @@ public class LinkReferenceDefinitionParser {
     private String whitespacePostTitle = "";
 
     public void parse(SourceLine line) {
-    	paragraphLines.add(line.getLiteralLine());
+        paragraphLines.add(line.getLiteralLine());
         rawParagraphLines.add(line);
         
-    	if (state == State.PARAGRAPH) {
+        if (state == State.PARAGRAPH) {
             // We're in a paragraph now. Link reference definitions can only appear at the beginning, so once
             // we're in a paragraph, there's no going back.
             return;
@@ -65,7 +65,7 @@ public class LinkReferenceDefinitionParser {
                     break;
                 }
                 case LABEL: {
-                	// Capture line number to determine if line breaks occur
+                    // Capture line number to determine if line breaks occur
                     if(line.getSourceSpan() != null) {
                         previousLineIndex = line.getSourceSpan().getLineIndex();
                     }
@@ -74,7 +74,7 @@ public class LinkReferenceDefinitionParser {
                     break;
                 }
                 case DESTINATION: {
-                	// Check for any line breaks
+                    // Check for any line breaks
                     if(line.getSourceSpan() != null) {
                         if(line.getSourceSpan().getLineIndex() > previousLineIndex) {
                             whitespacePreDestination = whitespacePreDestination + "\n";
@@ -86,7 +86,7 @@ public class LinkReferenceDefinitionParser {
                     break;
                 }
                 case START_TITLE: {
-                	// Check for any line breaks
+                    // Check for any line breaks
                     if(line.getSourceSpan() != null) {
                         if(line.getSourceSpan().getLineIndex() > previousLineIndex) {
                             whitespacePreTitle = whitespacePreTitle + "\n";
@@ -150,7 +150,7 @@ public class LinkReferenceDefinitionParser {
     }
 
     private boolean startDefinition(Scanner scanner) {
-    	// Capture whitespace for roundtrip purposes
+        // Capture whitespace for roundtrip purposes
         whitespacePreLabel = scanner.whitespaceAsString();
         
         String whitespaceCheck = scanner.alignToLiteral();
@@ -159,7 +159,7 @@ public class LinkReferenceDefinitionParser {
             whitespacePreLabel = whitespaceCheck;
         }
         
-    	if (!scanner.next('[')) {
+        if (!scanner.next('[')) {
             return false;
         }
 
@@ -210,7 +210,7 @@ public class LinkReferenceDefinitionParser {
     }
 
     private boolean destination(Scanner scanner) {
-    	whitespacePreDestination = whitespacePreDestination +
+        whitespacePreDestination = whitespacePreDestination +
                 scanner.whitespaceAsString();
         Position start = scanner.position();
         if (!LinkScanner.scanLinkDestination(scanner)) {
@@ -239,8 +239,8 @@ public class LinkReferenceDefinitionParser {
     }
 
     private boolean startTitle(Scanner scanner) {
-    	whitespacePreTitle = whitespacePreTitle + scanner.whitespaceAsString();
-    	if (!scanner.hasNext()) {
+        whitespacePreTitle = whitespacePreTitle + scanner.whitespaceAsString();
+        if (!scanner.hasNext()) {
             state = State.START_DEFINITION;
             return true;
         }
@@ -291,7 +291,7 @@ public class LinkReferenceDefinitionParser {
         scanner.next();
         whitespacePostTitle = scanner.whitespaceAsString();
         if (scanner.hasNext()) {
-        	title = null;
+            title = null;
             whitespacePostTitle = "";
             // spec: No further non-whitespace characters may occur on the line.
             return false;

--- a/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
@@ -135,7 +135,7 @@ public class ListBlockParser extends AbstractBlockParser {
             case '-':
             case '+':
             case '*':
-            	if (isSpaceTabOrEnd(line, index + 1)) {
+                if (isSpaceTabOrEnd(line, index + 1)) {
                     // Collect any pre-content whitespace in the first line for
                     //    roundtrip purposes.
                     String preContentWhitespace = Parsing.collectWhitespace(line, index + 1, line.length());
@@ -156,7 +156,8 @@ public class ListBlockParser extends AbstractBlockParser {
                     
                     BulletList bulletList = new BulletList();
                     bulletList.setBulletMarker(c);
-                    bulletList.setWhitespace(preBlockWhitespace, preContentWhitespace);
+                    bulletList.setPreBlockWhitespace(preBlockWhitespace);
+                    bulletList.setPreContentWhitespace(preContentWhitespace);
                     return new ListMarkerData(bulletList, index + 1);
                 } else {
                     return null;
@@ -217,7 +218,8 @@ public class ListBlockParser extends AbstractBlockParser {
                         //         only auto-incremented during rendering
                         currentRawNumber = number;
                         orderedList.setDelimiter(c);
-                        orderedList.setWhitespace(preBlockWhitespace, preContentWhitespace);
+                        orderedList.setPreBlockWhitespace(preBlockWhitespace);
+                        orderedList.setPreContentWhitespace(preContentWhitespace);
                         return new ListMarkerData(orderedList, i + 1);
                     } else {
                         return null;

--- a/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
@@ -142,7 +142,7 @@ public class ListBlockParser extends AbstractBlockParser {
                     
                     // AST: Lists can be separated from their delimiter by a blank line, make
                     //    sure to capture this for roundtrip purposes if it occurs
-                    if(line.subSequence(index + 1, line.length()).toString().isBlank()) {
+                    if(line.subSequence(index + 1, line.length()).toString().trim().equals("")) {
                         firstLineBlank = true;
                     }else {
                         firstLineBlank = false;
@@ -150,7 +150,7 @@ public class ListBlockParser extends AbstractBlockParser {
                     
                     String preBlockWhitespace = line.subSequence(0, index).toString();
                     
-                    if(!preBlockWhitespace.isBlank()) {
+                    if(!preBlockWhitespace.trim().equals("")) {
                         preBlockWhitespace = "";
                     }
                     
@@ -196,7 +196,7 @@ public class ListBlockParser extends AbstractBlockParser {
 
                         // AST: Lists can be separated from their delimiter by a blank line, make
                         //    sure to capture this for roundtrip purposes if it occurs
-                        if(line.subSequence(index + 1, line.length()).toString().isBlank()) {
+                        if(line.subSequence(index + 1, line.length()).toString().trim().equals("")) {
                             firstLineBlank = true;
                         }else {
                             firstLineBlank = false;
@@ -207,7 +207,7 @@ public class ListBlockParser extends AbstractBlockParser {
                         String preContentWhitespace = Parsing.collectWhitespace(line, i+1, line.length());
                         String preBlockWhitespace = line.subSequence(0, index).toString();
                         
-                        if(!preBlockWhitespace.isBlank()) {
+                        if(!preBlockWhitespace.trim().equals("")) {
                             preBlockWhitespace = "";
                         }
                         

--- a/commonmark/src/main/java/org/commonmark/internal/ListItemParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ListItemParser.java
@@ -29,11 +29,12 @@ public class ListItemParser extends AbstractBlockParser {
         block.setRawNumber("");
     }
     
-    public ListItemParser(int contentIndent, String currentRawNumber, boolean firstLineBlank, String whitespacePreBlock, String whitespacePreContent) {
+    public ListItemParser(int contentIndent, String currentRawNumber, boolean firstLineBlank, String whitespacePreMarker, String whitespacePostMarker) {
         this(contentIndent);
         block.setRawNumber(currentRawNumber);
         this.firstLineBlank = firstLineBlank;
-        block.setWhitespace(whitespacePreBlock, whitespacePreContent);
+        block.setPreMarkerWhitespace(whitespacePreMarker);
+        block.setPostMarkerWhitespace(whitespacePostMarker);
     }
 
     @Override
@@ -64,7 +65,7 @@ public class ListItemParser extends AbstractBlockParser {
     @Override
     public BlockContinue tryContinue(ParserState state) {
         if (state.isBlank()) {
-        	if (block.getFirstChild() == null || block.getFirstChild() instanceof BlankLine) {
+            if (block.getFirstChild() == null || block.getFirstChild() instanceof BlankLine) {
                 // Blank line after empty list item
                 return BlockContinue.none();
             } else {
@@ -77,9 +78,9 @@ public class ListItemParser extends AbstractBlockParser {
         }
 
         if (state.getIndent() >= contentIndent) {
-        	if(firstLineBlank) {
-                String whitespacePreContent = block.whitespacePreContent() + "\n";
-                block.setWhitespace(block.whitespacePreBlock(), whitespacePreContent);
+            if(firstLineBlank) {
+                String whitespacePostMarker = block.whitespacePostMarker() + "\n";
+                block.setPostMarkerWhitespace(whitespacePostMarker);
                 firstLineBlank = false;
             }
             return BlockContinue.atColumn(state.getColumn() + contentIndent);

--- a/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
@@ -1,5 +1,8 @@
 package org.commonmark.internal;
 
+import java.util.List;
+
+import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.Block;
 import org.commonmark.node.LinkReferenceDefinition;
 import org.commonmark.node.Paragraph;
@@ -11,13 +14,25 @@ import org.commonmark.parser.block.AbstractBlockParser;
 import org.commonmark.parser.block.BlockContinue;
 import org.commonmark.parser.block.ParserState;
 
-import java.util.List;
-
 public class ParagraphParser extends AbstractBlockParser {
 
     private final Paragraph block = new Paragraph();
     private final LinkReferenceDefinitionParser linkReferenceDefinitionParser = new LinkReferenceDefinitionParser();
 
+    private String postContentWhitespace = "";
+    private String postBlockWhitespace = "";
+    
+    // Preserve original default constructor by explicitly defining one
+    public ParagraphParser() {
+        super();
+    }
+    
+    public ParagraphParser(String preBlockWhitespace) {
+        block.setWhitespace(preBlockWhitespace);
+        postContentWhitespace = "";
+        postBlockWhitespace = "";
+    }
+    
     @Override
     public boolean canHaveLazyContinuationLines() {
         return true;
@@ -30,7 +45,19 @@ public class ParagraphParser extends AbstractBlockParser {
 
     @Override
     public BlockContinue tryContinue(ParserState state) {
+    	char setextCheck = Character.MIN_VALUE;
+        postBlockWhitespace = block.whitespacePostBlock();
+        
         if (!state.isBlank()) {
+            
+            if(state.getLine() != null && state.getLine().getContent().toString().stripLeading().length() != 0) {
+                setextCheck = state.getLine().getContent().toString().stripLeading().charAt(0);
+            }
+            
+            if(setextCheck != Character.MIN_VALUE && setextCheck != '=' && setextCheck != '-') {
+                // Collect post-content whitespace for roundtrip purposes
+                postContentWhitespace = Parsing.collectWhitespaceBackwards(state.getLine().getContent(), state.getLine().getContent().length() - 1, 0);
+            }
             return BlockContinue.atIndex(state.getIndex());
         } else {
             return BlockContinue.none();
@@ -51,6 +78,8 @@ public class ParagraphParser extends AbstractBlockParser {
 
     @Override
     public void closeBlock() {
+        block.setWhitespace(block.whitespacePreBlock(), block.whitespacePreContent(), postContentWhitespace, postBlockWhitespace);
+        
         if (linkReferenceDefinitionParser.getParagraphLines().isEmpty()) {
             block.unlink();
         } else {
@@ -62,12 +91,20 @@ public class ParagraphParser extends AbstractBlockParser {
     public void parseInlines(InlineParser inlineParser) {
         SourceLines lines = linkReferenceDefinitionParser.getParagraphLines();
         if (!lines.isEmpty()) {
-            inlineParser.parse(lines, block);
+            inlineParser.parse(getRawParagraphLines(), block);
         }
     }
 
     public SourceLines getParagraphLines() {
         return linkReferenceDefinitionParser.getParagraphLines();
+    }
+    
+    public SourceLines getRawParagraphLines() {
+        return linkReferenceDefinitionParser.getRawParagraphLines();
+    }
+    
+    public void setRawParagraphLines(SourceLines rawParagraphLines) {
+        linkReferenceDefinitionParser.setRawParagraphLines(rawParagraphLines);
     }
 
     public List<LinkReferenceDefinition> getDefinitions() {

--- a/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
@@ -50,8 +50,8 @@ public class ParagraphParser extends AbstractBlockParser {
         
         if (!state.isBlank()) {
             
-            if(state.getLine() != null && state.getLine().getContent().toString().stripLeading().length() != 0) {
-                setextCheck = state.getLine().getContent().toString().stripLeading().charAt(0);
+            if(state.getLine() != null && state.getLine().getContent().toString().replaceFirst("^\\s+", "").length() != 0) {
+                setextCheck = state.getLine().getContent().toString().replaceFirst("^\\s+", "").charAt(0);
             }
             
             if(setextCheck != Character.MIN_VALUE && setextCheck != '=' && setextCheck != '-') {

--- a/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
@@ -2,7 +2,6 @@ package org.commonmark.internal;
 
 import java.util.List;
 
-import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.Block;
 import org.commonmark.node.LinkReferenceDefinition;
 import org.commonmark.node.Paragraph;
@@ -19,18 +18,13 @@ public class ParagraphParser extends AbstractBlockParser {
     private final Paragraph block = new Paragraph();
     private final LinkReferenceDefinitionParser linkReferenceDefinitionParser = new LinkReferenceDefinitionParser();
 
-    private String postContentWhitespace = "";
-    private String postBlockWhitespace = "";
-    
     // Preserve original default constructor by explicitly defining one
     public ParagraphParser() {
         super();
     }
     
     public ParagraphParser(String preBlockWhitespace) {
-        block.setWhitespace(preBlockWhitespace);
-        postContentWhitespace = "";
-        postBlockWhitespace = "";
+        block.setPreBlockWhitespace(preBlockWhitespace);
     }
     
     @Override
@@ -45,19 +39,7 @@ public class ParagraphParser extends AbstractBlockParser {
 
     @Override
     public BlockContinue tryContinue(ParserState state) {
-    	char setextCheck = Character.MIN_VALUE;
-        postBlockWhitespace = block.whitespacePostBlock();
-        
         if (!state.isBlank()) {
-            
-            if(state.getLine() != null && state.getLine().getContent().toString().replaceFirst("^\\s+", "").length() != 0) {
-                setextCheck = state.getLine().getContent().toString().replaceFirst("^\\s+", "").charAt(0);
-            }
-            
-            if(setextCheck != Character.MIN_VALUE && setextCheck != '=' && setextCheck != '-') {
-                // Collect post-content whitespace for roundtrip purposes
-                postContentWhitespace = Parsing.collectWhitespaceBackwards(state.getLine().getContent(), state.getLine().getContent().length() - 1, 0);
-            }
             return BlockContinue.atIndex(state.getIndex());
         } else {
             return BlockContinue.none();
@@ -78,8 +60,6 @@ public class ParagraphParser extends AbstractBlockParser {
 
     @Override
     public void closeBlock() {
-        block.setWhitespace(block.whitespacePreBlock(), block.whitespacePreContent(), postContentWhitespace, postBlockWhitespace);
-        
         if (linkReferenceDefinitionParser.getParagraphLines().isEmpty()) {
             block.unlink();
         } else {

--- a/commonmark/src/main/java/org/commonmark/internal/StaggeredDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/StaggeredDelimiterProcessor.java
@@ -73,4 +73,10 @@ class StaggeredDelimiterProcessor implements DelimiterProcessor {
     public int process(DelimiterRun openingRun, DelimiterRun closingRun) {
         return findProcessor(openingRun.length()).process(openingRun, closingRun);
     }
+
+
+    @Override
+    public int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix) {
+        return process(openingRun, closingRun);
+    }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/ThematicBreakParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ThematicBreakParser.java
@@ -1,6 +1,5 @@
 package org.commonmark.internal;
 
-import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.Block;
 import org.commonmark.node.ThematicBreak;
 import org.commonmark.parser.block.AbstractBlockParser;
@@ -21,11 +20,6 @@ public class ThematicBreakParser extends AbstractBlockParser {
     
     public ThematicBreakParser(CharSequence content) {
         block.setContent(content);
-    }
-    
-    public ThematicBreakParser(CharSequence content, String... whitespace) {
-        block.setContent(content);
-        block.setWhitespace(whitespace);
     }
     
     @Override
@@ -49,12 +43,8 @@ public class ThematicBreakParser extends AbstractBlockParser {
             int nextNonSpace = state.getNextNonSpaceIndex();
             CharSequence line = state.getLine().getContent();
             
-            // Collect pre- and post-content whitespace for roundtrip purposes
-            String preContentWhitespace = Parsing.collectWhitespace(line, 0, nextNonSpace);
-            String postContentWhitespace = Parsing.collectWhitespaceBackwards(line, line.length() - 1, nextNonSpace);
-            
             if (isThematicBreak(line, nextNonSpace)) {
-            	return BlockStart.of(new ThematicBreakParser(line, "", preContentWhitespace, postContentWhitespace)).atIndex(line.length());
+                return BlockStart.of(new ThematicBreakParser(line)).atIndex(line.length());
             } else {
                 return BlockStart.none();
             }

--- a/commonmark/src/main/java/org/commonmark/internal/ThematicBreakParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ThematicBreakParser.java
@@ -1,13 +1,33 @@
 package org.commonmark.internal;
 
+import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.Block;
 import org.commonmark.node.ThematicBreak;
-import org.commonmark.parser.block.*;
+import org.commonmark.parser.block.AbstractBlockParser;
+import org.commonmark.parser.block.AbstractBlockParserFactory;
+import org.commonmark.parser.block.BlockContinue;
+import org.commonmark.parser.block.BlockStart;
+import org.commonmark.parser.block.MatchedBlockParser;
+import org.commonmark.parser.block.ParserState;
 
 public class ThematicBreakParser extends AbstractBlockParser {
 
     private final ThematicBreak block = new ThematicBreak();
 
+    // Preserve original default constructor by explicitly defining one
+    public ThematicBreakParser() {
+        super();
+    }
+    
+    public ThematicBreakParser(CharSequence content) {
+        block.setContent(content);
+    }
+    
+    public ThematicBreakParser(CharSequence content, String... whitespace) {
+        block.setContent(content);
+        block.setWhitespace(whitespace);
+    }
+    
     @Override
     public Block getBlock() {
         return block;
@@ -28,8 +48,13 @@ public class ThematicBreakParser extends AbstractBlockParser {
             }
             int nextNonSpace = state.getNextNonSpaceIndex();
             CharSequence line = state.getLine().getContent();
+            
+            // Collect pre- and post-content whitespace for roundtrip purposes
+            String preContentWhitespace = Parsing.collectWhitespace(line, 0, nextNonSpace);
+            String postContentWhitespace = Parsing.collectWhitespaceBackwards(line, line.length() - 1, nextNonSpace);
+            
             if (isThematicBreak(line, nextNonSpace)) {
-                return BlockStart.of(new ThematicBreakParser()).atIndex(line.length());
+            	return BlockStart.of(new ThematicBreakParser(line, "", preContentWhitespace, postContentWhitespace)).atIndex(line.length());
             } else {
                 return BlockStart.none();
             }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/AutolinkInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/AutolinkInlineParser.java
@@ -1,10 +1,11 @@
 package org.commonmark.internal.inline;
 
+import java.util.regex.Pattern;
+
 import org.commonmark.node.Link;
+import org.commonmark.node.LinkFormat.LinkType;
 import org.commonmark.node.Text;
 import org.commonmark.parser.SourceLines;
-
-import java.util.regex.Pattern;
 
 /**
  * Attempt to parse an autolink (URL or email in pointy brackets).
@@ -39,9 +40,16 @@ public class AutolinkInlineParser implements InlineContentParser {
                 Text text = new Text(content);
                 text.setSourceSpans(textSource.getSourceSpans());
                 link.appendChild(text);
+                link.setLinkType(LinkType.AUTOLINK);
                 return ParsedInline.of(link, scanner.position());
             }
         }
         return ParsedInline.none();
+    }
+    
+    @Override
+    public ParsedInline tryParse(InlineParserState inlineParserState, String prefix) {
+        // Autolinks do not have significant prefix values
+        return tryParse(inlineParserState);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/BackslashInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/BackslashInlineParser.java
@@ -24,12 +24,18 @@ public class BackslashInlineParser implements InlineContentParser {
         char next = scanner.peek();
         if (next == '\n') {
             scanner.next();
-            return ParsedInline.of(new HardLineBreak(), scanner.position());
+            return ParsedInline.of(new HardLineBreak(true), scanner.position());
         } else if (ESCAPABLE.matcher(String.valueOf(next)).matches()) {
             scanner.next();
-            return ParsedInline.of(new Text(String.valueOf(next)), scanner.position());
+            return ParsedInline.of(new Text(String.valueOf(next), "\\" + String.valueOf(next), "", ""), scanner.position());
         } else {
             return ParsedInline.of(new Text("\\"), scanner.position());
         }
+    }
+    
+    @Override
+    public ParsedInline tryParse(InlineParserState inlineParserState, String prefix) {
+        // Backslash-escaped characters do not have significant prefix values
+        return tryParse(inlineParserState);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/BackticksInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/BackticksInlineParser.java
@@ -30,7 +30,7 @@ public class BackticksInlineParser implements InlineContentParser {
             if (count == openingTicks) {
                 Code node = new Code();
 
-node.setNumBackticks(count);
+                node.setNumBackticks(count);
                 
                 String content = scanner.getSource(afterOpening, beforeClosing).getContent();
                 // Capture raw string for roundtrip rendering

--- a/commonmark/src/main/java/org/commonmark/internal/inline/BackticksInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/BackticksInlineParser.java
@@ -14,6 +14,13 @@ public class BackticksInlineParser implements InlineContentParser {
     public ParsedInline tryParse(InlineParserState inlineParserState) {
         Scanner scanner = inlineParserState.scanner();
         Position start = scanner.position();
+        String preBlockWhitespace = "";
+        
+        char listCheck = scanner.peek();
+        if(listCheck == '-' || listCheck == '*' || listCheck == '+') {
+            preBlockWhitespace = listCheck + scanner.whitespaceAsString();
+        }
+        
         int openingTicks = scanner.matchMultiple('`');
         Position afterOpening = scanner.position();
 
@@ -23,7 +30,11 @@ public class BackticksInlineParser implements InlineContentParser {
             if (count == openingTicks) {
                 Code node = new Code();
 
+node.setNumBackticks(count);
+                
                 String content = scanner.getSource(afterOpening, beforeClosing).getContent();
+                // Capture raw string for roundtrip rendering
+                node.setRaw(content);
                 content = content.replace('\n', ' ');
 
                 // spec: If the resulting string both begins and ends with a space character, but does not consist
@@ -42,7 +53,13 @@ public class BackticksInlineParser implements InlineContentParser {
 
         // If we got here, we didn't find a matching closing backtick sequence.
         SourceLines source = scanner.getSource(start, afterOpening);
-        Text text = new Text(source.getContent());
+        Text text = new Text(source.getContent(), source.getContent(), preBlockWhitespace, "");
         return ParsedInline.of(text, afterOpening);
+    }
+    
+    @Override
+    public ParsedInline tryParse(InlineParserState inlineParserState, String prefix) {
+        // Backticks do not have significant prefix values
+        return tryParse(inlineParserState);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/BlankLineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/BlankLineParser.java
@@ -7,22 +7,22 @@ import org.commonmark.parser.block.BlockContinue;
 import org.commonmark.parser.block.ParserState;
 
 public class BlankLineParser extends AbstractBlockParser {
-	
-	private BlankLine block;
-	
-	public BlankLineParser(String raw) {
-		block = new BlankLine(raw);
-	}
 
-	@Override
-	public Block getBlock() {
-		return block;
-	}
+    private BlankLine block;
 
-	@Override
-	public BlockContinue tryContinue(ParserState parserState) {
-		// Blank lines do not become active parsers, so they cannot be continued
-		return null;
-	}
+    public BlankLineParser(String raw) {
+        block = new BlankLine(raw);
+    }
+
+    @Override
+    public Block getBlock() {
+        return block;
+    }
+
+    @Override
+    public BlockContinue tryContinue(ParserState parserState) {
+        // Blank lines do not become active parsers, so they cannot be continued
+        return null;
+    }
 
 }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/BlankLineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/BlankLineParser.java
@@ -1,0 +1,28 @@
+package org.commonmark.internal.inline;
+
+import org.commonmark.node.BlankLine;
+import org.commonmark.node.Block;
+import org.commonmark.parser.block.AbstractBlockParser;
+import org.commonmark.parser.block.BlockContinue;
+import org.commonmark.parser.block.ParserState;
+
+public class BlankLineParser extends AbstractBlockParser {
+	
+	private BlankLine block;
+	
+	public BlankLineParser(String raw) {
+		block = new BlankLine(raw);
+	}
+
+	@Override
+	public Block getBlock() {
+		return block;
+	}
+
+	@Override
+	public BlockContinue tryContinue(ParserState parserState) {
+		// Blank lines do not become active parsers, so they cannot be continued
+		return null;
+	}
+
+}

--- a/commonmark/src/main/java/org/commonmark/internal/inline/EmphasisDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/EmphasisDelimiterProcessor.java
@@ -63,4 +63,49 @@ public abstract class EmphasisDelimiterProcessor implements DelimiterProcessor {
 
         return usedDelimiters;
     }
+    
+    public int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix) {
+        // "multiple of 3" rule for internal delimiter runs
+        if ((openingRun.canClose() || closingRun.canOpen()) &&
+                closingRun.originalLength() % 3 != 0 &&
+                (openingRun.originalLength() + closingRun.originalLength()) % 3 == 0) {
+            return 0;
+        }
+
+        int usedDelimiters;
+        Node emphasis;
+        
+        // Pre-content whitespace in emphasis is primarily used during thematic breaks
+        String preContentWhitespace = prefix;
+        
+        if(!openingRun.getOpener().whitespacePreContent().isEmpty() &&
+                openingRun.getOpener().whitespacePreContent().isBlank()) {
+            preContentWhitespace = openingRun.getOpener().whitespacePreContent();
+        }
+        
+        // calculate actual number of delimiters used from this closer
+        if (openingRun.length() >= 2 && closingRun.length() >= 2) {
+            usedDelimiters = 2;
+            emphasis = new StrongEmphasis(String.valueOf(delimiterChar) + delimiterChar, preContentWhitespace);
+        } else {
+            usedDelimiters = 1;
+            emphasis = new Emphasis(String.valueOf(delimiterChar), preContentWhitespace);
+        }
+
+        SourceSpans sourceSpans = SourceSpans.empty();
+        sourceSpans.addAllFrom(openingRun.getOpeners(usedDelimiters));
+
+        Text opener = openingRun.getOpener();
+        for (Node node : Nodes.between(opener, closingRun.getCloser())) {
+            emphasis.appendChild(node);
+            sourceSpans.addAll(node.getSourceSpans());
+        }
+
+        sourceSpans.addAllFrom(closingRun.getClosers(usedDelimiters));
+
+        emphasis.setSourceSpans(sourceSpans.getSourceSpans());
+        opener.insertAfter(emphasis);
+
+        return usedDelimiters;
+    }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/EmphasisDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/EmphasisDelimiterProcessor.java
@@ -79,7 +79,7 @@ public abstract class EmphasisDelimiterProcessor implements DelimiterProcessor {
         String preContentWhitespace = prefix;
         
         if(!openingRun.getOpener().whitespacePreContent().isEmpty() &&
-                openingRun.getOpener().whitespacePreContent().isBlank()) {
+                openingRun.getOpener().whitespacePreContent().trim().equals("")) {
             preContentWhitespace = openingRun.getOpener().whitespacePreContent();
         }
         

--- a/commonmark/src/main/java/org/commonmark/internal/inline/EntityInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/EntityInlineParser.java
@@ -45,9 +45,15 @@ public class EntityInlineParser implements InlineContentParser {
 
         return ParsedInline.none();
     }
+    
+    @Override
+    public ParsedInline tryParse(InlineParserState inlineParserState, String prefix) {
+        // Inline entities do not have significant prefix values
+        return tryParse(inlineParserState);
+    }
 
     private ParsedInline entity(Scanner scanner, Position start) {
         String text = scanner.getSource(start, scanner.position()).getContent();
-        return ParsedInline.of(new Text(Html5Entities.entityToString(text)), scanner.position());
+        return ParsedInline.of(new Text(Html5Entities.entityToString(text), text, "", ""), scanner.position());
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/HtmlInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/HtmlInlineParser.java
@@ -65,6 +65,12 @@ public class HtmlInlineParser implements InlineContentParser {
 
         return ParsedInline.none();
     }
+    
+    @Override
+    public ParsedInline tryParse(InlineParserState inlineParserState, String prefix) {
+        // Inline HTML does not have significant prefix values
+        return tryParse(inlineParserState);
+    }
 
     private static ParsedInline htmlInline(Position start, Scanner scanner) {
         String text = scanner.getSource(start, scanner.position()).getContent();

--- a/commonmark/src/main/java/org/commonmark/internal/inline/InlineContentParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/InlineContentParser.java
@@ -3,4 +3,6 @@ package org.commonmark.internal.inline;
 public interface InlineContentParser {
 
     ParsedInline tryParse(InlineParserState inlineParserState);
+    
+    ParsedInline tryParse(InlineParserState inlineParserState, String prefix);
 }

--- a/commonmark/src/main/java/org/commonmark/internal/renderer/text/OrderedListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/internal/renderer/text/OrderedListHolder.java
@@ -5,11 +5,13 @@ import org.commonmark.node.OrderedList;
 public class OrderedListHolder extends ListHolder {
     private final char delimiter;
     private int counter;
+    private String rawNumber;
 
     public OrderedListHolder(ListHolder parent, OrderedList list) {
         super(parent);
         delimiter = list.getDelimiter();
         counter = list.getStartNumber();
+        rawNumber = list.getRawNumber();
     }
 
     public char getDelimiter() {
@@ -18,6 +20,10 @@ public class OrderedListHolder extends ListHolder {
 
     public int getCounter() {
         return counter;
+    }
+    
+    public String getRawNumber() {
+        return rawNumber;
     }
 
     public void increaseCounter() {

--- a/commonmark/src/main/java/org/commonmark/internal/util/LinkScanner.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/LinkScanner.java
@@ -70,7 +70,9 @@ public class LinkScanner {
         }
 
         char endDelimiter;
-        switch (scanner.peek()) {
+        char c = scanner.peek();
+        
+        switch (c) {
             case '"':
                 endDelimiter = '"';
                 break;
@@ -83,6 +85,10 @@ public class LinkScanner {
             default:
                 return false;
         }
+        
+//        if(c != '(' && !(scanner.hasNext() && scanner.peek() == '(')) {
+//            scanner.next();
+//        }
         scanner.next();
 
         if (!scanLinkTitleContent(scanner, endDelimiter)) {
@@ -158,6 +164,11 @@ public class LinkScanner {
             }
             empty = false;
         }
+        
+        if(parens > 0) {
+            return false;
+        }
+        
         return true;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/util/LinkScanner.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/LinkScanner.java
@@ -86,9 +86,6 @@ public class LinkScanner {
                 return false;
         }
         
-//        if(c != '(' && !(scanner.hasNext() && scanner.peek() == '(')) {
-//            scanner.next();
-//        }
         scanner.next();
 
         if (!scanLinkTitleContent(scanner, endDelimiter)) {

--- a/commonmark/src/main/java/org/commonmark/internal/util/Parsing.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Parsing.java
@@ -226,6 +226,56 @@ public class Parsing {
         return lastIndex - 1;
     }
 
+    public static String collectWhitespace(CharSequence s, int startIndex, int lastIndex) {
+        StringBuilder whitespace = new StringBuilder(lastIndex - startIndex);
+        
+        for (int i = startIndex; i < lastIndex; i++) {
+            switch (s.charAt(i)) {
+                case ' ':
+                case '\t':
+                case '\n':
+                case '\u000B':
+                case '\f':
+                case '\r':
+                    whitespace.append(s.charAt(i));
+                    break;
+                default:
+                    return whitespace.toString();
+            }
+        }
+        return whitespace.toString();
+    }
+    
+    public static String collectWhitespaceBackwards(CharSequence s, int startIndex, int lastIndex) {
+        StringBuilder whitespace = new StringBuilder(startIndex - lastIndex);
+        
+        for (int i = startIndex; i >= lastIndex; i--) {
+            switch (s.charAt(i)) {
+                case ' ':
+                case '\t':
+                case '\n':
+                case '\u000B':
+                case '\f':
+                case '\r':
+                    whitespace.append(s.charAt(i));
+                    break;
+                default:
+                    return whitespace.toString();
+            }
+        }
+        return whitespace.toString();
+    }
+    
+    public static String generateSpaces(int numberOfSpaces) {
+        StringBuilder spaces = new StringBuilder(numberOfSpaces);
+        
+        for(int i = 0; i < numberOfSpaces; i++) {
+            spaces.append(" ");
+        }
+        
+        return spaces.toString();
+    }
+    
     private static int findNonSpace(CharSequence s, int startIndex) {
         int length = s.length();
         for (int i = startIndex; i < length; i++) {

--- a/commonmark/src/main/java/org/commonmark/node/AbstractVisitor.java
+++ b/commonmark/src/main/java/org/commonmark/node/AbstractVisitor.java
@@ -8,11 +8,11 @@ package org.commonmark.node;
  */
 public abstract class AbstractVisitor implements Visitor {
 
-	@Override
+    @Override
     public void visit(BlankLine blankLine) {
         visitChildren(blankLine);
     }
-	
+
     @Override
     public void visit(BlockQuote blockQuote) {
         visitChildren(blockQuote);

--- a/commonmark/src/main/java/org/commonmark/node/AbstractVisitor.java
+++ b/commonmark/src/main/java/org/commonmark/node/AbstractVisitor.java
@@ -8,6 +8,11 @@ package org.commonmark.node;
  */
 public abstract class AbstractVisitor implements Visitor {
 
+	@Override
+    public void visit(BlankLine blankLine) {
+        visitChildren(blankLine);
+    }
+	
     @Override
     public void visit(BlockQuote blockQuote) {
         visitChildren(blockQuote);

--- a/commonmark/src/main/java/org/commonmark/node/BlankLine.java
+++ b/commonmark/src/main/java/org/commonmark/node/BlankLine.java
@@ -2,51 +2,22 @@ package org.commonmark.node;
 
 public class BlankLine extends Block {
 
-	private String raw;
-	
-	public BlankLine(String rawContent) {
-		raw = rawContent;
-	}
+    private String raw;
 
-	public String getRaw() {
-		return raw;
-	}
+    public BlankLine(String rawContent) {
+        raw = rawContent;
+    }
 
-	public void setRaw(String raw) {
-		this.raw = raw;
-	}
+    public String getRaw() {
+        return raw;
+    }
 
-	@Override
-	public String whitespacePreBlock() {
-		// Blank lines contain any whitespace as part of their raw content
-		return "";
-	}
+    public void setRaw(String raw) {
+        this.raw = raw;
+    }
 
-	@Override
-	public String whitespacePreContent() {
-		// Blank lines contain any whitespace as part of their raw content
-		return "";
-	}
-
-	@Override
-	public String whitespacePostContent() {
-		// Blank lines contain any whitespace as part of their raw content
-		return "";
-	}
-
-	@Override
-	public String whitespacePostBlock() {
-		// Blank lines contain any whitespace as part of their raw content
-		return "";
-	}
-
-	@Override
-	public void setWhitespace(String... newWhitespace) {
-		// Blank lines contain any whitespace as part of their raw content
-	}
-
-	@Override
-	public void accept(Visitor visitor) {
-		visitor.visit(this);
-	}
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/commonmark/src/main/java/org/commonmark/node/BlankLine.java
+++ b/commonmark/src/main/java/org/commonmark/node/BlankLine.java
@@ -1,0 +1,52 @@
+package org.commonmark.node;
+
+public class BlankLine extends Block {
+
+	private String raw;
+	
+	public BlankLine(String rawContent) {
+		raw = rawContent;
+	}
+
+	public String getRaw() {
+		return raw;
+	}
+
+	public void setRaw(String raw) {
+		this.raw = raw;
+	}
+
+	@Override
+	public String whitespacePreBlock() {
+		// Blank lines contain any whitespace as part of their raw content
+		return "";
+	}
+
+	@Override
+	public String whitespacePreContent() {
+		// Blank lines contain any whitespace as part of their raw content
+		return "";
+	}
+
+	@Override
+	public String whitespacePostContent() {
+		// Blank lines contain any whitespace as part of their raw content
+		return "";
+	}
+
+	@Override
+	public String whitespacePostBlock() {
+		// Blank lines contain any whitespace as part of their raw content
+		return "";
+	}
+
+	@Override
+	public void setWhitespace(String... newWhitespace) {
+		// Blank lines contain any whitespace as part of their raw content
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		visitor.visit(this);
+	}
+}

--- a/commonmark/src/main/java/org/commonmark/node/Block.java
+++ b/commonmark/src/main/java/org/commonmark/node/Block.java
@@ -16,40 +16,4 @@ public abstract class Block extends Node {
         }
         super.setParent(parent);
     }
-    
- // Roundtrip rendering requires capturing various pieces before and after blocks and their contents
-    public abstract String whitespacePreBlock();
-    public abstract String whitespacePreContent();
-    public abstract String whitespacePostContent();
-    public abstract String whitespacePostBlock();
-    public abstract void setWhitespace(String...newWhitespace);
-    
-    /**
-     * All block elements can be impacted structurally by whitespace in some way or another.
-     * For convenience, this method allows passing any number of strings. However, these strings
-     * are interpreted as linearly replacing one of 4 pre-defined positions (i.e
-     * 2 values replace [0] and [1], 3 replace [0], [1], and [2] etc.). These 4
-     * values correspond to:
-     * 0. Pre-block element whitespace
-     * 1. Pre-content whitespace
-     * 2. Post-content whitespace
-     * 3. Post-block element whitespace
-     * 
-     * If a caller passes more than 4 values, all values past the fourth will be ignored.
-     * @param newWhitespace
-     * @return Prepared array of structural whitespace
-     */
-    protected String[] prepareStructuralWhitespace(String... newWhitespace) {
-        String[] container = {"", "", "", ""};
-        
-        if(newWhitespace.length == 4) {
-            container = newWhitespace;
-        }else {
-            for(int i = 0; i < newWhitespace.length; i++) {
-                container[i] = newWhitespace[i];
-            }
-        }
-        
-        return container;
-    }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Block.java
+++ b/commonmark/src/main/java/org/commonmark/node/Block.java
@@ -16,4 +16,40 @@ public abstract class Block extends Node {
         }
         super.setParent(parent);
     }
+    
+ // Roundtrip rendering requires capturing various pieces before and after blocks and their contents
+    public abstract String whitespacePreBlock();
+    public abstract String whitespacePreContent();
+    public abstract String whitespacePostContent();
+    public abstract String whitespacePostBlock();
+    public abstract void setWhitespace(String...newWhitespace);
+    
+    /**
+     * All block elements can be impacted structurally by whitespace in some way or another.
+     * For convenience, this method allows passing any number of strings. However, these strings
+     * are interpreted as linearly replacing one of 4 pre-defined positions (i.e
+     * 2 values replace [0] and [1], 3 replace [0], [1], and [2] etc.). These 4
+     * values correspond to:
+     * 0. Pre-block element whitespace
+     * 1. Pre-content whitespace
+     * 2. Post-content whitespace
+     * 3. Post-block element whitespace
+     * 
+     * If a caller passes more than 4 values, all values past the fourth will be ignored.
+     * @param newWhitespace
+     * @return Prepared array of structural whitespace
+     */
+    protected String[] prepareStructuralWhitespace(String... newWhitespace) {
+        String[] container = {"", "", "", ""};
+        
+        if(newWhitespace.length == 4) {
+            container = newWhitespace;
+        }else {
+            for(int i = 0; i < newWhitespace.length; i++) {
+                container[i] = newWhitespace[i];
+            }
+        }
+        
+        return container;
+    }
 }

--- a/commonmark/src/main/java/org/commonmark/node/BlockQuote.java
+++ b/commonmark/src/main/java/org/commonmark/node/BlockQuote.java
@@ -1,9 +1,39 @@
 package org.commonmark.node;
 
 public class BlockQuote extends Block {
-
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
+	
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
+    }
+    
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/BlockQuote.java
+++ b/commonmark/src/main/java/org/commonmark/node/BlockQuote.java
@@ -1,39 +1,28 @@
 package org.commonmark.node;
 
 public class BlockQuote extends Block {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
-	
+    // Whitespace for roundtrip rendering
+    private String whitespacePreMarker = "";
+    private String whitespacePostMarker = "";
+
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
     
-    @Override
-    public String whitespacePreBlock() {
-        return whitespaceTracker[0];
+    public String whitespacePreMarker() {
+        return whitespacePreMarker;
     }
 
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
+    public String whitespacePostMarker() {
+        return whitespacePostMarker;
     }
     
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    public void setPreMarkerWhitespace(String whitespace) {
+        whitespacePreMarker = whitespace;
+    }
+    
+    public void setPostMarkerWhitespace(String whitespace) {
+        whitespacePostMarker = whitespace;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/BulletList.java
+++ b/commonmark/src/main/java/org/commonmark/node/BulletList.java
@@ -1,6 +1,12 @@
 package org.commonmark.node;
 
 public class BulletList extends ListBlock {
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
 
     private char bulletMarker;
 
@@ -17,4 +23,27 @@ public class BulletList extends ListBlock {
         this.bulletMarker = bulletMarker;
     }
 
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    }
 }

--- a/commonmark/src/main/java/org/commonmark/node/BulletList.java
+++ b/commonmark/src/main/java/org/commonmark/node/BulletList.java
@@ -1,13 +1,6 @@
 package org.commonmark.node;
 
 public class BulletList extends ListBlock {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
-
     private char bulletMarker;
 
     @Override
@@ -21,29 +14,5 @@ public class BulletList extends ListBlock {
 
     public void setBulletMarker(char bulletMarker) {
         this.bulletMarker = bulletMarker;
-    }
-
-    @Override
-    public String whitespacePreBlock() {
-        return whitespaceTracker[0];
-    }
-
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
-    }
-    
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Code.java
+++ b/commonmark/src/main/java/org/commonmark/node/Code.java
@@ -3,6 +3,9 @@ package org.commonmark.node;
 public class Code extends Node {
 
     private String literal;
+    private String raw;
+    private boolean strippedSpaces;
+    private int numBackticks;
 
     public Code() {
     }
@@ -22,5 +25,29 @@ public class Code extends Node {
 
     public void setLiteral(String literal) {
         this.literal = literal;
+    }
+    
+    public boolean hasStrippedSpaces() {
+        return strippedSpaces;
+    }
+
+    public void setStrippedSpaces(boolean strippedSpaces) {
+        this.strippedSpaces = strippedSpaces;
+    }
+
+    public int getNumBackticks() {
+        return numBackticks;
+    }
+
+    public void setNumBackticks(int numBackticks) {
+        this.numBackticks = numBackticks;
+    }
+    
+    public String getRaw() {
+        return raw;
+    }
+
+    public void setRaw(String raw) {
+        this.raw = raw;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Document.java
+++ b/commonmark/src/main/java/org/commonmark/node/Document.java
@@ -1,39 +1,18 @@
 package org.commonmark.node;
 
 public class Document extends Block {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
+    private String whitespaceEndOfDocument = "";
 
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
     
-    @Override
-    public String whitespacePreBlock() {
-        return whitespaceTracker[0];
-    }
-
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
+    public String whitespaceEndOfDocument() {
+        return whitespaceEndOfDocument;
     }
     
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    public void setEndOfDocumentWhitespace(String whitespace) {
+        whitespaceEndOfDocument = whitespace;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Document.java
+++ b/commonmark/src/main/java/org/commonmark/node/Document.java
@@ -1,9 +1,39 @@
 package org.commonmark.node;
 
 public class Document extends Block {
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
 
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
+    }
+    
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Emphasis.java
+++ b/commonmark/src/main/java/org/commonmark/node/Emphasis.java
@@ -3,12 +3,22 @@ package org.commonmark.node;
 public class Emphasis extends Node implements Delimited {
 
     private String delimiter;
+    private String preBlockWhitespace = "";
 
     public Emphasis() {
     }
 
     public Emphasis(String delimiter) {
         this.delimiter = delimiter;
+    }
+    
+    public Emphasis(String delimiter, String preBlockWhitespace) {
+        this(delimiter);
+        this.preBlockWhitespace = preBlockWhitespace;
+    }
+    
+    public String whitespacePreBlock() {
+        return preBlockWhitespace;
     }
 
     public void setDelimiter(String delimiter) {

--- a/commonmark/src/main/java/org/commonmark/node/FencedCodeBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/FencedCodeBlock.java
@@ -1,13 +1,20 @@
 package org.commonmark.node;
 
 public class FencedCodeBlock extends Block {
+ // Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
 
     private char fenceChar;
-    private int fenceLength;
-    private int fenceIndent;
+    private int startFenceLength;
+    private int endFenceLength;
 
     private String info;
     private String literal;
+    private String raw;
 
     @Override
     public void accept(Visitor visitor) {
@@ -22,20 +29,28 @@ public class FencedCodeBlock extends Block {
         this.fenceChar = fenceChar;
     }
 
-    public int getFenceLength() {
-        return fenceLength;
+    public int getStartFenceLength() {
+        return startFenceLength;
     }
 
-    public void setFenceLength(int fenceLength) {
-        this.fenceLength = fenceLength;
+    public void setStartFenceLength(int startFenceLength) {
+        this.startFenceLength = startFenceLength;
     }
 
-    public int getFenceIndent() {
-        return fenceIndent;
+    public int getEndFenceLength() {
+        return endFenceLength;
     }
 
-    public void setFenceIndent(int fenceIndent) {
-        this.fenceIndent = fenceIndent;
+    public void setEndFenceLength(int endFenceLength) {
+        this.endFenceLength = endFenceLength;
+    }
+
+    public int getStartFenceIndent() {
+        return whitespaceTracker[0].length();
+    }
+    
+    public int getEndFenceIndent() {
+        return whitespaceTracker[2].length();
     }
 
     /**
@@ -55,5 +70,37 @@ public class FencedCodeBlock extends Block {
 
     public void setLiteral(String literal) {
         this.literal = literal;
+    }
+    
+    public String getRaw() {
+        return raw;
+    }
+    
+    public void setRaw(String raw) {
+        this.raw = raw;
+    }
+    
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/FencedCodeBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/FencedCodeBlock.java
@@ -1,12 +1,6 @@
 package org.commonmark.node;
 
 public class FencedCodeBlock extends Block {
- // Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
 
     private char fenceChar;
     private int startFenceLength;
@@ -15,6 +9,12 @@ public class FencedCodeBlock extends Block {
     private String info;
     private String literal;
     private String raw;
+    
+    // Whitespace tracked for roundtrip rendering
+    private String whitespacePreStartFence = "";
+    private String whitespacePreContent = "";
+    private String whitespacePreEndFence = "";
+    private String whitespacePostBlock = "";
 
     @Override
     public void accept(Visitor visitor) {
@@ -46,15 +46,16 @@ public class FencedCodeBlock extends Block {
     }
 
     public int getStartFenceIndent() {
-        return whitespaceTracker[0].length();
+        return whitespacePreStartFence.length();
     }
     
     public int getEndFenceIndent() {
-        return whitespaceTracker[2].length();
+        return whitespacePreEndFence.length();
     }
 
     /**
      * @see <a href="http://spec.commonmark.org/0.18/#info-string">CommonMark spec</a>
+     * @return Info string or null
      */
     public String getInfo() {
         return info;
@@ -80,27 +81,35 @@ public class FencedCodeBlock extends Block {
         this.raw = raw;
     }
     
-    @Override
-    public String whitespacePreBlock() {
-        return whitespaceTracker[0];
+    public String whitespacePreStartFence() {
+        return whitespacePreStartFence;
     }
 
-    @Override
     public String whitespacePreContent() {
-        return whitespaceTracker[1];
+        return whitespacePreContent;
     }
 
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
+    public String whitespacePreEndFence() {
+        return whitespacePreEndFence;
     }
 
-    @Override
     public String whitespacePostBlock() {
-        return whitespaceTracker[3];
+        return whitespacePostBlock;
     }
     
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    public void setPreStartFenceWhitespace(String whitespace) {
+        whitespacePreStartFence = whitespace;
+    }
+    
+    public void setPreContentWhitespace(String whitespace) {
+        whitespacePreContent = whitespace;
+    }
+    
+    public void setPreEndFenceWhitespace(String whitespace) {
+        whitespacePreEndFence = whitespace;
+    }
+    
+    public void setPostBlockWhitespace(String whitespace) {
+        whitespacePostBlock = whitespace;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/HardLineBreak.java
+++ b/commonmark/src/main/java/org/commonmark/node/HardLineBreak.java
@@ -1,9 +1,23 @@
 package org.commonmark.node;
 
 public class HardLineBreak extends Node {
-
+    boolean hasBackslash = false;
+    
+    // Preserve original default constructor by explicitly defining one
+    public HardLineBreak() {
+        super();
+    }
+    
+    public HardLineBreak(boolean hasBackslash) {
+        this.hasBackslash = hasBackslash;
+    }
+    
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
+    }
+    
+    public boolean hasBackslash() {
+        return hasBackslash;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Heading.java
+++ b/commonmark/src/main/java/org/commonmark/node/Heading.java
@@ -1,8 +1,16 @@
 package org.commonmark.node;
 
 public class Heading extends Block {
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
 
     private int level;
+    private char symbolType;
+    private int numEndingSymbol;
 
     @Override
     public void accept(Visitor visitor) {
@@ -15,5 +23,45 @@ public class Heading extends Block {
 
     public void setLevel(int level) {
         this.level = level;
+    }
+    
+    public char getSymbolType() {
+        return symbolType;
+    }
+
+    public void setSymbolType(char symbolType) {
+        this.symbolType = symbolType;
+    }
+
+    public int getNumEndingSymbol() {
+        return numEndingSymbol;
+    }
+
+    public void setNumEndingSymbol(int numEndingSymbol) {
+        this.numEndingSymbol = numEndingSymbol;
+    }
+    
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Heading.java
+++ b/commonmark/src/main/java/org/commonmark/node/Heading.java
@@ -1,16 +1,19 @@
 package org.commonmark.node;
 
 public class Heading extends Block {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
-
     private int level;
     private char symbolType;
     private int numEndingSymbol;
+    
+    // Whitespace for roundtrip rendering
+    // AST: Pre-marker whitespace (ATX) or before setext text (setext)
+    private String whitespacePreBlock = "";
+    // AST: Pre-text (ATX) or after setext text ends (setext)
+    private String whitespacePreContent = "";
+    // AST: Post-text (ATX) or before setext delimiting line (setext)
+    private String whitespacePostContent = "";
+    // AST: Post-block (ATX) or after setext delimiting line (setext) 
+    private String whitespacePostBlock = "";
 
     @Override
     public void accept(Visitor visitor) {
@@ -41,27 +44,35 @@ public class Heading extends Block {
         this.numEndingSymbol = numEndingSymbol;
     }
     
-    @Override
     public String whitespacePreBlock() {
-        return whitespaceTracker[0];
-    }
-
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
+        return whitespacePreBlock;
     }
     
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    public String whitespacePreContent() {
+        return whitespacePreContent;
+    }
+    
+    public String whitespacePostContent() {
+        return whitespacePostContent;
+    }
+    
+    public String whitespacePostBlock() {
+        return whitespacePostBlock;
+    }
+    
+    public void setPreBlockWhitespace(String whitespace) {
+        whitespacePreBlock = whitespace;
+    }
+    
+    public void setPreContentWhitespace(String whitespace) {
+        whitespacePreContent = whitespace;
+    }
+    
+    public void setPostContentWhitespace(String whitespace) {
+        whitespacePostContent = whitespace;
+    }
+    
+    public void setPostBlockWhitespace(String whitespace) {
+        whitespacePostBlock = whitespace;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/HtmlBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/HtmlBlock.java
@@ -6,8 +6,15 @@ package org.commonmark.node;
  * @see <a href="http://spec.commonmark.org/0.18/#html-blocks">CommonMark Spec</a>
  */
 public class HtmlBlock extends Block {
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
 
     private String literal;
+    private String raw;
 
     @Override
     public void accept(Visitor visitor) {
@@ -20,5 +27,37 @@ public class HtmlBlock extends Block {
 
     public void setLiteral(String literal) {
         this.literal = literal;
+    }
+    
+    public String getRaw() {
+        return raw;
+    }
+    
+    public void setRaw(String raw) {
+        this.raw = raw;
+    }
+    
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/HtmlBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/HtmlBlock.java
@@ -6,13 +6,6 @@ package org.commonmark.node;
  * @see <a href="http://spec.commonmark.org/0.18/#html-blocks">CommonMark Spec</a>
  */
 public class HtmlBlock extends Block {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
-
     private String literal;
     private String raw;
 
@@ -35,29 +28,5 @@ public class HtmlBlock extends Block {
     
     public void setRaw(String raw) {
         this.raw = raw;
-    }
-    
-    @Override
-    public String whitespacePreBlock() {
-        return whitespaceTracker[0];
-    }
-
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
-    }
-    
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/HtmlInline.java
+++ b/commonmark/src/main/java/org/commonmark/node/HtmlInline.java
@@ -8,6 +8,7 @@ package org.commonmark.node;
 public class HtmlInline extends Node {
 
     private String literal;
+    private String raw;
 
     @Override
     public void accept(Visitor visitor) {
@@ -20,5 +21,13 @@ public class HtmlInline extends Node {
 
     public void setLiteral(String literal) {
         this.literal = literal;
+    }
+    
+    public String getRaw() {
+        return raw;
+    }
+    
+    public void setRaw(String raw) {
+        this.raw = raw;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Image.java
+++ b/commonmark/src/main/java/org/commonmark/node/Image.java
@@ -2,7 +2,7 @@ package org.commonmark.node;
 
 public class Image extends Node implements LinkFormat {
 
-	private String destination;
+    private String destination;
     private String rawDestination;
     private String title;
     private String rawTitle;

--- a/commonmark/src/main/java/org/commonmark/node/Image.java
+++ b/commonmark/src/main/java/org/commonmark/node/Image.java
@@ -1,16 +1,50 @@
 package org.commonmark.node;
 
-public class Image extends Node {
+public class Image extends Node implements LinkFormat {
 
-    private String destination;
+	private String destination;
+    private String rawDestination;
     private String title;
+    private String rawTitle;
+    private String label;
+    private String rawLabel;
+    private LinkType linkType;
+    private char titleSymbol;
+    private String whitespacePreDestination;
+    private String whitespacePreTitle;
+    private String whitespacePostContent;
 
     public Image() {
     }
 
     public Image(String destination, String title) {
         this.destination = destination;
+        this.rawDestination = "";
         this.title = title;
+        this.rawTitle = "";
+        this.label = null;
+        this.rawLabel = null;
+        linkType = LinkType.NULL;
+        whitespacePreDestination = "";
+        whitespacePreTitle = "";
+        whitespacePostContent = "";
+    }
+    
+    public Image(String destination, String rawDestination, String title,
+            String rawTitle, String label, String rawLabel, LinkType linkType,
+            char titleSymbol, String whitespacePreDestination,
+            String whitespacePreTitle, String whitespacePostContent) {
+        this.destination = destination;
+        this.rawDestination = rawDestination;
+        this.title = title;
+        this.rawTitle = rawTitle;
+        this.label = label;
+        this.rawLabel = rawLabel;
+        this.linkType = linkType;
+        this.titleSymbol = titleSymbol;
+        this.whitespacePreDestination = whitespacePreDestination;
+        this.whitespacePreTitle = whitespacePreTitle;
+        this.whitespacePostContent = whitespacePostContent;
     }
 
     @Override
@@ -18,20 +52,114 @@ public class Image extends Node {
         visitor.visit(this);
     }
 
+    @Override
     public String getDestination() {
         return destination;
     }
 
+    @Override
     public void setDestination(String destination) {
         this.destination = destination;
     }
+    
+    @Override
+    public String getRawDestination() {
+        return rawDestination;
+    }
 
+    @Override
+    public void setRawDestination(String rawDestination) {
+        this.rawDestination = rawDestination;
+    }
+
+    @Override
     public String getTitle() {
         return title;
     }
 
+    @Override
     public void setTitle(String title) {
         this.title = title;
+    }
+    
+    @Override
+    public String getRawTitle() {
+        return rawTitle;
+    }
+    
+    @Override
+    public void setRawTitle(String rawTitle) {
+        this.rawTitle = rawTitle;
+    }
+    
+    @Override
+    public LinkType getLinkType() {
+        return linkType;
+    }
+
+    @Override
+    public void setLinkType(LinkType linkType) {
+        this.linkType = linkType;
+    }
+
+    @Override
+    public char getTitleSymbol() {
+        return titleSymbol;
+    }
+
+    @Override
+    public void setTitleSymbol(char titleSymbol) {
+        this.titleSymbol = titleSymbol;
+    }
+    
+    @Override
+    public String getWhitespacePreDestination() {
+        return whitespacePreDestination;
+    }
+
+    @Override
+    public void setWhitespacePreDestination(String whitespacePreDestination) {
+        this.whitespacePreDestination = whitespacePreDestination;
+    }
+
+    @Override
+    public String getWhitespacePreTitle() {
+        return whitespacePreTitle;
+    }
+
+    @Override
+    public void setWhitespacePreTitle(String whitespacePreTitle) {
+        this.whitespacePreTitle = whitespacePreTitle;
+    }
+
+    @Override
+    public String getWhitespacePostContent() {
+        return whitespacePostContent;
+    }
+
+    @Override
+    public void setWhitespacePostContent(String whitespacePostContent) {
+        this.whitespacePostContent = whitespacePostContent;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public void setLabel(String label) {
+        this.label = label;
+    }
+    
+    @Override
+    public String getRawLabel() {
+        return rawLabel;
+    }
+    
+    @Override
+    public void setRawLabel(String rawLabel) {
+        this.rawLabel = rawLabel;
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/node/IndentedCodeBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/IndentedCodeBlock.java
@@ -1,20 +1,16 @@
 package org.commonmark.node;
 
 public class IndentedCodeBlock extends Block {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
-
- // The "literal" string is optimized for HTML formatting, but omits some details
+    // The "literal" string is optimized for HTML formatting, but omits some details
     //    which are important for roundtrip rendering
     private String literal;
     
     // The "raw" string is, as much as possible, the entire raw content as it was first
     //    entered into the parser. This allows roundtrip parsing for indented code blocks.
     private String raw;
+    
+    // Actual indent whitespace of a raw string for roundtrip rendering
+    private String indentWhitespace = "";
 
     @Override
     public void accept(Visitor visitor) {
@@ -37,27 +33,11 @@ public class IndentedCodeBlock extends Block {
         this.raw = raw;
     }
     
-    @Override
-    public String whitespacePreBlock() {
-        return whitespaceTracker[0];
-    }
-
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
+    public String getIndentWhitespace() {
+        return indentWhitespace;
     }
     
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    public void setIndentWhitespace(String whitespace) {
+        indentWhitespace = whitespace;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/IndentedCodeBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/IndentedCodeBlock.java
@@ -1,8 +1,20 @@
 package org.commonmark.node;
 
 public class IndentedCodeBlock extends Block {
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
 
+ // The "literal" string is optimized for HTML formatting, but omits some details
+    //    which are important for roundtrip rendering
     private String literal;
+    
+    // The "raw" string is, as much as possible, the entire raw content as it was first
+    //    entered into the parser. This allows roundtrip parsing for indented code blocks.
+    private String raw;
 
     @Override
     public void accept(Visitor visitor) {
@@ -15,5 +27,37 @@ public class IndentedCodeBlock extends Block {
 
     public void setLiteral(String literal) {
         this.literal = literal;
+    }
+    
+    public String getRaw() {
+        return raw;
+    }
+    
+    public void setRaw(String raw) {
+        this.raw = raw;
+    }
+    
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Link.java
+++ b/commonmark/src/main/java/org/commonmark/node/Link.java
@@ -20,17 +20,51 @@ package org.commonmark.node;
  *
  * @see <a href="http://spec.commonmark.org/0.26/#links">CommonMark Spec for links</a>
  */
-public class Link extends Node {
+public class Link extends Node implements LinkFormat {
 
-    private String destination;
+	private String destination;
+    private String rawDestination;
     private String title;
+    private String rawTitle;
+    private String label;
+    private String rawLabel;
+    private LinkType linkType;
+    private char titleSymbol;
+    private String whitespacePreDestination;
+    private String whitespacePreTitle;
+    private String whitespacePostContent;
 
     public Link() {
     }
 
     public Link(String destination, String title) {
         this.destination = destination;
+        this.rawDestination = "";
         this.title = title;
+        this.rawTitle = "";
+        this.label = "";
+        this.rawLabel = "";
+        linkType = LinkType.NULL;
+        whitespacePreDestination = "";
+        whitespacePreTitle = "";
+        whitespacePostContent = "";
+    }
+    
+    public Link(String destination, String rawDestination, String title,
+            String rawTitle, String label, String rawLabel,
+            LinkType linkType, char titleSymbol, String whitespacePreDestination,
+            String whitespacePreTitle, String whitespacePostContent) {
+        this.destination = destination;
+        this.rawDestination = rawDestination;
+        this.title = title;
+        this.rawTitle = rawTitle;
+        this.label = label;
+        this.rawLabel = rawLabel;
+        this.linkType = linkType;
+        this.titleSymbol = titleSymbol;
+        this.whitespacePreDestination = whitespacePreDestination;
+        this.whitespacePreTitle = whitespacePreTitle;
+        this.whitespacePostContent = whitespacePostContent;
     }
 
     @Override
@@ -38,22 +72,116 @@ public class Link extends Node {
         visitor.visit(this);
     }
 
+    @Override
     public String getDestination() {
         return destination;
     }
 
+    @Override
     public void setDestination(String destination) {
         this.destination = destination;
     }
+    
+    @Override
+    public String getRawDestination() {
+        return rawDestination;
+    }
 
+    @Override
+    public void setRawDestination(String rawDestination) {
+        this.rawDestination = rawDestination;
+    }
+
+    @Override
     public String getTitle() {
         return title;
     }
 
+    @Override
     public void setTitle(String title) {
         this.title = title;
     }
+    
+    @Override
+    public String getRawTitle() {
+        return rawTitle;
+    }
+    
+    @Override
+    public void setRawTitle(String rawTitle) {
+        this.rawTitle = rawTitle;
+    }
+    
+    @Override
+    public LinkType getLinkType() {
+        return linkType;
+    }
 
+    @Override
+    public void setLinkType(LinkType linkType) {
+        this.linkType = linkType;
+    }
+
+    @Override
+    public char getTitleSymbol() {
+        return titleSymbol;
+    }
+
+    @Override
+    public void setTitleSymbol(char titleSymbol) {
+        this.titleSymbol = titleSymbol;
+    }
+    
+    @Override
+    public String getWhitespacePreDestination() {
+        return whitespacePreDestination;
+    }
+
+    @Override
+    public void setWhitespacePreDestination(String whitespacePreDestination) {
+        this.whitespacePreDestination = whitespacePreDestination;
+    }
+
+    @Override
+    public String getWhitespacePreTitle() {
+        return whitespacePreTitle;
+    }
+
+    @Override
+    public void setWhitespacePreTitle(String whitespacePreTitle) {
+        this.whitespacePreTitle = whitespacePreTitle;
+    }
+
+    @Override
+    public String getWhitespacePostContent() {
+        return whitespacePostContent;
+    }
+
+    @Override
+    public void setWhitespacePostContent(String whitespacePostContent) {
+        this.whitespacePostContent = whitespacePostContent;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public void setLabel(String label) {
+        this.label = label;
+    }
+    
+    @Override
+    public String getRawLabel() {
+        return rawLabel;
+    }
+    
+    @Override
+    public void setRawLabel(String rawLabel) {
+        this.rawLabel = rawLabel;
+    }
+    
     @Override
     protected String toStringAttributes() {
         return "destination=" + destination + ", title=" + title;

--- a/commonmark/src/main/java/org/commonmark/node/Link.java
+++ b/commonmark/src/main/java/org/commonmark/node/Link.java
@@ -22,7 +22,7 @@ package org.commonmark.node;
  */
 public class Link extends Node implements LinkFormat {
 
-	private String destination;
+    private String destination;
     private String rawDestination;
     private String title;
     private String rawTitle;

--- a/commonmark/src/main/java/org/commonmark/node/LinkFormat.java
+++ b/commonmark/src/main/java/org/commonmark/node/LinkFormat.java
@@ -1,0 +1,30 @@
+package org.commonmark.node;
+
+public interface LinkFormat {
+    public String getDestination();
+    public void setDestination(String destination);
+    public String getRawDestination();
+    public void setRawDestination(String destination);
+    public String getLabel();
+    public void setLabel(String label);
+    public String getRawLabel();
+    public void setRawLabel(String label);
+    public String getTitle();
+    public void setTitle(String title);
+    public String getRawTitle();
+    public void setRawTitle(String title);
+    public char getTitleSymbol();
+    public void setTitleSymbol(char symbol);
+    public LinkType getLinkType();
+    public void setLinkType(LinkType linkType);
+    public String getWhitespacePreDestination();
+    public void setWhitespacePreDestination(String whitespace);
+    public String getWhitespacePreTitle();
+    public void setWhitespacePreTitle(String whitespace);
+    public String getWhitespacePostContent();
+    public void setWhitespacePostContent(String whitespace);
+    
+    public enum LinkType {
+        INLINE, REFERENCE, AUTOLINK, NULL;
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/node/LinkReferenceDefinition.java
+++ b/commonmark/src/main/java/org/commonmark/node/LinkReferenceDefinition.java
@@ -13,7 +13,7 @@ package org.commonmark.node;
  */
 public class LinkReferenceDefinition extends Node {
 
-	private String label;
+    private String label;
     private String destination;
     private String rawDestination;
     private String title;
@@ -47,7 +47,7 @@ public class LinkReferenceDefinition extends Node {
     public void setLabel(String label) {
         this.label = label;
     }
-    
+
     public String getDestination() {
         return destination;
     }

--- a/commonmark/src/main/java/org/commonmark/node/LinkReferenceDefinition.java
+++ b/commonmark/src/main/java/org/commonmark/node/LinkReferenceDefinition.java
@@ -13,17 +13,31 @@ package org.commonmark.node;
  */
 public class LinkReferenceDefinition extends Node {
 
-    private String label;
+	private String label;
     private String destination;
+    private String rawDestination;
     private String title;
+    private String rawTitle;
+    private char delimiterChar;
+    private String whitespacePreLabel = "";
+    private String whitespacePreDestination = "";
+    private String whitespacePreTitle = "";
+    private String whitespacePostTitle = "";
 
     public LinkReferenceDefinition() {
     }
 
-    public LinkReferenceDefinition(String label, String destination, String title) {
+    public LinkReferenceDefinition(String label, String destination, String rawDestination, String title, String rawTitle, char delimiterChar, String whitespacePreLabel, String whitespacePreDestination, String whitespacePreTitle, String whitespacePostTitle) {
         this.label = label;
         this.destination = destination;
+        this.rawDestination = rawDestination;
         this.title = title;
+        this.rawTitle = rawTitle;
+        this.delimiterChar = delimiterChar;
+        this.whitespacePreLabel = whitespacePreLabel;
+        this.whitespacePreDestination = whitespacePreDestination;
+        this.whitespacePreTitle = whitespacePreTitle;
+        this.whitespacePostTitle = whitespacePostTitle;
     }
 
     public String getLabel() {
@@ -33,7 +47,7 @@ public class LinkReferenceDefinition extends Node {
     public void setLabel(String label) {
         this.label = label;
     }
-
+    
     public String getDestination() {
         return destination;
     }
@@ -42,12 +56,48 @@ public class LinkReferenceDefinition extends Node {
         this.destination = destination;
     }
 
+    public String getRawDestination() {
+        return rawDestination;
+    }
+
+    public void setRawDestination(String rawDestination) {
+        this.rawDestination = rawDestination;
+    }
+
     public String getTitle() {
         return title;
     }
 
     public void setTitle(String title) {
         this.title = title;
+    }
+    
+    public String getRawTitle() {
+        return rawTitle;
+    }
+
+    public void setRawTitle(String rawTitle) {
+        this.rawTitle = rawTitle;
+    }
+
+    public char getDelimiterChar() {
+        return delimiterChar;
+    }
+    
+    public String whitespacePreLabel() {
+        return whitespacePreLabel;
+    }
+
+    public String whitespacePreDestination() {
+        return whitespacePreDestination;
+    }
+
+    public String whitespacePreTitle() {
+        return whitespacePreTitle;
+    }
+
+    public String whitespacePostTitle() {
+        return whitespacePostTitle;
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/node/ListBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/ListBlock.java
@@ -3,6 +3,10 @@ package org.commonmark.node;
 public abstract class ListBlock extends Block {
 
     private boolean tight;
+    
+    // Whitespace for roundtrip parsing of the first line in a list block
+    private String whitespacePreBlock = "";
+    private String whitespacePreContent = "";
 
     /**
      * @return whether this list is tight or loose
@@ -16,4 +20,19 @@ public abstract class ListBlock extends Block {
         this.tight = tight;
     }
 
+    public String whitespacePreBlock() {
+        return whitespacePreBlock;
+    }
+    
+    public String whitespacePreContent() {
+        return whitespacePreContent;
+    }
+    
+    public void setPreBlockWhitespace(String whitespace) {
+        whitespacePreBlock = whitespace;
+    }
+    
+    public void setPreContentWhitespace(String whitespace) {
+        whitespacePreContent = whitespace;
+    }
 }

--- a/commonmark/src/main/java/org/commonmark/node/ListItem.java
+++ b/commonmark/src/main/java/org/commonmark/node/ListItem.java
@@ -1,41 +1,30 @@
 package org.commonmark.node;
 
 public class ListItem extends Block {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
     private String rawNumber = "";
+    
+    private String whitespacePreMarker = "";
+    private String whitespacePostMarker = "";
 
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
     
-    @Override
-    public String whitespacePreBlock() {
-        return whitespaceTracker[0];
+    public String whitespacePreMarker() {
+        return whitespacePreMarker;
     }
 
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
+    public String whitespacePostMarker() {
+        return whitespacePostMarker;
     }
     
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    public void setPreMarkerWhitespace(String whitespace) {
+        whitespacePreMarker = whitespace;
+    }
+    
+    public void setPostMarkerWhitespace(String whitespace) {
+        whitespacePostMarker = whitespace;
     }
     
     public String getRawNumber() {

--- a/commonmark/src/main/java/org/commonmark/node/ListItem.java
+++ b/commonmark/src/main/java/org/commonmark/node/ListItem.java
@@ -1,9 +1,48 @@
 package org.commonmark.node;
 
 public class ListItem extends Block {
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
+    private String rawNumber = "";
 
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
+    }
+    
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    }
+    
+    public String getRawNumber() {
+        return rawNumber;
+    }
+    
+    public void setRawNumber(String rawNumber) {
+        this.rawNumber = rawNumber;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Node.java
+++ b/commonmark/src/main/java/org/commonmark/node/Node.java
@@ -149,21 +149,6 @@ public abstract class Node {
         }
         this.sourceSpans.add(sourceSpan);
     }
-
-    /**
-     * Check whether the given node is of the subset which count as "inline" nodes
-     * @param node Node to be checked for inline
-     * @return true if node is an inline node, otherwise false
-     */
-    public static boolean isInlineNode(Node node) {
-        if(node instanceof Code || node instanceof Emphasis || node instanceof StrongEmphasis ||
-                node instanceof Link || node instanceof Image || node instanceof HtmlInline ||
-                node instanceof HardLineBreak) {
-            return true;
-        }else {
-            return false;
-        }
-    }
     
     @Override
     public String toString() {

--- a/commonmark/src/main/java/org/commonmark/node/Node.java
+++ b/commonmark/src/main/java/org/commonmark/node/Node.java
@@ -150,6 +150,21 @@ public abstract class Node {
         this.sourceSpans.add(sourceSpan);
     }
 
+    /**
+     * Check whether the given node is of the subset which count as "inline" nodes
+     * @param node Node to be checked for inline
+     * @return true if node is an inline node, otherwise false
+     */
+    public static boolean isInlineNode(Node node) {
+        if(node instanceof Code || node instanceof Emphasis || node instanceof StrongEmphasis ||
+                node instanceof Link || node instanceof Image || node instanceof HtmlInline ||
+                node instanceof HardLineBreak) {
+            return true;
+        }else {
+            return false;
+        }
+    }
+    
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{" + toStringAttributes() + "}";

--- a/commonmark/src/main/java/org/commonmark/node/Nodes.java
+++ b/commonmark/src/main/java/org/commonmark/node/Nodes.java
@@ -14,6 +14,9 @@ public class Nodes {
 
     /**
      * The nodes between (not including) start and end.
+     * @param start Start node
+     * @param end End node
+     * @return Iterable list of <pre>Node</pre>s
      */
     public static Iterable<Node> between(Node start, Node end) {
         return new NodeIterable(start.getNext(), end);

--- a/commonmark/src/main/java/org/commonmark/node/OrderedList.java
+++ b/commonmark/src/main/java/org/commonmark/node/OrderedList.java
@@ -1,8 +1,15 @@
 package org.commonmark.node;
 
 public class OrderedList extends ListBlock {
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
 
     private int startNumber;
+    private String rawNumber;
     private char delimiter;
 
     @Override
@@ -17,6 +24,14 @@ public class OrderedList extends ListBlock {
     public void setStartNumber(int startNumber) {
         this.startNumber = startNumber;
     }
+    
+    public String getRawNumber() {
+        return rawNumber;
+    }
+
+    public void setRawNumber(String rawNumber) {
+        this.rawNumber = rawNumber;
+    }
 
     public char getDelimiter() {
         return delimiter;
@@ -26,4 +41,27 @@ public class OrderedList extends ListBlock {
         this.delimiter = delimiter;
     }
 
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    }
 }

--- a/commonmark/src/main/java/org/commonmark/node/OrderedList.java
+++ b/commonmark/src/main/java/org/commonmark/node/OrderedList.java
@@ -1,13 +1,6 @@
 package org.commonmark.node;
 
 public class OrderedList extends ListBlock {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
-
     private int startNumber;
     private String rawNumber;
     private char delimiter;
@@ -39,29 +32,5 @@ public class OrderedList extends ListBlock {
 
     public void setDelimiter(char delimiter) {
         this.delimiter = delimiter;
-    }
-
-    @Override
-    public String whitespacePreBlock() {
-        return whitespaceTracker[0];
-    }
-
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
-    }
-    
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Paragraph.java
+++ b/commonmark/src/main/java/org/commonmark/node/Paragraph.java
@@ -4,9 +4,39 @@ package org.commonmark.node;
  * A paragraph block, contains inline nodes such as {@link Text}
  */
 public class Paragraph extends Block {
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
 
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
+    }
+
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Paragraph.java
+++ b/commonmark/src/main/java/org/commonmark/node/Paragraph.java
@@ -4,39 +4,19 @@ package org.commonmark.node;
  * A paragraph block, contains inline nodes such as {@link Text}
  */
 public class Paragraph extends Block {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
+    // Whitespace for roundtrip rendering
+    private String whitespacePreBlock = "";
 
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
 
-    @Override
     public String whitespacePreBlock() {
-        return whitespaceTracker[0];
-    }
-
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
+        return whitespacePreBlock;
     }
     
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
+    public void setPreBlockWhitespace(String whitespace) {
+        whitespacePreBlock = whitespace;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/StrongEmphasis.java
+++ b/commonmark/src/main/java/org/commonmark/node/StrongEmphasis.java
@@ -4,11 +4,23 @@ public class StrongEmphasis extends Node implements Delimited {
 
     private String delimiter;
 
+    // Specifically used during roundtrip rendering of thematic breaks
+    private String preBlockWhitespace;
+    
     public StrongEmphasis() {
     }
 
     public StrongEmphasis(String delimiter) {
         this.delimiter = delimiter;
+    }
+    
+    public StrongEmphasis(String delimiter, String preBlockWhitespace) {
+        this(delimiter);
+        this.preBlockWhitespace = preBlockWhitespace;
+    }
+    
+    public String whitespacePreBlock() {
+        return preBlockWhitespace;
     }
 
     public void setDelimiter(String delimiter) {

--- a/commonmark/src/main/java/org/commonmark/node/Text.java
+++ b/commonmark/src/main/java/org/commonmark/node/Text.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 public class Text extends Node {
 
-	private String literal;
+    private String literal;
     private String raw = "";
     private String preContentWhitespace;
     private String postContentWhitespace;

--- a/commonmark/src/main/java/org/commonmark/node/Text.java
+++ b/commonmark/src/main/java/org/commonmark/node/Text.java
@@ -1,14 +1,29 @@
 package org.commonmark.node;
 
+import java.util.Objects;
+
 public class Text extends Node {
 
-    private String literal;
+	private String literal;
+    private String raw = "";
+    private String preContentWhitespace;
+    private String postContentWhitespace;
 
     public Text() {
     }
 
     public Text(String literal) {
         this.literal = literal;
+        this.raw = literal;
+        this.preContentWhitespace = "";
+        this.postContentWhitespace = "";
+    }
+    
+    public Text(String literal, String raw, String preContentWhitespace, String postContentWhitespace) {
+        this.literal = literal;
+        this.raw = raw;
+        this.preContentWhitespace = preContentWhitespace;
+        this.postContentWhitespace = postContentWhitespace;
     }
 
     @Override
@@ -23,9 +38,56 @@ public class Text extends Node {
     public void setLiteral(String literal) {
         this.literal = literal;
     }
+    
+    public String getRaw() {
+        return raw;
+    }
+    
+    public void setRaw(String raw) {
+        this.raw = raw;
+    }
+    
+    public String whitespacePreContent() {
+        if(preContentWhitespace != null) {
+            return preContentWhitespace;
+        }else {
+            return "";
+        }
+    }
+    
+    public String whitespacePostContent() {
+        if(postContentWhitespace != null) {
+            return postContentWhitespace;
+        }else {
+            return "";
+        }
+    }
+    
+    public void setWhitespace(String pre, String post) {
+        preContentWhitespace = pre;
+        postContentWhitespace = post;
+    }
 
     @Override
     protected String toStringAttributes() {
         return "literal=" + literal;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof Text) {
+            if(((Text)obj).getLiteral().equals(literal) && ((Text)obj).getRaw().equals(raw) &&
+                    ((Text)obj).whitespacePreContent().equals(preContentWhitespace) &&
+                    ((Text)obj).whitespacePostContent().equals(postContentWhitespace)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(literal, raw, preContentWhitespace, postContentWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/ThematicBreak.java
+++ b/commonmark/src/main/java/org/commonmark/node/ThematicBreak.java
@@ -1,13 +1,6 @@
 package org.commonmark.node;
 
 public class ThematicBreak extends Block {
-	// Track whitespace as follows:
-    //    [0] Pre-block
-    //    [1] Pre-content
-    //    [2] Post-content
-    //    [3] Post-block
-    private String[] whitespaceTracker = {"", "", "", ""};
-    
     private CharSequence content;
 
     @Override
@@ -21,29 +14,5 @@ public class ThematicBreak extends Block {
     
     public void setContent(CharSequence content) {
         this.content = content;
-    }
-    
-    @Override
-    public String whitespacePreBlock() {
-        return whitespaceTracker[0];
-    }
-
-    @Override
-    public String whitespacePreContent() {
-        return whitespaceTracker[1];
-    }
-
-    @Override
-    public String whitespacePostContent() {
-        return whitespaceTracker[2];
-    }
-
-    @Override
-    public String whitespacePostBlock() {
-        return whitespaceTracker[3];
-    }
-    
-    public void setWhitespace(String... newWhitespace) {
-        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/ThematicBreak.java
+++ b/commonmark/src/main/java/org/commonmark/node/ThematicBreak.java
@@ -1,9 +1,49 @@
 package org.commonmark.node;
 
 public class ThematicBreak extends Block {
+	// Track whitespace as follows:
+    //    [0] Pre-block
+    //    [1] Pre-content
+    //    [2] Post-content
+    //    [3] Post-block
+    private String[] whitespaceTracker = {"", "", "", ""};
+    
+    private CharSequence content;
 
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
+    }
+    
+    public CharSequence getContent() {
+        return content;
+    }
+    
+    public void setContent(CharSequence content) {
+        this.content = content;
+    }
+    
+    @Override
+    public String whitespacePreBlock() {
+        return whitespaceTracker[0];
+    }
+
+    @Override
+    public String whitespacePreContent() {
+        return whitespaceTracker[1];
+    }
+
+    @Override
+    public String whitespacePostContent() {
+        return whitespaceTracker[2];
+    }
+
+    @Override
+    public String whitespacePostBlock() {
+        return whitespaceTracker[3];
+    }
+    
+    public void setWhitespace(String... newWhitespace) {
+        whitespaceTracker = super.prepareStructuralWhitespace(newWhitespace);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/Visitor.java
+++ b/commonmark/src/main/java/org/commonmark/node/Visitor.java
@@ -7,6 +7,8 @@ package org.commonmark.node;
  */
 public interface Visitor {
 
+	void visit(BlankLine blankLine);
+	
     void visit(BlockQuote blockQuote);
 
     void visit(BulletList bulletList);

--- a/commonmark/src/main/java/org/commonmark/node/Visitor.java
+++ b/commonmark/src/main/java/org/commonmark/node/Visitor.java
@@ -7,8 +7,8 @@ package org.commonmark.node;
  */
 public interface Visitor {
 
-	void visit(BlankLine blankLine);
-	
+    void visit(BlankLine blankLine);
+
     void visit(BlockQuote blockQuote);
 
     void visit(BulletList bulletList);

--- a/commonmark/src/main/java/org/commonmark/parser/SourceLine.java
+++ b/commonmark/src/main/java/org/commonmark/parser/SourceLine.java
@@ -1,5 +1,7 @@
 package org.commonmark.parser;
 
+import java.util.Objects;
+
 import org.commonmark.node.SourceSpan;
 
 /**
@@ -11,9 +13,15 @@ public class SourceLine {
 
     private final CharSequence content;
     private final SourceSpan sourceSpan;
+    private final int literalIndex;
 
     public static SourceLine of(CharSequence content, SourceSpan sourceSpan) {
         return new SourceLine(content, sourceSpan);
+    }
+    
+    // The literal index is the beginning of a literal line, as found within a raw line
+    public static SourceLine of(CharSequence content, SourceSpan sourceSpan, int literalIndex) {
+        return new SourceLine(content, sourceSpan, literalIndex);
     }
 
     private SourceLine(CharSequence content, SourceSpan sourceSpan) {
@@ -22,6 +30,16 @@ public class SourceLine {
         }
         this.content = content;
         this.sourceSpan = sourceSpan;
+        this.literalIndex = 0;
+    }
+    
+    private SourceLine(CharSequence content, SourceSpan sourceSpan, int literalIndex) {
+        if (content == null) {
+            throw new NullPointerException("content must not be null");
+        }
+        this.content = content;
+        this.sourceSpan = sourceSpan;
+        this.literalIndex = literalIndex;
     }
 
     public CharSequence getContent() {
@@ -30,6 +48,10 @@ public class SourceLine {
 
     public SourceSpan getSourceSpan() {
         return sourceSpan;
+    }
+    
+    public int getLiteralIndex() {
+        return literalIndex;
     }
 
     public SourceLine substring(int beginIndex, int endIndex) {
@@ -43,5 +65,42 @@ public class SourceLine {
             }
         }
         return SourceLine.of(newContent, newSourceSpan);
+    }
+    
+ // Many lines are passed around as raw strings, with an index value indicating
+    //    where the literal string begins. Calling this method returns a SourceLine containing
+    //    only the literal portion of the line (if it is a subset of the line) or the line
+    //    in full (if they are the same).
+    public SourceLine getLiteralLine() {
+        if(literalIndex == 0) {
+            return SourceLine.of(content, sourceSpan);
+        }else {
+            SourceSpan newSourceSpan = null;
+            if(sourceSpan != null) {
+                int columnIndex = sourceSpan.getColumnIndex() - literalIndex;
+                int length = content.length() - literalIndex;
+                if(length != 0) {
+                    newSourceSpan = SourceSpan.of(sourceSpan.getLineIndex(), columnIndex, length);
+                }
+            }
+            return SourceLine.of(content.subSequence(literalIndex, content.length()), newSourceSpan);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(content, literalIndex);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof SourceLine) {
+            if(((SourceLine)obj).getContent().toString().equals(content) &&
+                    ((SourceLine)obj).getLiteralIndex() == literalIndex) {
+                return true;
+            }
+        }
+        
+        return false;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/parser/SourceLines.java
+++ b/commonmark/src/main/java/org/commonmark/parser/SourceLines.java
@@ -1,9 +1,10 @@
 package org.commonmark.parser;
 
-import org.commonmark.node.SourceSpan;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
+import org.commonmark.node.SourceSpan;
 
 /**
  * A set of lines ({@link SourceLine}) from the input source.
@@ -62,5 +63,33 @@ public class SourceLines {
             }
         }
         return sourceSpans;
+    }
+    
+    /**
+     * Return original <pre>List&lt;SourceLine&rt;</pre>, but with first line removed.
+     * If the list is already empty, return the list unchanged
+     */
+    public List<SourceLine> removeFirstLine() {
+        if(!isEmpty()) {
+            lines.remove(0);
+        }
+        
+        return lines;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lines);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof SourceLines) {
+            if(((SourceLines)obj).getLines().equals(lines)) {
+                return true;
+            }
+        }
+        
+        return false;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/parser/SourceLines.java
+++ b/commonmark/src/main/java/org/commonmark/parser/SourceLines.java
@@ -66,8 +66,9 @@ public class SourceLines {
     }
     
     /**
-     * Return original <pre>List&lt;SourceLine&rt;</pre>, but with first line removed.
+     * Return original <pre>List&lt;SourceLine&gt;</pre>, but with first line removed.
      * If the list is already empty, return the list unchanged
+     * @return List of source lines, or a blank list
      */
     public List<SourceLine> removeFirstLine() {
         if(!isEmpty()) {

--- a/commonmark/src/main/java/org/commonmark/parser/block/BlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/BlockParser.java
@@ -13,18 +13,18 @@ import org.commonmark.parser.SourceLine;
 public interface BlockParser {
 
     /**
-     * Return true if the block that is parsed is a container (contains other blocks), or false if it's a leaf.
+     * @return true if the block that is parsed is a container (contains other blocks), or false if it's a leaf.
      */
     boolean isContainer();
 
     /**
-     * Return true if the block can have lazy continuation lines.
      * <p>
      * Lazy continuation lines are lines that were rejected by this {@link #tryContinue(ParserState)} but didn't match
      * any other block parsers either.
      * <p>
      * If true is returned here, those lines will get added via {@link #addLine(SourceLine)}. For false, the block is
      * closed instead.
+     * @return true if the block can have lazy continuation lines.
      */
     boolean canHaveLazyContinuationLines();
 
@@ -42,6 +42,7 @@ public interface BlockParser {
      * need to override this.
      *
      * @since 0.16.0
+     * @param sourceSpan Source span to be added into the current block
      */
     void addSourceSpan(SourceSpan sourceSpan);
 

--- a/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterProcessor.java
@@ -23,6 +23,7 @@ public interface DelimiterProcessor {
 
     /**
      * Minimum number of delimiter characters that are needed to activate this. Must be at least 1.
+     * @return the minimum number of delimiter characters needed to activate the processor.
      */
     int getMinLength();
 

--- a/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterProcessor.java
@@ -41,4 +41,19 @@ public interface DelimiterProcessor {
      */
     int process(DelimiterRun openingRun, DelimiterRun closingRun);
 
+    /**
+     * Process the delimiter runs.
+     * <p>
+     * The processor can examine the runs and the nodes and decide if it wants to process or not. If not, it should not
+     * change any nodes and return 0. If yes, it should do the processing (wrapping nodes, etc) and then return how many
+     * delimiters were used.
+     * <p>
+     * Note that removal (unlinking) of the used delimiter {@link Text} nodes is done by the caller.
+     *
+     * @param openingRun the opening delimiter run
+     * @param closingRun the closing delimiter run
+     * @param prefix whitespace before the delimiter run, if any
+     * @return how many delimiters were used; must not be greater than length of either opener or closer
+     */
+    int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix);
 }

--- a/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterRun.java
+++ b/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterRun.java
@@ -44,6 +44,8 @@ public interface DelimiterRun {
      * <p>
      * For example, for a delimiter run {@code ***}, calling this with 1 would return the last {@code *}.
      * Calling it with 2 would return the second last {@code *} and the last {@code *}.
+     * @param length Number of openers to capture
+     * @return Requested number of opening characters
      */
     Iterable<Text> getOpeners(int length);
 
@@ -53,6 +55,8 @@ public interface DelimiterRun {
      * <p>
      * For example, for a delimiter run {@code ***}, calling this with 1 would return the first {@code *}.
      * Calling it with 2 would return the first {@code *} and the second {@code *}.
+     * @param length Number of closers to capture
+     * @return Requested number of closing characters
      */
     Iterable<Text> getClosers(int length);
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
@@ -1,9 +1,38 @@
 package org.commonmark.renderer.html;
 
-import org.commonmark.node.*;
-import org.commonmark.renderer.NodeRenderer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
-import java.util.*;
+import org.commonmark.internal.util.Escaping;
+import org.commonmark.node.AbstractVisitor;
+import org.commonmark.node.BlankLine;
+import org.commonmark.node.BlockQuote;
+import org.commonmark.node.BulletList;
+import org.commonmark.node.Code;
+import org.commonmark.node.Document;
+import org.commonmark.node.Emphasis;
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.HardLineBreak;
+import org.commonmark.node.Heading;
+import org.commonmark.node.HtmlBlock;
+import org.commonmark.node.HtmlInline;
+import org.commonmark.node.Image;
+import org.commonmark.node.IndentedCodeBlock;
+import org.commonmark.node.Link;
+import org.commonmark.node.ListBlock;
+import org.commonmark.node.ListItem;
+import org.commonmark.node.Node;
+import org.commonmark.node.OrderedList;
+import org.commonmark.node.Paragraph;
+import org.commonmark.node.SoftLineBreak;
+import org.commonmark.node.StrongEmphasis;
+import org.commonmark.node.Text;
+import org.commonmark.node.ThematicBreak;
+import org.commonmark.renderer.NodeRenderer;
 
 /**
  * The node renderer that renders all the core nodes (comes last in the order of node renderers).
@@ -40,7 +69,8 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
                 Code.class,
                 HtmlInline.class,
                 SoftLineBreak.class,
-                HardLineBreak.class
+                HardLineBreak.class,
+                BlankLine.class
         ));
     }
 
@@ -99,7 +129,11 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
     public void visit(FencedCodeBlock fencedCodeBlock) {
         String literal = fencedCodeBlock.getLiteral();
         Map<String, String> attributes = new LinkedHashMap<>();
-        String info = fencedCodeBlock.getInfo();
+        
+        // The info string for FencedCodeBlock is not escaped or trimmed
+        //    of excess whitespace, do that now
+        String info = Escaping.unescapeString(fencedCodeBlock.getInfo()).trim();
+        
         if (info != null && !info.isEmpty()) {
             int space = info.indexOf(" ");
             String language;
@@ -244,6 +278,13 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
         html.line();
     }
 
+    @Override
+    public void visit(BlankLine blankLine) {
+        // The BlankLine class is not part of the CommonMark standard, and is
+        //    only for roundtrip rendering. Thus, it is specifically ignored
+        //    by the HTML renderer.
+    }
+    
     @Override
     protected void visitChildren(Node parent) {
         Node node = parent.getFirstChild();

--- a/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonMarkNodeRendererContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonMarkNodeRendererContext.java
@@ -1,0 +1,25 @@
+package org.commonmark.renderer.roundtrip;
+
+import org.commonmark.node.Node;
+
+public interface CommonMarkNodeRendererContext {
+
+    /**
+     * @return true for stripping new lines and render text as "single line",
+     * false for keeping all line breaks.
+     */
+    boolean stripNewlines();
+
+    /**
+     * @return the writer to use
+     */
+    CommonMarkWriter getWriter();
+
+    /**
+     * Render the specified node and its children using the configured renderers. This should be used to render child
+     * nodes; be careful not to pass the node that is being rendered, that would result in an endless loop.
+     *
+     * @param node the node to render
+     */
+    void render(Node node);
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonMarkRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonMarkRenderer.java
@@ -1,0 +1,149 @@
+package org.commonmark.renderer.roundtrip;
+
+import org.commonmark.Extension;
+import org.commonmark.internal.renderer.NodeRendererMap;
+import org.commonmark.node.Node;
+import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.Renderer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CommonMarkRenderer implements Renderer {
+
+    private final boolean stripNewlines;
+
+    private final List<CommonmarkNodeRendererFactory> nodeRendererFactories;
+
+    private CommonMarkRenderer(Builder builder) {
+        this.stripNewlines = builder.stripNewlines;
+
+        this.nodeRendererFactories = new ArrayList<>(builder.nodeRendererFactories.size() + 1);
+        this.nodeRendererFactories.addAll(builder.nodeRendererFactories);
+        // Add as last. This means clients can override the rendering of core nodes if they want.
+        this.nodeRendererFactories.add(new CommonmarkNodeRendererFactory() {
+            @Override
+            public NodeRenderer create(CommonMarkNodeRendererContext context) {
+                return new CoreCommonMarkNodeRenderer(context);
+            }
+        });
+    }
+
+    /**
+     * Create a new builder for configuring an {@link CommonMarkRenderer}.
+     *
+     * @return a builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public void render(Node node, Appendable output) {
+        RendererContext context = new RendererContext(new CommonMarkWriter(output));
+        context.render(node);
+    }
+
+    @Override
+    public String render(Node node) {
+        StringBuilder sb = new StringBuilder();
+        render(node, sb);
+        return sb.toString();
+    }
+
+    /**
+     * Builder for configuring an {@link CommonMarkRenderer}. See methods for default configuration.
+     */
+    public static class Builder {
+
+        private boolean stripNewlines = false;
+        private List<CommonmarkNodeRendererFactory> nodeRendererFactories = new ArrayList<>();
+
+        /**
+         * @return the configured {@link CommonMarkRenderer}
+         */
+        public CommonMarkRenderer build() {
+            return new CommonMarkRenderer(this);
+        }
+
+        /**
+         * Set the value of flag for stripping new lines.
+         *
+         * @param stripNewlines true for stripping new lines and render text as "single line",
+         *                      false for keeping all line breaks
+         * @return {@code this}
+         */
+        public Builder stripNewlines(boolean stripNewlines) {
+            this.stripNewlines = stripNewlines;
+            return this;
+        }
+
+        /**
+         * Add a factory for instantiating a node renderer (done when rendering). This allows to override the rendering
+         * of node types or define rendering for custom node types.
+         * <p>
+         * If multiple node renderers for the same node type are created, the one from the factory that was added first
+         * "wins". (This is how the rendering for core node types can be overridden; the default rendering comes last.)
+         *
+         * @param nodeRendererFactory the factory for creating a node renderer
+         * @return {@code this}
+         */
+        public Builder nodeRendererFactory(CommonmarkNodeRendererFactory nodeRendererFactory) {
+            this.nodeRendererFactories.add(nodeRendererFactory);
+            return this;
+        }
+
+        /**
+         * @param extensions extensions to use on this text content renderer
+         * @return {@code this}
+         */
+        public Builder extensions(Iterable<? extends Extension> extensions) {
+            for (Extension extension : extensions) {
+                if (extension instanceof CommonMarkRenderer.CommonMarkRendererExtension) {
+                    CommonMarkRenderer.CommonMarkRendererExtension textContentRendererExtension =
+                            (CommonMarkRenderer.CommonMarkRendererExtension) extension;
+                    textContentRendererExtension.extend(this);
+                }
+            }
+            return this;
+        }
+    }
+
+    /**
+     * Extension for {@link CommonMarkRenderer}.
+     */
+    public interface CommonMarkRendererExtension extends Extension {
+        void extend(CommonMarkRenderer.Builder rendererBuilder);
+    }
+
+    private class RendererContext implements CommonMarkNodeRendererContext {
+        private final CommonMarkWriter commonMarkWriter;
+        private final NodeRendererMap nodeRendererMap = new NodeRendererMap();
+
+        private RendererContext(CommonMarkWriter commonMarkWriter) {
+            this.commonMarkWriter = commonMarkWriter;
+
+            // The first node renderer for a node type "wins".
+            for (int i = nodeRendererFactories.size() - 1; i >= 0; i--) {
+                CommonmarkNodeRendererFactory nodeRendererFactory = nodeRendererFactories.get(i);
+                NodeRenderer nodeRenderer = nodeRendererFactory.create(this);
+                nodeRendererMap.add(nodeRenderer);
+            }
+        }
+
+        @Override
+        public boolean stripNewlines() {
+            return stripNewlines;
+        }
+
+        @Override
+        public CommonMarkWriter getWriter() {
+            return commonMarkWriter;
+        }
+
+        @Override
+        public void render(Node node) {
+            nodeRendererMap.render(node);
+        }
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonMarkWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonMarkWriter.java
@@ -1,0 +1,65 @@
+package org.commonmark.renderer.roundtrip;
+
+import java.io.IOException;
+
+public class CommonMarkWriter {
+
+    private final Appendable buffer;
+
+    private char lastChar;
+
+    public CommonMarkWriter(Appendable out) {
+        buffer = out;
+    }
+
+    public void whitespace() {
+        if (lastChar != 0 && lastChar != ' ') {
+            append(' ');
+        }
+    }
+
+    public void colon() {
+        if (lastChar != 0 && lastChar != ':') {
+            append(':');
+        }
+    }
+
+    public void line() {
+    	append('\n');
+    }
+
+    public void writeStripped(String s) {
+        append(s.replaceAll("[\\r\\n\\s]+", " "));
+    }
+
+    public void write(String s) {
+        append(s);
+    }
+    
+    public void write(char c) {
+        append(c);
+    }
+
+    private void append(String s) {
+        try {
+            buffer.append(s);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        int length = s.length();
+        if (length != 0) {
+            lastChar = s.charAt(length - 1);
+        }
+    }
+
+    private void append(char c) {
+        try {
+            buffer.append(c);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        lastChar = c;
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonMarkWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonMarkWriter.java
@@ -25,7 +25,7 @@ public class CommonMarkWriter {
     }
 
     public void line() {
-    	append('\n');
+        append('\n');
     }
 
     public void writeStripped(String s) {

--- a/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonmarkNodeRendererFactory.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CommonmarkNodeRendererFactory.java
@@ -1,0 +1,17 @@
+package org.commonmark.renderer.roundtrip;
+
+import org.commonmark.renderer.NodeRenderer;
+
+/**
+ * Factory for instantiating new node renderers when rendering is done.
+ */
+public interface CommonmarkNodeRendererFactory {
+
+    /**
+     * Create a new node renderer for the specified rendering context.
+     *
+     * @param context the context for rendering (normally passed on to the node renderer)
+     * @return a node renderer
+     */
+    NodeRenderer create(CommonMarkNodeRendererContext context);
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CoreCommonMarkNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/roundtrip/CoreCommonMarkNodeRenderer.java
@@ -1,0 +1,575 @@
+package org.commonmark.renderer.roundtrip;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.commonmark.internal.renderer.text.BulletListHolder;
+import org.commonmark.internal.renderer.text.ListHolder;
+import org.commonmark.internal.renderer.text.OrderedListHolder;
+import org.commonmark.node.AbstractVisitor;
+import org.commonmark.node.BlankLine;
+import org.commonmark.node.BlockQuote;
+import org.commonmark.node.BulletList;
+import org.commonmark.node.Code;
+import org.commonmark.node.Document;
+import org.commonmark.node.Emphasis;
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.HardLineBreak;
+import org.commonmark.node.Heading;
+import org.commonmark.node.HtmlBlock;
+import org.commonmark.node.HtmlInline;
+import org.commonmark.node.Image;
+import org.commonmark.node.IndentedCodeBlock;
+import org.commonmark.node.Link;
+import org.commonmark.node.LinkFormat.LinkType;
+import org.commonmark.node.LinkReferenceDefinition;
+import org.commonmark.node.ListBlock;
+import org.commonmark.node.ListItem;
+import org.commonmark.node.Node;
+import org.commonmark.node.OrderedList;
+import org.commonmark.node.Paragraph;
+import org.commonmark.node.SoftLineBreak;
+import org.commonmark.node.StrongEmphasis;
+import org.commonmark.node.Text;
+import org.commonmark.node.ThematicBreak;
+import org.commonmark.renderer.NodeRenderer;
+
+/**
+ * The node renderer that renders all the core nodes (comes last in the order of node renderers).
+ */
+public class CoreCommonMarkNodeRenderer extends AbstractVisitor implements NodeRenderer {
+
+    protected final CommonMarkNodeRendererContext context;
+    private final CommonMarkWriter textContent;
+
+    private ListHolder listHolder;
+    
+    public CoreCommonMarkNodeRenderer(CommonMarkNodeRendererContext context) {
+        this.context = context;
+        this.textContent = context.getWriter();
+    }
+
+    @Override
+    public Set<Class<? extends Node>> getNodeTypes() {
+        return new HashSet<>(Arrays.asList(
+                Document.class,
+                Heading.class,
+                Paragraph.class,
+                BlockQuote.class,
+                BulletList.class,
+                FencedCodeBlock.class,
+                HtmlBlock.class,
+                ThematicBreak.class,
+                IndentedCodeBlock.class,
+                Link.class,
+                LinkReferenceDefinition.class,
+                ListBlock.class,
+                ListItem.class,
+                OrderedList.class,
+                Image.class,
+                Emphasis.class,
+                StrongEmphasis.class,
+                Text.class,
+                Code.class,
+                HtmlInline.class,
+                SoftLineBreak.class,
+                HardLineBreak.class,
+                BlankLine.class
+        ));
+    }
+
+    @Override
+    public void render(Node node) {
+        node.accept(this);
+    }
+
+    @Override
+    public void visit(Document document) {
+        // No rendering itself (aside from post-block whitespace, if present)
+    	
+        visitChildren(document);
+
+        textContent.write(document.whitespacePostBlock());
+    }
+
+    public void visit(BlockQuote blockQuote) {
+    	if(blockQuote.getFirstChild() instanceof Heading ||
+    			blockQuote.getFirstChild() instanceof IndentedCodeBlock ||
+    			blockQuote.getFirstChild() instanceof FencedCodeBlock) {
+	    	textContent.write(blockQuote.whitespacePreBlock());
+	    	textContent.write(">");
+	    	textContent.write(blockQuote.whitespacePreContent());
+    	}
+    	
+        visitChildren(blockQuote);
+        
+        writeEndOfLineIfNeeded(blockQuote, null);
+    }
+
+    @Override
+    public void visit(BulletList bulletList) {
+        listHolder = new BulletListHolder(listHolder, bulletList);
+        visitChildren(bulletList);
+        writeEndOfLineIfNeeded(bulletList, null);
+
+        if (listHolder.getParent() != null) {
+            listHolder = listHolder.getParent();
+        } else {
+            listHolder = null;
+        }
+    }
+
+    public void visit(Code code) {
+        for(int i = 0; i < code.getNumBackticks(); i++) {
+            textContent.write('`');
+        }
+        
+        textContent.write(code.getRaw());
+        
+        for(int i = 0; i < code.getNumBackticks(); i++) {
+            textContent.write('`');
+        }
+    }
+    
+    @Override
+    public void visit(Emphasis emphasis) {
+    	textContent.write(emphasis.whitespacePreBlock());
+        textContent.write(emphasis.getOpeningDelimiter());
+        visitChildren(emphasis);
+        textContent.write(emphasis.getClosingDelimiter());
+    }
+
+    public void visit(FencedCodeBlock fencedCodeBlock) {
+        for(int i = 0; i < fencedCodeBlock.getStartFenceIndent(); i++) {
+            textContent.write(" ");
+        }
+        
+        for(int i = 0; i < fencedCodeBlock.getStartFenceLength(); i++) {
+            textContent.write(fencedCodeBlock.getFenceChar());
+        }
+        
+        if(fencedCodeBlock.getInfo() != null && !fencedCodeBlock.getInfo().isEmpty()) {
+            textContent.write(fencedCodeBlock.getInfo());
+        }
+        
+        // CommonMark test case #96 shows that content with no ending fence and
+        //    completely blank content should not trigger a new line
+        if(fencedCodeBlock.getEndFenceLength() > 0 || !fencedCodeBlock.getRaw().isEmpty()) {
+        	textContent.line();
+        }
+        
+        textContent.write(fencedCodeBlock.getRaw());
+        
+        if(fencedCodeBlock.getEndFenceLength() > 0 && !fencedCodeBlock.getRaw().isEmpty()) {
+        	textContent.line();
+        }
+        
+        for(int i = 0; i < fencedCodeBlock.getEndFenceIndent(); i++) {
+            textContent.write(" ");
+        }
+        
+        for(int i = 0; i < fencedCodeBlock.getEndFenceLength(); i++) {
+            textContent.write(fencedCodeBlock.getFenceChar());
+        }
+        
+        if(fencedCodeBlock.getEndFenceLength() > 0) {
+            textContent.write(fencedCodeBlock.whitespacePostBlock());
+        }
+        
+        writeEndOfLineIfNeeded(fencedCodeBlock, null);
+    }
+
+    @Override
+    public void visit(HardLineBreak hardLineBreak) {
+    	if(hardLineBreak.hasBackslash()) {
+    		textContent.write("\\");
+    	}
+    	
+        writeEndOfLine();
+    }
+
+    public void visit(Heading heading) {
+        
+        if(heading.getSymbolType() == '#') {
+        	textContent.write(heading.whitespacePreBlock());
+            
+            for(int i = 0; i < heading.getLevel(); i++) {
+                textContent.write(heading.getSymbolType());
+            }
+            
+            textContent.write(heading.whitespacePreContent());
+            
+            visitChildren(heading);
+            
+            textContent.write(heading.whitespacePostContent());
+            
+            if(heading.getNumEndingSymbol() > 0) {
+                for(int i = 0; i < heading.getNumEndingSymbol(); i++) {
+                    textContent.write(heading.getSymbolType());
+                }
+            }
+            
+            textContent.write(heading.whitespacePostBlock());
+            
+            writeEndOfLineIfNeeded(heading, null);
+            
+        }else {
+        	textContent.write(heading.whitespacePreBlock());
+        	
+        	visitChildren(heading);
+        	
+        	textContent.write(heading.whitespacePreContent());
+        	
+        	writeEndOfLine();
+
+        	textContent.write(heading.whitespacePostContent());
+        	
+            if(heading.getNumEndingSymbol() > 0) {
+            	for(int i = 0; i < heading.getNumEndingSymbol(); i++) {
+            		textContent.write(heading.getSymbolType());
+            	}
+            }
+            
+           	textContent.write(heading.whitespacePostBlock());
+            
+            writeEndOfLineIfNeeded(heading, null);
+        }
+    }
+
+    public void visit(ThematicBreak thematicBreak) {
+    	if(thematicBreak.getContent() != null) {
+    		textContent.write(thematicBreak.getContent().toString());
+    	}
+    	
+        writeEndOfLineIfNeeded(thematicBreak, null);
+    }
+
+    @Override
+    public void visit(HtmlInline htmlInline) {
+        textContent.write(htmlInline.getLiteral());
+    }
+
+    @Override
+    public void visit(HtmlBlock htmlBlock) {
+    	textContent.write(htmlBlock.getRaw());
+    	writeEndOfLineIfNeeded(htmlBlock, null);
+    }
+
+    @Override
+    public void visit(Image image) {
+        writeLink(image, image.getTitle(), image.getDestination());
+    }
+
+    @Override
+    public void visit(IndentedCodeBlock indentedCodeBlock) {
+   		textContent.write(indentedCodeBlock.whitespacePreContent());
+    	
+    	textContent.write(indentedCodeBlock.getRaw());
+    	
+    	writeEndOfLineIfNeeded(indentedCodeBlock, null);
+    }
+
+    public void visit(Link link) {
+        writeLink(link, link.getTitle(), link.getDestination());
+    }
+    
+    @Override
+    public void visit(LinkReferenceDefinition linkDef) {
+        writeLinkReference(linkDef);
+        writeEndOfLineIfNeeded(linkDef, null);
+    }
+
+    @Override
+    public void visit(ListItem listItem) {
+        if (listHolder != null && listHolder instanceof OrderedListHolder) {
+            OrderedListHolder orderedListHolder = (OrderedListHolder) listHolder;
+            
+            textContent.write(listItem.whitespacePreBlock());
+            
+            if(!(listItem.getFirstChild() instanceof ThematicBreak) &&
+            		!(listItem.getFirstChild() instanceof HtmlBlock) &&
+            		!(listItem.getParent().getParent() instanceof BlockQuote) &&
+            		!(listItem.getFirstChild() instanceof BlankLine)) {
+            	textContent.write(listItem.getRawNumber() + "");
+            	textContent.write(orderedListHolder.getDelimiter());
+            	textContent.write(listItem.whitespacePreContent());
+            }
+            
+            visitChildren(listItem);
+            
+            textContent.write(listItem.whitespacePostBlock());
+            
+            writeEndOfLineIfNeeded(listItem, null);
+        } else if (listHolder != null && listHolder instanceof BulletListHolder) {
+            BulletListHolder bulletListHolder = (BulletListHolder) listHolder;
+            
+            textContent.write(listItem.whitespacePreBlock());
+            
+            if(!(listItem.getFirstChild() instanceof ThematicBreak) &&
+            		!(listItem.getFirstChild() instanceof HtmlBlock) &&
+            		!(listItem.getParent().getParent() instanceof BlockQuote) &&
+            		!(listItem.getFirstChild() instanceof BlankLine)) {
+            	textContent.write(bulletListHolder.getMarker());
+            	textContent.write(listItem.whitespacePreContent());
+            }
+            visitChildren(listItem);
+            
+            textContent.write(listItem.whitespacePostBlock());
+            
+            writeEndOfLineIfNeeded(listItem, null);
+        }
+        
+    }
+
+    @Override
+    public void visit(OrderedList orderedList) {
+        listHolder = new OrderedListHolder(listHolder, orderedList);
+        visitChildren(orderedList);
+        writeEndOfLineIfNeeded(orderedList, null);
+
+        if (listHolder.getParent() != null) {
+            listHolder = listHolder.getParent();
+        } else {
+            listHolder = null;
+        }
+        
+    }
+
+    public void visit(Paragraph paragraph) {
+        visitChildren(paragraph);
+        
+        writeEndOfLineIfNeeded(paragraph, null);
+
+        textContent.write(paragraph.whitespacePostBlock());
+    }
+
+    @Override
+    public void visit(SoftLineBreak softLineBreak) {
+    	// Within roundtrip rendering, a soft break is always a newline of some kind
+        writeEndOfLine();
+    }
+    
+    @Override
+    public void visit(StrongEmphasis strongEmphasis) {
+    	textContent.write(strongEmphasis.whitespacePreBlock());
+        textContent.write(strongEmphasis.getOpeningDelimiter());
+        visitChildren(strongEmphasis);
+        textContent.write(strongEmphasis.getClosingDelimiter());
+    }
+
+    @Override
+    public void visit(Text text) {
+    	if(!text.getRaw().isEmpty()) {
+			textContent.write(text.whitespacePreContent() + text.getRaw() + text.whitespacePostContent());
+		}else {
+			textContent.write(text.whitespacePreContent() + text.getLiteral() + text.whitespacePostContent());
+		}
+    }
+    
+    @Override
+	public void visit(BlankLine blankLine) {
+		System.out.println(blankLine.getRaw());
+		textContent.write(blankLine.getRaw());
+		writeEndOfLineIfNeeded(blankLine, null);
+	}
+
+	@Override
+    protected void visitChildren(Node parent) {
+        Node node = parent.getFirstChild();
+        
+        while (node != null) {
+            Node next = node.getNext();
+            
+            context.render(node);
+            node = next;
+        }
+    }
+
+    private void writeLink(Node node, String title, String destination) {
+        if(node instanceof Link) {
+            writeLink((Link)node);
+        }
+        
+        if(node instanceof Image) {
+            writeImage((Image)node);
+        }
+    }
+    
+    private void writeLink(Link node) {
+        // Autolink
+        if(node.getLinkType() == LinkType.AUTOLINK) {
+            textContent.write("<");
+            visitChildren(node);
+            textContent.write(">");
+        }else if(node.getLinkType() == LinkType.REFERENCE) {
+        	textContent.write("[");
+            visitChildren(node);
+            textContent.write("]");
+            
+            if(node.getLabel() != null) {
+	            textContent.write("[");
+	            if(node.getRawLabel() != null && !node.getRawLabel().isEmpty()) {
+	            	textContent.write(node.getRawLabel());
+	            }else {
+	            	textContent.write(node.getLabel());
+	            }
+	            textContent.write("]");
+            }
+        }else {
+            textContent.write("[");
+            visitChildren(node);
+            textContent.write("]");
+            
+            textContent.write("(");
+            
+            if(!node.getRawDestination().isEmpty()) {
+            	textContent.write(node.getWhitespacePreDestination());
+            	textContent.write(node.getRawDestination());
+            }else if(node.getDestination() != null) {
+                textContent.write(node.getWhitespacePreDestination());
+                textContent.write(node.getDestination());
+            }else {
+                visitChildren(node);
+            }
+            
+            if(!node.getRawTitle().isEmpty()) {
+            	textContent.write(node.getWhitespacePreTitle());
+            	textContent.write(node.getRawTitle());
+            }else if(node.getTitle() != null) {
+                textContent.write(node.getWhitespacePreTitle());
+                textContent.write(node.getTitleSymbol() + "");
+                
+                textContent.write(node.getTitle());
+                
+                if(node.getTitleSymbol() == '(') {
+                	textContent.write(")");
+                }else {
+                	textContent.write(node.getTitleSymbol());
+                }
+            }
+            
+            textContent.write(node.getWhitespacePostContent());
+            textContent.write(")");
+        }
+    }
+    
+    private void writeLinkReference(LinkReferenceDefinition node) {
+    	textContent.write(node.whitespacePreLabel());
+    	
+        textContent.write("[");
+        textContent.write(node.getLabel());
+        textContent.write("]:");
+        
+        if(node.getDestination() != null) {
+        	textContent.write(node.whitespacePreDestination());
+        	if(!node.getRawDestination().isEmpty()) {
+        		textContent.write(node.getRawDestination());
+        	}else {
+        		textContent.write(node.getDestination());
+        	}
+            
+            if(node.getTitle() != null) {
+            	textContent.write(node.whitespacePreTitle());
+            	
+            	char delimiter = node.getDelimiterChar();
+            	
+            	if(delimiter == Character.MIN_VALUE) {
+            		delimiter = '"';
+            	}
+            	
+            	textContent.write(delimiter);
+            	
+            	if(!node.getRawTitle().isEmpty()) {
+            		textContent.write(node.getRawTitle());
+            	}else {
+            		textContent.write(node.getTitle());
+            	}
+            	
+            	textContent.write(delimiter);
+            }
+        }
+        
+        textContent.write(node.whitespacePostTitle());
+    }
+    
+    private void writeImage(Image node) {
+        // Autolink
+        if(node.getLinkType() == LinkType.AUTOLINK) {
+            textContent.write("<");
+            visitChildren(node);
+            textContent.write(">");
+        }else if(node.getLinkType() == LinkType.REFERENCE) {
+        	textContent.write("![");
+            visitChildren(node);
+            textContent.write("]");
+            
+            if(node.getLabel() != null) {
+	            textContent.write("[");
+	            if(node.getRawLabel() != null && !node.getRawLabel().isEmpty()) {
+	            	textContent.write(node.getRawLabel());
+	            }else {
+	            	textContent.write(node.getLabel());
+	            }
+	            textContent.write("]");
+            }
+        }else {
+            textContent.write("![");
+            visitChildren(node);
+            textContent.write("]");
+            
+            textContent.write("(");
+            
+            if(!node.getRawDestination().isEmpty()) {
+            	textContent.write(node.getWhitespacePreDestination());
+            	textContent.write(node.getRawDestination());
+            }else if(node.getDestination() != null) {
+                textContent.write(node.getWhitespacePreDestination());
+                textContent.write(node.getDestination());
+            }else {
+                visitChildren(node);
+            }
+            
+            if(!node.getRawTitle().isEmpty()) {
+            	textContent.write(node.getWhitespacePreTitle());
+            	textContent.write(node.getRawTitle());
+            }else if(node.getTitle() != null) {
+                textContent.write(node.getWhitespacePreTitle());
+                textContent.write(node.getTitleSymbol() + "");
+                
+                textContent.write(node.getTitle());
+                
+                if(node.getTitleSymbol() == '(') {
+                	textContent.write(")");
+                }else {
+                	textContent.write(node.getTitleSymbol());
+                }
+            }
+            
+            textContent.write(node.getWhitespacePostContent());
+            textContent.write(")");
+        }
+    }
+
+    private void writeEndOfLineIfNeeded(Node node, Character c) {
+        if (node.getNext() != null) {
+        	if(node instanceof ListItem) {
+        		// If a list item has post-block whitespace, allow it to handle whitespace
+        		if(((ListItem)node).whitespacePostBlock().isEmpty()) {
+        			textContent.line();
+        		}
+        	}else if(node instanceof Paragraph) {
+        		// If a paragraph has post-block whitespace, allow it to handle whitespace
+        		if(((Paragraph)node).whitespacePostBlock().isEmpty()) {
+        			textContent.line();
+        		}
+        	}else {
+        		textContent.line();
+        	}
+        }
+    }
+
+    private void writeEndOfLine() {
+        textContent.line();
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
@@ -102,6 +102,11 @@ public class DelimiterProcessorTest extends RenderingTestCase {
         public int process(DelimiterRun openingRun, DelimiterRun closingRun) {
             return delimiterUse;
         }
+
+        @Override
+        public int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix) {
+            return process(openingRun, closingRun);
+        }
     }
 
     private static class AsymmetricDelimiterProcessor implements DelimiterProcessor {
@@ -135,6 +140,11 @@ public class DelimiterProcessorTest extends RenderingTestCase {
             start.insertAfter(content);
 
             return 1;
+        }
+
+        @Override
+        public int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix) {
+            return process(openingRun, closingRun);
         }
     }
 
@@ -198,6 +208,11 @@ public class DelimiterProcessorTest extends RenderingTestCase {
             closingRun.getCloser().insertBefore(new Text("(/1)"));
             return 1;
         }
+
+        @Override
+        public int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix) {
+            return process(openingRun, closingRun);
+        }
     }
 
     private static class TwoDelimiterProcessor implements DelimiterProcessor {
@@ -222,6 +237,11 @@ public class DelimiterProcessorTest extends RenderingTestCase {
             openingRun.getOpener().insertAfter(new Text("(2)"));
             closingRun.getCloser().insertBefore(new Text("(/2)"));
             return 2;
+        }
+
+        @Override
+        public int process(DelimiterRun openingRun, DelimiterRun closingRun, String prefix) {
+            return process(openingRun, closingRun);
         }
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/LinkReferenceDefinitionNodeTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/LinkReferenceDefinitionNodeTest.java
@@ -17,9 +17,11 @@ public class LinkReferenceDefinitionNodeTest {
         Node document = parse("This is a paragraph with a [foo] link.\n\n[foo]: /url 'title'");
         List<Node> nodes = Nodes.getChildren(document);
 
-        assertThat(nodes.size(), is(2));
+        // Node size is 3 instead of 2 due to BlankLine pseudo-node
+        assertThat(nodes.size(), is(3));
         assertThat(nodes.get(0), instanceOf(Paragraph.class));
-        LinkReferenceDefinition definition = assertDef(nodes.get(1), "foo");
+        assertThat(nodes.get(1), instanceOf(BlankLine.class));
+        LinkReferenceDefinition definition = assertDef(nodes.get(2), "foo");
 
         assertThat(definition.getDestination(), is("/url"));
         assertThat(definition.getTitle(), is("title"));
@@ -41,10 +43,12 @@ public class LinkReferenceDefinitionNodeTest {
         Node document = parse("This is a paragraph with a [foo] link.\n\n[foo]: /url\n[bar]: /url");
         List<Node> nodes = Nodes.getChildren(document);
 
-        assertThat(nodes.size(), is(3));
+        // Node size is 4 instead of 3 due to BlankLine pseudo-node
+        assertThat(nodes.size(), is(4));
         assertThat(nodes.get(0), instanceOf(Paragraph.class));
-        assertDef(nodes.get(1), "foo");
-        assertDef(nodes.get(2), "bar");
+        assertThat(nodes.get(1), instanceOf(BlankLine.class));
+        assertDef(nodes.get(2), "foo");
+        assertDef(nodes.get(3), "bar");
     }
 
     @Test
@@ -52,13 +56,15 @@ public class LinkReferenceDefinitionNodeTest {
         Node document = parse("This is a paragraph with a [foo] link.\n\n[foo]: /url1\n[foo]: /url2");
         List<Node> nodes = Nodes.getChildren(document);
 
-        assertThat(nodes.size(), is(3));
+        // Node size is 4 instead of 3 due to BlankLine pseudo-node
+        assertThat(nodes.size(), is(4));
         assertThat(nodes.get(0), instanceOf(Paragraph.class));
-        LinkReferenceDefinition def1 = assertDef(nodes.get(1), "foo");
+        assertThat(nodes.get(1), instanceOf(BlankLine.class));
+        LinkReferenceDefinition def1 = assertDef(nodes.get(2), "foo");
         assertThat(def1.getDestination(), is("/url1"));
         // When there's multiple definitions with the same label, the first one "wins", as in reference links will use
         // that. But we still want to preserve the original definitions in the document.
-        LinkReferenceDefinition def2 = assertDef(nodes.get(2), "foo");
+        LinkReferenceDefinition def2 = assertDef(nodes.get(3), "foo");
         assertThat(def2.getDestination(), is("/url2"));
     }
 
@@ -110,9 +116,11 @@ public class LinkReferenceDefinitionNodeTest {
         Node document = parse("This is a paragraph with a [foo] link.\n\n[fOo]: /url 'title'");
         List<Node> nodes = Nodes.getChildren(document);
 
-        assertThat(nodes.size(), is(2));
+        // Node size is 3 instead of 2 due to BlankLine pseudo-node
+        assertThat(nodes.size(), is(3));
         assertThat(nodes.get(0), instanceOf(Paragraph.class));
-        assertDef(nodes.get(1), "fOo");
+        assertThat(nodes.get(1), instanceOf(BlankLine.class));
+        assertDef(nodes.get(2), "fOo");
     }
 
     private static Node parse(String input) {

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -155,6 +155,31 @@ public class ParserTest {
     }
 
     private static class DashBlock extends CustomBlock {
+
+        @Override
+        public String whitespacePreBlock() {
+            return "";
+        }
+
+        @Override
+        public String whitespacePreContent() {
+            return "";
+        }
+
+        @Override
+        public String whitespacePostContent() {
+            return "";
+        }
+
+        @Override
+        public String whitespacePostBlock() {
+            return "";
+        }
+
+        @Override
+        public void setWhitespace(String... newWhitespace) {
+            // No whitespace needed for testing
+        }
     }
 
     private static class DashBlockParser extends AbstractBlockParser {

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -155,31 +155,6 @@ public class ParserTest {
     }
 
     private static class DashBlock extends CustomBlock {
-
-        @Override
-        public String whitespacePreBlock() {
-            return "";
-        }
-
-        @Override
-        public String whitespacePreContent() {
-            return "";
-        }
-
-        @Override
-        public String whitespacePostContent() {
-            return "";
-        }
-
-        @Override
-        public String whitespacePostBlock() {
-            return "";
-        }
-
-        @Override
-        public void setWhitespace(String... newWhitespace) {
-            // No whitespace needed for testing
-        }
     }
 
     private static class DashBlockParser extends AbstractBlockParser {


### PR DESCRIPTION
Fixes #12 

Until now, this library could parse Commonmark into other formats, but not back into Commonmark format. This is understandable, as the Commonmark spec itself uses conversions to HTML to depict compliance. However, with the new `CoreCommonMarkNodeRenderer` it becomes possible to render Commonmark once it has been parsed - a "roundtrip" rendering. Usage is identical to `HtmlRenderer`.

### KNOWN ISSUE:
- If using `IncludeSourceSpans.NONE` (the default) or `IncludeSourceSpans.BLOCKS`, 4 test cases related to link reference definitions (193, 195, 198, and 217) will fail. In all cases it's due to line breaks, this is the only data structure where I couldn't find another way (besides `SourceSpan`) to track the line number if newlines occur. Use of `IncludeSourceSpans.BLOCKS_AND_INLINES` is recommended for 100% Commonmark roundtrip compliance.

### DETAILS:
This is a relatively large PR. I have attempted to keep backwards compatibility whenever possible, but it's uncertain whether this update may break extensions to the core specification. Core specifications are confirmed to all pass.

In order to achieve this roundtrip functionality, new fields have been added to the various Commonmark nodes, and many changes to parsers have been added to populate these new fields. The `commonmark-java` library is geared towards conversion to HTML already, so I have chosen to keep that functionality and its optimizations intact and build extra structures on top of that approach rather than trying to rewrite what has already been done.

The one change which departs from existing functionality is the addition of a new `BlankLine` node type. This node represents a concept explained in the Commonmark spec (blank lines), but it is not truly defined in the spec as a Commonmark block. `BlankLine` should be treated as `SourceSpan` already is - a utility class that helps to describe the structure. (Speaking of `SourceSpan`, I have elected to keep them tracking the HTML wherever possible rather than the raw text in order to avoid breaking changes.)

The `BlankLine` class is specifically ignored in HTML rendering and is only currently used by the roundtrip rendering to fill in gaps which otherwise can't be determined from the parsed AST tree. In this way, existing plugins can render to other formats the same as they always have, but will also have the option of rendering back to Commonmark.