### PR TITLE
Fix tables with leading/trailing header pipes and trailing spaces

### DIFF
--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -236,6 +236,49 @@ public class TablesTest extends RenderingTestCase {
     }
 
     @Test
+    public void pipesOnOutsideWhitespaceAfterHeader() {
+        assertRendering("|Abc|Def| \n|---|---|\n|1|2|", "<table>\n" +
+                "<thead>\n" +
+                "<tr>\n" +
+                "<th>Abc</th>\n" +
+                "<th>Def</th>\n" +
+                "</tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr>\n" +
+                "<td>1</td>\n" +
+                "<td>2</td>\n" +
+                "</tr>\n" +
+                "</tbody>\n" +
+                "</table>\n");
+    }
+
+    @Test
+    public void pipesOnOutsideZeroLengthHeaders() {
+        // This is literally what someone has done IRL - it helped to expose
+        // an issue with parsing the last header cell correctly
+        assertRendering("||center header||\n" +
+                        "-|-------------|-\n" +
+                        "1|      2      |3",
+                "<table>\n" +
+                "<thead>\n" +
+                "<tr>\n" +
+                "<th></th>\n" +
+                "<th>center header</th>\n" +
+                "<th></th>\n" +
+                "</tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr>\n" +
+                "<td>1</td>\n" +
+                "<td>2</td>\n" +
+                "<td>3</td>\n" +
+                "</tr>\n" +
+                "</tbody>\n" +
+                "</table>\n");
+    }
+
+    @Test
     public void inlineElements() {
         assertRendering("*Abc*|Def\n---|---\n1|2", "<table>\n" +
                 "<thead>\n" +


### PR DESCRIPTION
This is another table rendering issue introduced in 0.16.1. It's extremely obscure (found by running 0.18.0 against millions of markdown comments and comparing against 0.15.2) but I'm hoping the fix is simple enough that we can maintain compatibility with 0.15.2. 🤞 

It's probably easiest to look at the added test cases - note the space at the end of the header line in the first test. When the header row has leading/trailing pipes and the trailing pipe is followed by whitespace, the table fails to render. (Trailing whitespace on the separator line or content lines works fine; trailing whitespace when the header line doesn't have a trailing pipe also works fine)

[The 0.15.2 code would trim each line at the start of `split()`](https://github.com/commonmark/commonmark-java/blob/commonmark-parent-0.15.2/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java#L104). Without the trim, [`split()` adds the whitespace after the trailing pipe as another header cell](https://github.com/commonmark/commonmark-java/blob/commonmark-parent-0.18.0/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java#L155). As a result, [`tryStart` thinks there are more header cells than columns](https://github.com/commonmark/commonmark-java/blob/commonmark-parent-0.18.0/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java#L257) and stops trying to parse a table.

The current code [already removes any leading whitespace and any leading pipe](https://github.com/commonmark/commonmark-java/blob/commonmark-parent-0.18.0/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java#L125). If and only if there's a leading pipe, the fix does the same for the trailing pipe.