### PR TITLE
Check arg of enabledBlockTypes when building parser instead of NPE later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ with the exception that 0.x versions can break between minor versions.
 ### Added
 - YAML front matter extension: Limited support for single and double
   quoted string values (#260)
+### Changed
+- Check argument of `enabledBlockTypes` when building parser instead of NPEing later
 
 ## [0.18.2] - 2022-02-24
 ### Changed

--- a/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
@@ -98,6 +98,14 @@ public class DocumentParser implements ParserState {
         return list;
     }
 
+    public static void checkEnabledBlockTypes(Set<Class<? extends Block>> enabledBlockTypes) {
+        for (Class<? extends Block> enabledBlockType : enabledBlockTypes) {
+            if (!NODES_TO_CORE_FACTORIES.containsKey(enabledBlockType)) {
+                throw new IllegalArgumentException("Can't enable block type " + enabledBlockType + ", possible options are: " + NODES_TO_CORE_FACTORIES.keySet());
+            }
+        }
+    }
+
     /**
      * The main parsing function. Returns a parsed document AST.
      */

--- a/commonmark/src/main/java/org/commonmark/parser/Parser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/Parser.java
@@ -176,6 +176,7 @@ public class Parser {
             if (enabledBlockTypes == null) {
                 throw new NullPointerException("enabledBlockTypes must not be null");
             }
+            DocumentParser.checkEnabledBlockTypes(enabledBlockTypes);
             this.enabledBlockTypes = enabledBlockTypes;
             return this;
         }

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -11,10 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -73,6 +70,12 @@ public class ParserTest {
         parser = Parser.builder().enabledBlockTypes(noCoreTypes).build();
         document = parser.parse(given);
         assertThat(document.getFirstChild(), not(instanceOf(Heading.class)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void enabledBlockTypesThrowsWhenGivenUnknownClass() {
+        // BulletList can't be enabled separately at the moment, only all ListBlock types
+        Parser.builder().enabledBlockTypes(new HashSet<>(Arrays.asList(Heading.class, BulletList.class))).build();
     }
 
     @Test


### PR DESCRIPTION
Came up in #258, see https://github.com/commonmark/commonmark-java/issues/258#issuecomment-1143046809