### PR TITLE
Fix GFM table parser to handle dangling pipe correctly (fixes #255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## [Unreleased]
+### Fixed
+- A single pipe (optional whitespace) now ends a table instead of crashing or
+  being treated as an empty row, for consistency with GitHub (#255).
+
 ## [0.19.0] - 2022-06-02
 ### Added
 - YAML front matter extension: Limited support for single and double
@@ -362,6 +367,7 @@ Initial release of commonmark-java, a port of commonmark.js with extensions
 for autolinking URLs, GitHub flavored strikethrough and tables.
 
 
+[Unreleased]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.19.0...HEAD
 [0.19.0]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.18.2...commonmark-parent-0.19.0
 [0.18.2]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.18.1...commonmark-parent-0.18.2
 [0.18.1]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.18.0...commonmark-parent-0.18.1

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -261,21 +261,21 @@ public class TablesTest extends RenderingTestCase {
                         "-|-------------|-\n" +
                         "1|      2      |3",
                 "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th></th>\n" +
-                "<th>center header</th>\n" +
-                "<th></th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "<td>3</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+                        "<thead>\n" +
+                        "<tr>\n" +
+                        "<th></th>\n" +
+                        "<th>center header</th>\n" +
+                        "<th></th>\n" +
+                        "</tr>\n" +
+                        "</thead>\n" +
+                        "<tbody>\n" +
+                        "<tr>\n" +
+                        "<td>1</td>\n" +
+                        "<td>2</td>\n" +
+                        "<td>3</td>\n" +
+                        "</tr>\n" +
+                        "</tbody>\n" +
+                        "</table>\n");
     }
 
     @Test
@@ -665,6 +665,47 @@ public class TablesTest extends RenderingTestCase {
     }
 
     @Test
+    public void danglingPipe() {
+        assertRendering("Abc|Def\n" +
+                "---|---\n" +
+                "1|2\n" +
+                "|", "<table>\n" +
+                "<thead>\n" +
+                "<tr>\n" +
+                "<th>Abc</th>\n" +
+                "<th>Def</th>\n" +
+                "</tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr>\n" +
+                "<td>1</td>\n" +
+                "<td>2</td>\n" +
+                "</tr>\n" +
+                "</tbody>\n" +
+                "</table>\n" +
+                "<p>|</p>\n");
+
+        assertRendering("Abc|Def\n" +
+                "---|---\n" +
+                "1|2\n" +
+                "  |  ", "<table>\n" +
+                "<thead>\n" +
+                "<tr>\n" +
+                "<th>Abc</th>\n" +
+                "<th>Def</th>\n" +
+                "</tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr>\n" +
+                "<td>1</td>\n" +
+                "<td>2</td>\n" +
+                "</tr>\n" +
+                "</tbody>\n" +
+                "</table>\n" +
+                "<p>|</p>\n");
+    }
+
+    @Test
     public void attributeProviderIsApplied() {
         AttributeProviderFactory factory = new AttributeProviderFactory() {
             @Override
@@ -718,7 +759,7 @@ public class TablesTest extends RenderingTestCase {
 
         TableBlock block = (TableBlock) document.getFirstChild();
         assertEquals(Arrays.asList(SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 7),
-                SourceSpan.of(2, 0, 4), SourceSpan.of(3, 0, 8), SourceSpan.of(4, 0, 3)),
+                        SourceSpan.of(2, 0, 4), SourceSpan.of(3, 0, 8), SourceSpan.of(4, 0, 3)),
                 block.getSourceSpans());
 
         TableHead head = (TableHead) block.getFirstChild();


### PR DESCRIPTION
This input:

```
Abc|Def
---|---
1|2
|
```

Used to crash (`StringIndexOutOfBoundsException`, see issue) and after fixing the crash it would be treated as an empty table row. The behavior now matches GitHub, it terminates the table, see:

Abc|Def
---|---
1|2
|
