### PR TITLE
Adjust GFM strikethrough parsing (fixes #267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ with the exception that 0.x versions can break between minor versions.
 
 ## [Unreleased]
 ### Fixed
-- A single pipe (optional whitespace) now ends a table instead of crashing or
-  being treated as an empty row, for consistency with GitHub (#255).
+- GitHub tables: A single pipe (optional whitespace) now ends a table
+  instead of crashing or being treated as an empty row, for consistency
+  with GitHub (#255).
+- GitHub strikethrough: A single tilde now also works, and more than two
+  tildes are not accepted anymore. This brings us in line with what
+  GitHub actually does, which is a bit underspecified (#267)
 
 ## [0.19.0] - 2022-06-02
 ### Added

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
@@ -22,13 +22,13 @@ public class StrikethroughDelimiterProcessor implements DelimiterProcessor {
 
     @Override
     public int getMinLength() {
-        return 2;
+        return 1;
     }
 
     @Override
     public int process(DelimiterRun openingRun, DelimiterRun closingRun) {
-        if (openingRun.length() >= 2 && closingRun.length() >= 2) {
-            // Use exactly two delimiters even if we have more, and don't care about internal openers/closers.
+        if (openingRun.length() == closingRun.length() && openingRun.length() <= 2) {
+            // GitHub only accepts either one or two delimiters, but not a mix or more than that.
 
             Text opener = openingRun.getOpener();
 
@@ -36,19 +36,19 @@ public class StrikethroughDelimiterProcessor implements DelimiterProcessor {
             Node strikethrough = new Strikethrough();
 
             SourceSpans sourceSpans = new SourceSpans();
-            sourceSpans.addAllFrom(openingRun.getOpeners(2));
+            sourceSpans.addAllFrom(openingRun.getOpeners(openingRun.length()));
 
             for (Node node : Nodes.between(opener, closingRun.getCloser())) {
                 strikethrough.appendChild(node);
                 sourceSpans.addAll(node.getSourceSpans());
             }
 
-            sourceSpans.addAllFrom(closingRun.getClosers(2));
+            sourceSpans.addAllFrom(closingRun.getClosers(closingRun.length()));
             strikethrough.setSourceSpans(sourceSpans.getSourceSpans());
 
             opener.insertAfter(strikethrough);
 
-            return 2;
+            return openingRun.length();
         } else {
             return 0;
         }

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughSpecTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughSpecTest.java
@@ -1,4 +1,4 @@
-package org.commonmark.ext.gfm.tables;
+package org.commonmark.ext.gfm.strikethrough;
 
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
@@ -12,27 +12,26 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 @RunWith(Parameterized.class)
-public class TablesSpecTest extends RenderingTestCase {
+public class StrikethroughSpecTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(TablesExtension.create());
+    private static final Set<Extension> EXTENSIONS = Collections.singleton(StrikethroughExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
     private final Example example;
 
-    public TablesSpecTest(Example example) {
+    public StrikethroughSpecTest(Example example) {
         this.example = example;
     }
 
     @Parameters(name = "{0}")
     public static List<Object[]> data() {
-        return ExampleReader.readExampleObjects(TestResources.getGfmSpec(), "table");
+        return ExampleReader.readExampleObjects(TestResources.getGfmSpec(), "strikethrough");
     }
 
     @Test

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughTest.java
@@ -26,12 +26,12 @@ public class StrikethroughTest extends RenderingTestCase {
             .extensions(EXTENSIONS).build();
 
     @Test
-    public void oneTildeIsNotEnough() {
-        assertRendering("~foo~", "<p>~foo~</p>\n");
+    public void oneTildeIsEnough() {
+        assertRendering("~foo~", "<p><del>foo</del></p>\n");
     }
 
     @Test
-    public void twoTildesYay() {
+    public void twoTildesWorksToo() {
         assertRendering("~~foo~~", "<p><del>foo</del></p>\n");
     }
 
@@ -48,23 +48,22 @@ public class StrikethroughTest extends RenderingTestCase {
 
     @Test
     public void threeInnerThree() {
-        assertRendering("a ~~~foo~~~", "<p>a ~<del>foo</del>~</p>\n");
+        assertRendering("a ~~~foo~~~", "<p>a ~~~foo~~~</p>\n");
     }
 
     @Test
     public void twoInnerThree() {
-        assertRendering("~~foo~~~", "<p><del>foo</del>~</p>\n");
+        assertRendering("~~foo~~~", "<p>~~foo~~~</p>\n");
     }
 
     @Test
     public void tildesInside() {
         assertRendering("~~foo~bar~~", "<p><del>foo~bar</del></p>\n");
         assertRendering("~~foo~~bar~~", "<p><del>foo</del>bar~~</p>\n");
-        assertRendering("~~foo~~~bar~~", "<p><del>foo</del>~bar~~</p>\n");
-        assertRendering("~~foo~~~~bar~~", "<p><del>foo</del><del>bar</del></p>\n");
-        assertRendering("~~foo~~~~~bar~~", "<p><del>foo</del>~<del>bar</del></p>\n");
-        assertRendering("~~foo~~~~~~bar~~", "<p><del>foo</del>~~<del>bar</del></p>\n");
-        assertRendering("~~foo~~~~~~~bar~~", "<p><del>foo</del>~~~<del>bar</del></p>\n");
+        assertRendering("~~foo~~~bar~~", "<p><del>foo~~~bar</del></p>\n");
+        assertRendering("~~foo~~~~bar~~", "<p><del>foo~~~~bar</del></p>\n");
+        assertRendering("~~foo~~~~~bar~~", "<p><del>foo~~~~~bar</del></p>\n");
+        assertRendering("~~foo~~~~~~bar~~", "<p><del>foo~~~~~~bar</del></p>\n");
     }
 
     @Test

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
@@ -14,6 +14,10 @@ public class TestResources {
         return TestResources.class.getResource("/spec.txt");
     }
 
+    public static URL getGfmSpec() {
+        return TestResources.class.getResource("/gfm-spec.txt");
+    }
+
     public static List<URL> getRegressions() {
         return Arrays.asList(
                 TestResources.class.getResource("/cmark-regression.txt"),

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/example/ExampleReader.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/example/ExampleReader.java
@@ -42,6 +42,17 @@ public class ExampleReader {
         }
     }
 
+    public static List<Object[]> readExampleObjects(URL url, String info) {
+        List<Example> examples = readExamples(url);
+        List<Object[]> data = new ArrayList<>();
+        for (Example example : examples) {
+            if (example.getInfo().contains(info)) {
+                data.add(new Object[]{example});
+            }
+        }
+        return data;
+    }
+
     public static List<String> readExampleSources(URL url) {
         List<Example> examples = ExampleReader.readExamples(url);
         List<String> result = new ArrayList<>();

--- a/commonmark-test-util/src/main/resources/gfm-spec.txt
+++ b/commonmark-test-util/src/main/resources/gfm-spec.txt
@@ -2077,7 +2077,7 @@ followed by one of the strings (case-insensitive) `address`,
 `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `head`, `header`, `hr`,
 `html`, `iframe`, `legend`, `li`, `link`, `main`, `menu`, `menuitem`,
 `nav`, `noframes`, `ol`, `optgroup`, `option`, `p`, `param`,
-`section`, `source`, `summary`, `table`, `tbody`, `td`,
+`section`, `summary`, `table`, `tbody`, `td`,
 `tfoot`, `th`, `thead`, `title`, `tr`, `track`, `ul`, followed
 by [whitespace], the end of the line, the string `>`, or
 the string `/>`.\
@@ -10224,4 +10224,3 @@ closers:
 
 After we're done, we remove all delimiters above `stack_bottom` from the
 delimiter stack.
-

--- a/etc/update-spec.sh
+++ b/etc/update-spec.sh
@@ -7,7 +7,7 @@ fi
 
 version=$1
 curl -L "https://raw.githubusercontent.com/commonmark/commonmark-spec/$version/spec.txt" -o commonmark-test-util/src/main/resources/spec.txt
-curl -L "https://raw.githubusercontent.com/github/cmark-gfm/master/test/spec.txt" -o commonmark-ext-gfm-tables/src/test/resources/gfm-spec.txt
+curl -L "https://raw.githubusercontent.com/github/cmark-gfm/master/test/spec.txt" -o commonmark-test-util/src/main/resources/gfm-spec.txt
 
 echo "Check cmark and commonmark.js regression.txt:"
 echo "https://github.com/commonmark/cmark/blob/master/test/regression.txt"


### PR DESCRIPTION
We used to accept 2 or more tildes for strikethrough. But GitHub
actually accepts a single tilde as well, but rejects more than 2 tildes.
This brings our implementation more in line with GitHub's.