### PR TITLE
Add `requireTwoTildes` for `StrikethroughExtension` (fixes #271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## [Unreleased]
+### Added
+- GitHub strikethrough: With the previous version we adjusted the
+  extension to also accept the single tilde syntax. But if you use
+  another extension that uses the single tilde syntax, you will get a
+  conflict. To avoid that, `StrikethroughExtension` can now be
+  configured to require two tildes like before, see Javadoc.
+
 ## [0.20.0] - 2022-10-20
 ### Fixed
 - GitHub tables: A single pipe (optional whitespace) now ends a table
@@ -371,7 +379,7 @@ API breaking changes (caused by changes in spec):
 Initial release of commonmark-java, a port of commonmark.js with extensions
 for autolinking URLs, GitHub flavored strikethrough and tables.
 
-
+[Unreleased]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.20.0...HEAD
 [0.20.0]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.19.0...commonmark-parent-0.20.0
 [0.19.0]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.18.2...commonmark-parent-0.19.0
 [0.18.2]: https://github.com/commonmark/commonmark-java/compare/commonmark-parent-0.18.1...commonmark-parent-0.18.2

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
@@ -30,11 +30,13 @@ import org.commonmark.renderer.NodeRenderer;
  * <p>
  * If you have another extension that only uses a single tilde ({@code ~}) syntax, you will have to configure this
  * {@link StrikethroughExtension} to only accept the double tilde syntax, like this:
+ * </p>
  * <pre>
  *     {@code
  *     StrikethroughExtension.builder().requireTwoTildes(true).build();
  *     }
  * </pre>
+ * <p>
  * If you don't do that, there's a conflict between the two extensions and you will get an
  * {@link IllegalArgumentException} when constructing the parser.
  * </p>

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
@@ -14,29 +14,57 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.NodeRenderer;
 
 /**
- * Extension for GFM strikethrough using ~~ (GitHub Flavored Markdown).
+ * Extension for GFM strikethrough using {@code ~} or {@code ~~} (GitHub Flavored Markdown).
+ * <p>Example input:</p>
+ * <pre>{@code ~foo~ or ~~bar~~}</pre>
+ * <p>Example output (HTML):</p>
+ * <pre>{@code <del>foo</del> or <del>bar</del>}</pre>
  * <p>
- * Create it with {@link #create()} and then configure it on the builders
+ * Create the extension with {@link #create()} and then add it to the parser and renderer builders
  * ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)},
  * {@link HtmlRenderer.Builder#extensions(Iterable)}).
  * </p>
  * <p>
  * The parsed strikethrough text regions are turned into {@link Strikethrough} nodes.
  * </p>
+ * <p>
+ * If you have another extension that only uses a single tilde ({@code ~}) syntax, you will have to configure this
+ * {@link StrikethroughExtension} to only accept the double tilde syntax, like this:
+ * <pre>
+ *     {@code
+ *     StrikethroughExtension.builder().requireTwoTildes(true).build();
+ *     }
+ * </pre>
+ * If you don't do that, there's a conflict between the two extensions and you will get an
+ * {@link IllegalArgumentException} when constructing the parser.
+ * </p>
  */
 public class StrikethroughExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension,
         TextContentRenderer.TextContentRendererExtension {
 
-    private StrikethroughExtension() {
+    private final boolean requireTwoTildes;
+
+    private StrikethroughExtension(Builder builder) {
+        this.requireTwoTildes = builder.requireTwoTildes;
     }
 
+    /**
+     * @return the extension with default options
+     */
     public static Extension create() {
-        return new StrikethroughExtension();
+        return builder().build();
+    }
+
+    /**
+     * @return a builder to configure the behavior of the extension
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
     public void extend(Parser.Builder parserBuilder) {
-        parserBuilder.customDelimiterProcessor(new StrikethroughDelimiterProcessor());
+        parserBuilder.customDelimiterProcessor(new StrikethroughDelimiterProcessor(requireTwoTildes));
     }
 
     @Override
@@ -57,5 +85,27 @@ public class StrikethroughExtension implements Parser.ParserExtension, HtmlRende
                 return new StrikethroughTextContentNodeRenderer(context);
             }
         });
+    }
+
+    public static class Builder {
+
+        private boolean requireTwoTildes = false;
+
+        /**
+         * @param requireTwoTildes Whether two tilde characters ({@code ~~}) are required for strikethrough or whether
+         * one is also enough. Default is {@code false}; both a single tilde and two tildes can be used for strikethrough.
+         * @return {@code this}
+         */
+        public Builder requireTwoTildes(boolean requireTwoTildes) {
+            this.requireTwoTildes = requireTwoTildes;
+            return this;
+        }
+
+        /**
+         * @return a configured extension
+         */
+        public Extension build() {
+            return new StrikethroughExtension(this);
+        }
     }
 }

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
@@ -10,6 +10,16 @@ import org.commonmark.parser.delimiter.DelimiterRun;
 
 public class StrikethroughDelimiterProcessor implements DelimiterProcessor {
 
+    private final boolean requireTwoTildes;
+
+    public StrikethroughDelimiterProcessor() {
+        this(false);
+    }
+
+    public StrikethroughDelimiterProcessor(boolean requireTwoTildes) {
+        this.requireTwoTildes = requireTwoTildes;
+    }
+
     @Override
     public char getOpeningCharacter() {
         return '~';
@@ -22,7 +32,7 @@ public class StrikethroughDelimiterProcessor implements DelimiterProcessor {
 
     @Override
     public int getMinLength() {
-        return 1;
+        return requireTwoTildes ? 2 : 1;
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/internal/StaggeredDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/StaggeredDelimiterProcessor.java
@@ -51,7 +51,7 @@ class StaggeredDelimiterProcessor implements DelimiterProcessor {
                 added = true;
                 break;
             } else if (len == pLen) {
-                throw new IllegalArgumentException("Cannot add two delimiter processors for char '" + delim + "' and minimum length " + len);
+                throw new IllegalArgumentException("Cannot add two delimiter processors for char '" + delim + "' and minimum length " + len + "; conflicting processors: " + p + ", " + dp);
             }
         }
         if (!added) {

--- a/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
@@ -60,7 +60,7 @@ public class DelimiterProcessorTest extends RenderingTestCase {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void multipleDelimitersWithSameLength() {
+    public void multipleDelimitersWithSameLengthConflict() {
         Parser.builder()
                 .customDelimiterProcessor(new OneDelimiterProcessor())
                 .customDelimiterProcessor(new OneDelimiterProcessor())


### PR DESCRIPTION
With the previous version we adjusted the extension to also accept the single tilde syntax. But if you use another extension that uses the single tilde syntax, you will get a conflict, see issue.

To avoid that, `StrikethroughExtension` can now be configured to require two tildes like before, see Javadoc.