### PR TITLE
Add support for auto-detecting video content (#277)

### DIFF
--- a/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
@@ -254,6 +254,24 @@ public class HtmlRendererTest {
     }
 
     @Test
+    public void videoTagAutoDetectMp4() {
+        assertEquals("<p><video controls=\"\"><source src=\"/url.mp4\" />text</video></p>\n",
+                defaultRenderer().render(parse("![text](/url.mp4)")));
+    }
+
+    @Test
+    public void videoTagAutoDetectWebm() {
+        assertEquals("<p><video controls=\"\"><source src=\"/url.webm\" />text</video></p>\n",
+                defaultRenderer().render(parse("![text](/url.webm)")));
+    }
+
+    @Test
+    public void videoTagAutoDetectIsCaseInsensitive() {
+        assertEquals("<p><video controls=\"\"><source src=\"/url.Mp4\" />text</video></p>\n",
+                defaultRenderer().render(parse("![text](/url.Mp4)")));
+    }
+
+    @Test
     public void canRenderContentsOfSingleParagraph() {
         Node paragraphs = parse("Here I have a test [link](http://www.google.com)");
         Node paragraph = paragraphs.getFirstChild();


### PR DESCRIPTION
Here's a first cut at auto-detecting video content. Let me know what you think of this approach.

If the attached file has an `mp4` or `webm` extension, we'll generate a `<video>` tag instead of an `img` tag. The tests are probably the best demonstration of that.

Right now, this is not configurable or overridable. I will try to use image attributes so that `{type=image}` or `{type=video}` forces the tag type but my best solution so far feels pretty hacky... (`AttributeProvider.setAttributes` wants to extend attributes and know the tag name... but I don't have the attributes to extend or know the tag name because I need `type` to know that - Ignoring those problems, the solution works, it just feels dirty)