### PR TITLE
Fix #287 - Eating of whitespace at start of line

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
@@ -411,10 +411,8 @@ public class DocumentParser implements ParserState {
             }
             sb.append(rest);
             content = sb.toString();
-        } else if (index == 0) {
-            content = line.getContent();
         } else {
-            content = line.getContent().subSequence(index, line.getContent().length());
+            content = line.getContent();
         }
         SourceSpan sourceSpan = null;
         if (includeSourceSpans == IncludeSourceSpans.BLOCKS_AND_INLINES) {


### PR DESCRIPTION
In addLine() we return the substring "Foo()" when it should be "  Foo()".

This patch removes taking the substring and instead returns the line as is.

The prior if branch ([here](https://github.com/theIDinside/commonmark-java/commit/4fecb26a68a279bed6c60ab62274de8cd3fc16c4#diff-9c1169707cc7d5ce9e51b82bf59c5bef0eaa5dfd8ceb611d45334ee70391cdf5R403-R413)) seem to suggest that this _is_ the expected behavior since it converts tabs to spaces, yet does not remove those.