### PR TITLE
Keep leading spaces in paragraphs when there's a list

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
@@ -237,7 +237,9 @@ public class DocumentParser implements ParserState {
 
             BlockStartImpl blockStart = findBlockStart(blockParser);
             if (blockStart == null) {
-                setNewIndex(nextNonSpace);
+                if (!blockParserFactories.isEmpty()) {
+                    setNewIndex(nextNonSpace);
+                }
                 break;
             }
 

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -100,6 +100,35 @@ public class ParserTest {
     }
 
     @Test
+    public void indentationInParagraph() {
+        String given = " - 1 space\n   - 3 spaces\n     - 5 spaces\n\t - tab + space";
+        Parser parser = Parser.builder()
+                .enabledBlockTypes(new HashSet<Class<? extends Block>>())
+                .build();
+        Node document = parser.parse(given);
+
+        assertThat(document.getFirstChild(), instanceOf(Paragraph.class));
+
+        Node list = document.getFirstChild();
+        Node firstChild = list.getFirstChild(); // first item
+        assertEquals(" - 1 space", firstText(firstChild));
+
+        Node secondChild = firstChild.getNext(); // second item
+        assertThat(secondChild, instanceOf(SoftLineBreak.class));
+        assertEquals("   - 3 spaces", firstText(secondChild.getNext()));
+
+        Node fourthChild = secondChild.getNext().getNext();
+        assertThat(fourthChild, instanceOf(SoftLineBreak.class));
+        
+        assertEquals("     - 5 spaces", firstText(fourthChild.getNext()));
+
+        Node sixthChild = fourthChild.getNext().getNext();
+        assertThat(sixthChild, instanceOf(SoftLineBreak.class));
+        
+        assertEquals("\t - tab + space", firstText(sixthChild.getNext()));
+    }
+    
+    @Test
     public void inlineParser() {
         final InlineParser fakeInlineParser = new InlineParser() {
             @Override


### PR DESCRIPTION
When there are no `blockParserFactories`, leading spaces should be preserved. Here's a use case:

### Input
```
- one
  - two
```

When this is parsed with a Parser without any `enabledBlockTypes`, before this PR, it results in this:

```
- one
- two
```

But it should preserve the list hierarchy with the leading whitespace.