### PR TITLE
add column width to TableCell nodes

### DIFF
--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableCell.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableCell.java
@@ -9,6 +9,7 @@ public class TableCell extends CustomNode {
 
     private boolean header;
     private Alignment alignment;
+    private int width;
 
     /**
      * @return whether the cell is a header or not
@@ -30,6 +31,17 @@ public class TableCell extends CustomNode {
 
     public void setAlignment(Alignment alignment) {
         this.alignment = alignment;
+    }
+
+    /**
+     * @return the cell width
+     */
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
     }
 
     /**

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -750,6 +750,42 @@ public class TablesTest extends RenderingTestCase {
     }
 
     @Test
+    public void columnWidthIsRecorded() {
+        AttributeProviderFactory factory = new AttributeProviderFactory() {
+            @Override
+            public AttributeProvider create(AttributeProviderContext context) {
+                return new AttributeProvider() {
+                    @Override
+                    public void setAttributes(Node node, String tagName, Map<String, String> attributes) {
+                        if (node instanceof TableCell && "th".equals(tagName)) {
+                            attributes.put("width", ((TableCell) node).getWidth() + "em");
+                        }
+                    }
+                };
+            }
+        };
+        HtmlRenderer renderer = HtmlRenderer.builder()
+                .attributeProviderFactory(factory)
+                .extensions(EXTENSIONS)
+                .build();
+        String rendered = renderer.render(PARSER.parse("Abc|Def\n-----|---\n1|2"));
+        assertThat(rendered, is("<table>\n" +
+                "<thead>\n" +
+                "<tr>\n" +
+                "<th width=\"5em\">Abc</th>\n" +
+                "<th width=\"3em\">Def</th>\n" +
+                "</tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr>\n" +
+                "<td>1</td>\n" +
+                "<td>2</td>\n" +
+                "</tr>\n" +
+                "</tbody>\n" +
+                "</table>\n"));
+    }
+
+    @Test
     public void sourceSpans() {
         Parser parser = Parser.builder()
                 .extensions(EXTENSIONS)


### PR DESCRIPTION
Adds an extra property for column with to `TableCell` nodes.

The width is determined by the number of dash and colon characters in the separator line of a table, and passed on to the consumer as an integer. This permits consumers of the AST to render tables that are more proportional the width in the source markdown.

No changes have been made to the HTML render to make use of the width information, but the test for this feature demonstrates a possible usage.

Should a cell be be created that is further to the right than the parsed separator columns are (i.e., when alignment would be null), then the width will be reported as 0.