### PR TITLE
Make SpecTestCase not extend RenderingTestCase

### DIFF
--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/SourceSpanIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/SourceSpanIntegrationTest.java
@@ -5,7 +5,7 @@ import org.commonmark.parser.Parser;
 import org.commonmark.testutil.example.Example;
 
 /**
- * Spec and all extensions, with source spans enabed.
+ * Spec and all extensions, with source spans enabled.
  */
 public class SourceSpanIntegrationTest extends SpecIntegrationTest {
 

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
@@ -12,9 +12,12 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.parser.Parser;
 import org.commonmark.testutil.example.Example;
 import org.commonmark.testutil.SpecTestCase;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.*;
+
+import static org.commonmark.testutil.Asserts.assertRendering;
 
 /**
  * Tests that the spec examples still render the same with all extensions enabled.
@@ -39,17 +42,15 @@ public class SpecIntegrationTest extends SpecTestCase {
     }
 
     @Test
-    @Override
     public void testHtmlRendering() {
         String expectedHtml = OVERRIDDEN_EXAMPLES.get(example.getSource());
         if (expectedHtml != null) {
-            assertRendering(example.getSource(), expectedHtml);
+            assertRendering(example.getSource(), expectedHtml, render(example.getSource()));
         } else {
-            super.testHtmlRendering();
+            assertRendering(example.getSource(), example.getHtml(), render(example.getSource()));
         }
     }
 
-    @Override
     protected String render(String source) {
         return RENDERER.render(PARSER.parse(source));
     }

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/Asserts.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/Asserts.java
@@ -1,0 +1,17 @@
+package org.commonmark.testutil;
+
+import static org.junit.Assert.assertEquals;
+
+public class Asserts {
+    public static void assertRendering(String source, String expectedRendering, String actualRendering) {
+        // include source for better assertion errors
+        String expected = showTabs(expectedRendering + "\n\n" + source);
+        String actual = showTabs(actualRendering + "\n\n" + source);
+        assertEquals(expected, actual);
+    }
+
+    private static String showTabs(String s) {
+        // Tabs are shown as "rightwards arrow" for easier comparison
+        return s.replace("\t", "\u2192");
+    }
+}

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/RenderingTestCase.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/RenderingTestCase.java
@@ -1,22 +1,10 @@
 package org.commonmark.testutil;
 
-import static org.junit.Assert.assertEquals;
-
 public abstract class RenderingTestCase {
 
     protected abstract String render(String source);
 
     protected void assertRendering(String source, String expectedResult) {
-        String renderedContent = render(source);
-
-        // include source for better assertion errors
-        String expected = showTabs(expectedResult + "\n\n" + source);
-        String actual = showTabs(renderedContent + "\n\n" + source);
-        assertEquals(expected, actual);
-    }
-
-    private static String showTabs(String s) {
-        // Tabs are shown as "rightwards arrow" for easier comparison
-        return s.replace("\t", "\u2192");
+        Asserts.assertRendering(source, expectedResult, render(source));
     }
 }

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/SpecTestCase.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/SpecTestCase.java
@@ -10,8 +10,10 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.commonmark.testutil.Asserts.assertRendering;
+
 @RunWith(Parameterized.class)
-public abstract class SpecTestCase extends RenderingTestCase {
+public abstract class SpecTestCase {
 
     protected final Example example;
 
@@ -27,11 +29,6 @@ public abstract class SpecTestCase extends RenderingTestCase {
             data.add(new Object[]{example});
         }
         return data;
-    }
-
-    @Test
-    public void testHtmlRendering() {
-        assertRendering(example.getSource(), example.getHtml());
     }
 
 }

--- a/commonmark/src/test/java/org/commonmark/test/SpecCoreTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecCoreTest.java
@@ -9,6 +9,7 @@ import org.commonmark.testutil.SpecTestCase;
 import org.commonmark.testutil.example.Example;
 import org.junit.Test;
 
+import static org.commonmark.testutil.Asserts.assertRendering;
 import static org.junit.Assert.fail;
 
 public class SpecCoreTest extends SpecTestCase {
@@ -49,8 +50,12 @@ public class SpecCoreTest extends SpecTestCase {
         });
     }
 
-    @Override
-    protected String render(String source) {
+    @Test
+    public void testHtmlRendering() {
+        assertRendering(example.getSource(), example.getHtml(), render(example.getSource()));
+    }
+
+    private String render(String source) {
         return RENDERER.render(PARSER.parse(source));
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/SpecCrLfCoreTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecCrLfCoreTest.java
@@ -4,6 +4,9 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.SpecTestCase;
 import org.commonmark.testutil.example.Example;
+import org.junit.Test;
+
+import static org.commonmark.testutil.Asserts.assertRendering;
 
 /**
  * Same as {@link SpecCoreTest} but converts line endings to Windows-style CR+LF endings before parsing.
@@ -18,8 +21,12 @@ public class SpecCrLfCoreTest extends SpecTestCase {
         super(example);
     }
 
-    @Override
-    protected String render(String source) {
+    @Test
+    public void testHtmlRendering() {
+        assertRendering(example.getSource(), example.getHtml(), render(example.getSource()));
+    }
+
+    private String render(String source) {
         String windowsStyle = source.replace("\n", "\r\n");
         return RENDERER.render(PARSER.parse(windowsStyle));
     }


### PR DESCRIPTION
That allows it to be used outside of HTML rendering test cases. With JUnit 5, it might not even need to be a base class anymore.