### PR TITLE
Add renderer producing Markdown (CommonMark)

### DIFF
--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/Strikethrough.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/Strikethrough.java
@@ -4,19 +4,23 @@ import org.commonmark.node.CustomNode;
 import org.commonmark.node.Delimited;
 
 /**
- * A strikethrough node containing text and other inline nodes nodes as children.
+ * A strikethrough node containing text and other inline nodes as children.
  */
 public class Strikethrough extends CustomNode implements Delimited {
 
-    private static final String DELIMITER = "~~";
+    private String delimiter;
+
+    public Strikethrough(String delimiter) {
+        this.delimiter = delimiter;
+    }
 
     @Override
     public String getOpeningDelimiter() {
-        return DELIMITER;
+        return delimiter;
     }
 
     @Override
     public String getClosingDelimiter() {
-        return DELIMITER;
+        return delimiter;
     }
 }

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
@@ -17,6 +17,9 @@ import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentNodeRendererFactory;
 import org.commonmark.renderer.text.TextContentRenderer;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Extension for GFM strikethrough using {@code ~} or {@code ~~} (GitHub Flavored Markdown).
  * <p>Example input:</p>
@@ -99,6 +102,11 @@ public class StrikethroughExtension implements Parser.ParserExtension, HtmlRende
             @Override
             public NodeRenderer create(MarkdownNodeRendererContext context) {
                 return new StrikethroughMarkdownNodeRenderer(context);
+            }
+
+            @Override
+            public Set<Character> getSpecialCharacters() {
+                return Collections.singleton('~');
             }
         });
     }

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
@@ -1,17 +1,21 @@
 package org.commonmark.ext.gfm.strikethrough;
 
 import org.commonmark.Extension;
-import org.commonmark.renderer.text.TextContentRenderer;
-import org.commonmark.renderer.text.TextContentNodeRendererContext;
-import org.commonmark.renderer.text.TextContentNodeRendererFactory;
 import org.commonmark.ext.gfm.strikethrough.internal.StrikethroughDelimiterProcessor;
 import org.commonmark.ext.gfm.strikethrough.internal.StrikethroughHtmlNodeRenderer;
+import org.commonmark.ext.gfm.strikethrough.internal.StrikethroughMarkdownNodeRenderer;
 import org.commonmark.ext.gfm.strikethrough.internal.StrikethroughTextContentNodeRenderer;
-import org.commonmark.renderer.html.HtmlRenderer;
-import org.commonmark.renderer.html.HtmlNodeRendererContext;
-import org.commonmark.renderer.html.HtmlNodeRendererFactory;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.html.HtmlNodeRendererContext;
+import org.commonmark.renderer.html.HtmlNodeRendererFactory;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
+import org.commonmark.renderer.text.TextContentNodeRendererContext;
+import org.commonmark.renderer.text.TextContentNodeRendererFactory;
+import org.commonmark.renderer.text.TextContentRenderer;
 
 /**
  * Extension for GFM strikethrough using {@code ~} or {@code ~~} (GitHub Flavored Markdown).
@@ -42,7 +46,7 @@ import org.commonmark.renderer.NodeRenderer;
  * </p>
  */
 public class StrikethroughExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension,
-        TextContentRenderer.TextContentRendererExtension {
+        TextContentRenderer.TextContentRendererExtension, MarkdownRenderer.MarkdownRendererExtension {
 
     private final boolean requireTwoTildes;
 
@@ -89,13 +93,23 @@ public class StrikethroughExtension implements Parser.ParserExtension, HtmlRende
         });
     }
 
+    @Override
+    public void extend(MarkdownRenderer.Builder rendererBuilder) {
+        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
+            @Override
+            public NodeRenderer create(MarkdownNodeRendererContext context) {
+                return new StrikethroughMarkdownNodeRenderer(context);
+            }
+        });
+    }
+
     public static class Builder {
 
         private boolean requireTwoTildes = false;
 
         /**
          * @param requireTwoTildes Whether two tilde characters ({@code ~~}) are required for strikethrough or whether
-         * one is also enough. Default is {@code false}; both a single tilde and two tildes can be used for strikethrough.
+         *                         one is also enough. Default is {@code false}; both a single tilde and two tildes can be used for strikethrough.
          * @return {@code this}
          */
         public Builder requireTwoTildes(boolean requireTwoTildes) {

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
@@ -43,7 +43,8 @@ public class StrikethroughDelimiterProcessor implements DelimiterProcessor {
             Text opener = openingRun.getOpener();
 
             // Wrap nodes between delimiters in strikethrough.
-            Node strikethrough = new Strikethrough();
+            String delimiter = openingRun.length() == 1 ? opener.getLiteral() : opener.getLiteral() + opener.getLiteral();
+            Node strikethrough = new Strikethrough(delimiter);
 
             SourceSpans sourceSpans = new SourceSpans();
             sourceSpans.addAllFrom(openingRun.getOpeners(openingRun.length()));

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughMarkdownNodeRenderer.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughMarkdownNodeRenderer.java
@@ -1,0 +1,34 @@
+package org.commonmark.ext.gfm.strikethrough.internal;
+
+import org.commonmark.ext.gfm.strikethrough.Strikethrough;
+import org.commonmark.node.Node;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
+import org.commonmark.renderer.markdown.MarkdownWriter;
+
+public class StrikethroughMarkdownNodeRenderer extends StrikethroughNodeRenderer {
+
+    private final MarkdownNodeRendererContext context;
+    private final MarkdownWriter writer;
+
+    public StrikethroughMarkdownNodeRenderer(MarkdownNodeRendererContext context) {
+        this.context = context;
+        this.writer = context.getWriter();
+    }
+
+    @Override
+    public void render(Node node) {
+        Strikethrough strikethrough = (Strikethrough) node;
+        writer.raw(strikethrough.getOpeningDelimiter());
+        renderChildren(node);
+        writer.raw(strikethrough.getClosingDelimiter());
+    }
+
+    private void renderChildren(Node parent) {
+        Node node = parent.getFirstChild();
+        while (node != null) {
+            Node next = node.getNext();
+            context.render(node);
+            node = next;
+        }
+    }
+}

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughMarkdownRendererTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughMarkdownRendererTest.java
@@ -1,0 +1,36 @@
+package org.commonmark.ext.gfm.strikethrough;
+
+import org.commonmark.Extension;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class StrikethroughMarkdownRendererTest {
+
+    private static final Set<Extension> EXTENSIONS = Collections.singleton(StrikethroughExtension.create());
+    private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+
+    @Test
+    public void testStrikethrough() {
+        assertRoundTrip("~foo~ ~bar~\n");
+        assertRoundTrip("~~f~oo~~ ~~bar~~\n");
+
+        // TODO this new special character needs to be escaped:
+//        assertRoundTrip("\\~foo\\~\n");
+    }
+
+    protected String render(String source) {
+        return RENDERER.render(PARSER.parse(source));
+    }
+
+    private void assertRoundTrip(String input) {
+        String rendered = render(input);
+        assertEquals(input, rendered);
+    }
+}

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughMarkdownRendererTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughMarkdownRendererTest.java
@@ -19,10 +19,10 @@ public class StrikethroughMarkdownRendererTest {
     @Test
     public void testStrikethrough() {
         assertRoundTrip("~foo~ ~bar~\n");
-        assertRoundTrip("~~f~oo~~ ~~bar~~\n");
+        assertRoundTrip("~~foo~~ ~~bar~~\n");
+        assertRoundTrip("~~f\\~oo~~ ~~bar~~\n");
 
-        // TODO this new special character needs to be escaped:
-//        assertRoundTrip("\\~foo\\~\n");
+        assertRoundTrip("\\~foo\\~\n");
     }
 
     protected String render(String source) {

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableCell.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableCell.java
@@ -22,7 +22,7 @@ public class TableCell extends CustomNode {
     }
 
     /**
-     * @return the cell alignment
+     * @return the cell alignment or {@code null} if no specific alignment
      */
     public Alignment getAlignment() {
         return alignment;

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
@@ -78,7 +78,7 @@ public class TablesExtension implements Parser.ParserExtension, HtmlRenderer.Htm
 
             @Override
             public Set<Character> getSpecialCharacters() {
-                return Collections.emptySet();
+                return Collections.singleton('|');
             }
         });
     }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
@@ -17,6 +17,9 @@ import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentNodeRendererFactory;
 import org.commonmark.renderer.text.TextContentRenderer;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Extension for GFM tables using "|" pipes (GitHub Flavored Markdown).
  * <p>
@@ -71,6 +74,11 @@ public class TablesExtension implements Parser.ParserExtension, HtmlRenderer.Htm
             @Override
             public NodeRenderer create(MarkdownNodeRendererContext context) {
                 return new TableMarkdownNodeRenderer(context);
+            }
+
+            @Override
+            public Set<Character> getSpecialCharacters() {
+                return Collections.emptySet();
             }
         });
     }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
@@ -3,12 +3,16 @@ package org.commonmark.ext.gfm.tables;
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.tables.internal.TableBlockParser;
 import org.commonmark.ext.gfm.tables.internal.TableHtmlNodeRenderer;
+import org.commonmark.ext.gfm.tables.internal.TableMarkdownNodeRenderer;
 import org.commonmark.ext.gfm.tables.internal.TableTextContentNodeRenderer;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlNodeRendererFactory;
 import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentNodeRendererFactory;
 import org.commonmark.renderer.text.TextContentRenderer;
@@ -27,7 +31,7 @@ import org.commonmark.renderer.text.TextContentRenderer;
  * @see <a href="https://github.github.com/gfm/#tables-extension-">Tables (extension) in GitHub Flavored Markdown Spec</a>
  */
 public class TablesExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension,
-        TextContentRenderer.TextContentRendererExtension {
+        TextContentRenderer.TextContentRendererExtension, MarkdownRenderer.MarkdownRendererExtension {
 
     private TablesExtension() {
     }
@@ -57,6 +61,16 @@ public class TablesExtension implements Parser.ParserExtension, HtmlRenderer.Htm
             @Override
             public NodeRenderer create(TextContentNodeRendererContext context) {
                 return new TableTextContentNodeRenderer(context);
+            }
+        });
+    }
+
+    @Override
+    public void extend(MarkdownRenderer.Builder rendererBuilder) {
+        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
+            @Override
+            public NodeRenderer create(MarkdownNodeRendererContext context) {
+                return new TableMarkdownNodeRenderer(context);
             }
         });
     }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableMarkdownNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableMarkdownNodeRenderer.java
@@ -1,0 +1,96 @@
+package org.commonmark.ext.gfm.tables.internal;
+
+import org.commonmark.ext.gfm.tables.*;
+import org.commonmark.internal.util.AsciiMatcher;
+import org.commonmark.internal.util.CharMatcher;
+import org.commonmark.node.Node;
+import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
+import org.commonmark.renderer.markdown.MarkdownWriter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The Table node renderer that is needed for rendering GFM tables (GitHub Flavored Markdown) to text content.
+ */
+public class TableMarkdownNodeRenderer extends TableNodeRenderer implements NodeRenderer {
+    private final MarkdownWriter writer;
+    private final MarkdownNodeRendererContext context;
+
+    private final CharMatcher pipe = AsciiMatcher.builder().c('|').build();
+
+    private final List<TableCell.Alignment> columns = new ArrayList<>();
+
+    public TableMarkdownNodeRenderer(MarkdownNodeRendererContext context) {
+        this.writer = context.getWriter();
+        this.context = context;
+    }
+
+    @Override
+    protected void renderBlock(TableBlock node) {
+        columns.clear();
+        renderChildren(node);
+        writer.block();
+    }
+
+    @Override
+    protected void renderHead(TableHead node) {
+        renderChildren(node);
+        // TODO: Not sure about this.. Should block() detect if a line was already written? Or should line() itself be lazy?
+        writer.line();
+        for (TableCell.Alignment columnAlignment : columns) {
+            writer.raw('|');
+            if (columnAlignment == TableCell.Alignment.LEFT) {
+                writer.raw(":---");
+            } else if (columnAlignment == TableCell.Alignment.RIGHT) {
+                writer.raw("---:");
+            } else if (columnAlignment == TableCell.Alignment.CENTER) {
+                writer.raw(":---:");
+            } else {
+                writer.raw("---");
+            }
+        }
+        writer.raw("|");
+        // TODO
+        if (node.getNext() != null) {
+            writer.line();
+        }
+    }
+
+    @Override
+    protected void renderBody(TableBody node) {
+        renderChildren(node);
+    }
+
+    @Override
+    protected void renderRow(TableRow node) {
+        renderChildren(node);
+        // Trailing | at the end of the line
+        writer.raw("|");
+        // TODO
+        if (node.getNext() != null) {
+            writer.line();
+        }
+    }
+
+    @Override
+    protected void renderCell(TableCell node) {
+        if (node.getParent() != null && node.getParent().getParent() instanceof TableHead) {
+            columns.add(node.getAlignment());
+        }
+        writer.raw("|");
+        writer.pushRawEscape(pipe);
+        renderChildren(node);
+        writer.popRawEscape();
+    }
+
+    private void renderChildren(Node parent) {
+        Node node = parent.getFirstChild();
+        while (node != null) {
+            Node next = node.getNext();
+            context.render(node);
+            node = next;
+        }
+    }
+}

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableMarkdownNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableMarkdownNodeRenderer.java
@@ -30,15 +30,15 @@ public class TableMarkdownNodeRenderer extends TableNodeRenderer implements Node
     @Override
     protected void renderBlock(TableBlock node) {
         columns.clear();
+        writer.pushTight(true);
         renderChildren(node);
+        writer.popTight();
         writer.block();
     }
 
     @Override
     protected void renderHead(TableHead node) {
         renderChildren(node);
-        // TODO: Not sure about this.. Should block() detect if a line was already written? Or should line() itself be lazy?
-        writer.line();
         for (TableCell.Alignment columnAlignment : columns) {
             writer.raw('|');
             if (columnAlignment == TableCell.Alignment.LEFT) {
@@ -52,10 +52,7 @@ public class TableMarkdownNodeRenderer extends TableNodeRenderer implements Node
             }
         }
         writer.raw("|");
-        // TODO
-        if (node.getNext() != null) {
-            writer.line();
-        }
+        writer.block();
     }
 
     @Override
@@ -68,10 +65,7 @@ public class TableMarkdownNodeRenderer extends TableNodeRenderer implements Node
         renderChildren(node);
         // Trailing | at the end of the line
         writer.raw("|");
-        // TODO
-        if (node.getNext() != null) {
-            writer.line();
-        }
+        writer.block();
     }
 
     @Override

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TableMarkdownRendererTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TableMarkdownRendererTest.java
@@ -59,6 +59,12 @@ public class TableMarkdownRendererTest {
         assertRoundTrip("|Abc|Def|\n|---|---|\n|Inline HTML|<span>Foo\\|bar</span>|\n");
     }
 
+    @Test
+    public void testEscaped() {
+        // `|` in Text nodes needs to be escaped, otherwise the generated Markdown does not get parsed back as a table
+        assertRoundTrip("\\|Abc\\|\n\\|---\\|\n");
+    }
+
     protected String render(String source) {
         return RENDERER.render(PARSER.parse(source));
     }

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TableMarkdownRendererTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TableMarkdownRendererTest.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
-public class TablesMarkdownRenderingTest {
+public class TableMarkdownRendererTest {
 
     private static final Set<Extension> EXTENSIONS = Collections.singleton(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesMarkdownRenderingTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesMarkdownRenderingTest.java
@@ -1,0 +1,70 @@
+package org.commonmark.ext.gfm.tables;
+
+import org.commonmark.Extension;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class TablesMarkdownRenderingTest {
+
+    private static final Set<Extension> EXTENSIONS = Collections.singleton(TablesExtension.create());
+    private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+
+    @Test
+    public void testHeadNoBody() {
+        assertRoundTrip("|Abc|\n|---|\n");
+        assertRoundTrip("|Abc|Def|\n|---|---|\n");
+        assertRoundTrip("|Abc||\n|---|---|\n");
+    }
+
+    @Test
+    public void testHeadAndBody() {
+        assertRoundTrip("|Abc|\n|---|\n|1|\n");
+        assertRoundTrip("|Abc|Def|\n|---|---|\n|1|2|\n");
+    }
+
+    @Test
+    public void testBodyHasFewerColumns() {
+        // Could try not to write empty trailing cells but this is fine too
+        assertRoundTrip("|Abc|Def|\n|---|---|\n|1||\n");
+    }
+
+    @Test
+    public void testAlignment() {
+        assertRoundTrip("|Abc|Def|\n|:---|---|\n|1|2|\n");
+        assertRoundTrip("|Abc|Def|\n|---|---:|\n|1|2|\n");
+        assertRoundTrip("|Abc|Def|\n|:---:|:---:|\n|1|2|\n");
+    }
+
+    @Test
+    public void testInsideBlockQuote() {
+        assertRoundTrip("> |Abc|Def|\n> |---|---|\n> |1|2|\n");
+    }
+
+    @Test
+    public void testMultipleTables() {
+        assertRoundTrip("|Abc|Def|\n|---|---|\n\n|One|\n|---|\n|Only|\n");
+    }
+
+    @Test
+    public void testEscaping() {
+        assertRoundTrip("|Abc|Def|\n|---|---|\n|Pipe in|text \\||\n");
+        assertRoundTrip("|Abc|Def|\n|---|---|\n|Pipe in|code `\\|`|\n");
+        assertRoundTrip("|Abc|Def|\n|---|---|\n|Inline HTML|<span>Foo\\|bar</span>|\n");
+    }
+
+    protected String render(String source) {
+        return RENDERER.render(PARSER.parse(source));
+    }
+
+    private void assertRoundTrip(String input) {
+        String rendered = render(input);
+        assertEquals(input, rendered);
+    }
+}

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/InsExtension.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/InsExtension.java
@@ -3,15 +3,22 @@ package org.commonmark.ext.ins;
 import org.commonmark.Extension;
 import org.commonmark.ext.ins.internal.InsDelimiterProcessor;
 import org.commonmark.ext.ins.internal.InsHtmlNodeRenderer;
+import org.commonmark.ext.ins.internal.InsMarkdownNodeRenderer;
 import org.commonmark.ext.ins.internal.InsTextContentNodeRenderer;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlNodeRendererFactory;
 import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentNodeRendererFactory;
 import org.commonmark.renderer.text.TextContentRenderer;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Extension for ins using ++
@@ -24,9 +31,7 @@ import org.commonmark.renderer.text.TextContentRenderer;
  * The parsed ins text regions are turned into {@link Ins} nodes.
  * </p>
  */
-public class InsExtension implements Parser.ParserExtension,
-        HtmlRenderer.HtmlRendererExtension,
-        TextContentRenderer.TextContentRendererExtension {
+public class InsExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension, TextContentRenderer.TextContentRendererExtension, MarkdownRenderer.MarkdownRendererExtension {
 
     private InsExtension() {
     }
@@ -56,6 +61,23 @@ public class InsExtension implements Parser.ParserExtension,
             @Override
             public NodeRenderer create(TextContentNodeRendererContext context) {
                 return new InsTextContentNodeRenderer(context);
+            }
+        });
+    }
+
+    @Override
+    public void extend(MarkdownRenderer.Builder rendererBuilder) {
+        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
+            @Override
+            public NodeRenderer create(MarkdownNodeRendererContext context) {
+                return new InsMarkdownNodeRenderer(context);
+            }
+
+            @Override
+            public Set<Character> getSpecialCharacters() {
+                // We technically don't need to escape single occurrences of +, but that's all the extension API
+                // exposes currently.
+                return Collections.singleton('+');
             }
         });
     }

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsMarkdownNodeRenderer.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsMarkdownNodeRenderer.java
@@ -1,0 +1,32 @@
+package org.commonmark.ext.ins.internal;
+
+import org.commonmark.node.Node;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
+import org.commonmark.renderer.markdown.MarkdownWriter;
+
+public class InsMarkdownNodeRenderer extends InsNodeRenderer {
+
+    private final MarkdownNodeRendererContext context;
+    private final MarkdownWriter writer;
+
+    public InsMarkdownNodeRenderer(MarkdownNodeRendererContext context) {
+        this.context = context;
+        this.writer = context.getWriter();
+    }
+
+    @Override
+    public void render(Node node) {
+        writer.raw("++");
+        renderChildren(node);
+        writer.raw("++");
+    }
+
+    private void renderChildren(Node parent) {
+        Node node = parent.getFirstChild();
+        while (node != null) {
+            Node next = node.getNext();
+            context.render(node);
+            node = next;
+        }
+    }
+}

--- a/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsMarkdownRendererTest.java
+++ b/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsMarkdownRendererTest.java
@@ -1,0 +1,34 @@
+package org.commonmark.ext.ins;
+
+import org.commonmark.Extension;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class InsMarkdownRendererTest {
+
+    private static final Set<Extension> EXTENSIONS = Collections.singleton(InsExtension.create());
+    private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+
+    @Test
+    public void testStrikethrough() {
+        assertRoundTrip("++foo++\n");
+
+        assertRoundTrip("\\+\\+foo\\+\\+\n");
+    }
+
+    protected String render(String source) {
+        return RENDERER.render(PARSER.parse(source));
+    }
+
+    private void assertRoundTrip(String input) {
+        String rendered = render(input);
+        assertEquals(input, rendered);
+    }
+}

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/MarkdownRendererIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/MarkdownRendererIntegrationTest.java
@@ -1,0 +1,46 @@
+package org.commonmark.integration;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.autolink.AutolinkExtension;
+import org.commonmark.ext.front.matter.YamlFrontMatterExtension;
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.ext.image.attributes.ImageAttributesExtension;
+import org.commonmark.ext.ins.InsExtension;
+import org.commonmark.ext.task.list.items.TaskListItemsExtension;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class MarkdownRendererIntegrationTest {
+
+    private static final List<Extension> EXTENSIONS = Arrays.asList(
+            AutolinkExtension.create(),
+            ImageAttributesExtension.create(),
+            InsExtension.create(),
+            StrikethroughExtension.create(),
+            TablesExtension.create(),
+            TaskListItemsExtension.create(),
+            YamlFrontMatterExtension.create());
+    private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+
+    @Test
+    public void testStrikethroughInTable() {
+        assertRoundTrip("|Abc|\n|---|\n|~strikethrough~|\n|\\~escaped\\~|\n");
+    }
+
+    private String render(String source) {
+        return RENDERER.render(PARSER.parse(source));
+    }
+
+    private void assertRoundTrip(String input) {
+        String rendered = render(input);
+        assertEquals(input, rendered);
+    }
+}

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/example/Example.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/example/Example.java
@@ -30,6 +30,10 @@ public class Example {
         return html;
     }
 
+    public String getSection() {
+        return section;
+    }
+
     @Override
     public String toString() {
         return "File \"" + filename + "\" section \"" + section + "\" example " + exampleNumber;

--- a/commonmark/src/main/java/org/commonmark/internal/util/AsciiMatcher.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/AsciiMatcher.java
@@ -22,6 +22,10 @@ public class AsciiMatcher implements CharMatcher {
         return new Builder(new BitSet());
     }
 
+    public static Builder builder(AsciiMatcher matcher) {
+        return new Builder((BitSet) matcher.set.clone());
+    }
+
     public static class Builder {
         private final BitSet set;
 

--- a/commonmark/src/main/java/org/commonmark/internal/util/AsciiMatcher.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/AsciiMatcher.java
@@ -1,6 +1,7 @@
 package org.commonmark.internal.util;
 
 import java.util.BitSet;
+import java.util.Set;
 
 public class AsciiMatcher implements CharMatcher {
     private final BitSet set;
@@ -33,6 +34,14 @@ public class AsciiMatcher implements CharMatcher {
             this.set = set;
         }
 
+        public Builder c(char c) {
+            if (c > 127) {
+                throw new IllegalArgumentException("Can only match ASCII characters");
+            }
+            set.set(c);
+            return this;
+        }
+
         public Builder anyOf(String s) {
             for (int i = 0; i < s.length(); i++) {
                 c(s.charAt(i));
@@ -40,11 +49,10 @@ public class AsciiMatcher implements CharMatcher {
             return this;
         }
 
-        public Builder c(char c) {
-            if (c > 127) {
-                throw new IllegalArgumentException("Can only match ASCII characters");
+        public Builder anyOf(Set<Character> characters) {
+            for (Character c : characters) {
+                c(c);
             }
-            set.set(c);
             return this;
         }
 

--- a/commonmark/src/main/java/org/commonmark/internal/util/AsciiMatcher.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/AsciiMatcher.java
@@ -29,6 +29,13 @@ public class AsciiMatcher implements CharMatcher {
             this.set = set;
         }
 
+        public Builder anyOf(String s) {
+            for (int i = 0; i < s.length(); i++) {
+                c(s.charAt(i));
+            }
+            return this;
+        }
+
         public Builder c(char c) {
             if (c > 127) {
                 throw new IllegalArgumentException("Can only match ASCII characters");

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -88,7 +88,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(BlockQuote blockQuote) {
-        writer.write("> ");
+        writer.writePrefix("> ");
         writer.pushPrefix("> ");
         visitChildren(blockQuote);
         writer.popPrefix();
@@ -124,16 +124,16 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         if (listHolder instanceof BulletListHolder) {
             BulletListHolder bulletListHolder = (BulletListHolder) listHolder;
             String marker = repeat(" ", listItem.getMarkerIndent()) + bulletListHolder.bulletMarker;
-            writer.write(marker);
-            writer.write(repeat(" ", contentIndent - marker.length()));
+            writer.writePrefix(marker);
+            writer.writePrefix(repeat(" ", contentIndent - marker.length()));
             writer.pushPrefix(repeat(" ", contentIndent));
             pushedPrefix = true;
         } else if (listHolder instanceof OrderedListHolder) {
             OrderedListHolder orderedListHolder = (OrderedListHolder) listHolder;
             String marker = repeat(" ", listItem.getMarkerIndent()) + orderedListHolder.number + orderedListHolder.delimiter;
             orderedListHolder.number++;
-            writer.write(marker);
-            writer.write(repeat(" ", contentIndent - marker.length()));
+            writer.writePrefix(marker);
+            writer.writePrefix(repeat(" ", contentIndent - marker.length()));
             writer.pushPrefix(repeat(" ", contentIndent));
             pushedPrefix = true;
         }
@@ -190,7 +190,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
         if (indent > 0) {
             String indentPrefix = repeat(" ", indent);
-            writer.write(indentPrefix);
+            writer.writePrefix(indentPrefix);
             writer.pushPrefix(indentPrefix);
         }
 
@@ -286,7 +286,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         String literal = indentedCodeBlock.getLiteral();
         // We need to respect line prefixes which is why we need to write it line by line (e.g. an indented code block
         // within a block quote)
-        writer.write("    ");
+        writer.writePrefix("    ");
         writer.pushPrefix("    ");
         List<String> lines = getLines(literal);
         for (int i = 0; i < lines.size(); i++) {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -142,10 +142,12 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             writer.write(fencedCodeBlock.getInfo());
         }
         writer.line();
-        String[] lines = literal.split("\n");
-        for (String line : lines) {
-            writer.write(line);
-            writer.line();
+        if (!literal.isEmpty()) {
+            String[] lines = literal.split("\n");
+            for (String line : lines) {
+                writer.write(line);
+                writer.line();
+            }
         }
         writer.write(fence);
         if (indent > 0) {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -364,6 +364,17 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
                         writer.write("\\" + m.group(2));
                         literal = literal.substring(m.end());
                     }
+                    break;
+                }
+                case '\t': {
+                    writer.write("&#9;");
+                    literal = literal.substring(1);
+                    break;
+                }
+                case ' ': {
+                    writer.write("&#32;");
+                    literal = literal.substring(1);
+                    break;
                 }
             }
         }

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -65,10 +65,16 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
     public void visit(Document document) {
         // No rendering itself
         visitChildren(document);
+        writer.line();
     }
 
     @Override
     public void visit(BlockQuote blockQuote) {
+        writer.write("> ");
+        writer.pushPrefix("> ");
+        visitChildren(blockQuote);
+        writer.popPrefix();
+        writer.block();
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -24,6 +24,8 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     private final AsciiMatcher textEscape =
             AsciiMatcher.builder().anyOf("[]<>`*&").build();
+    private final CharMatcher textEscapeInHeading =
+            AsciiMatcher.builder(textEscape).anyOf("#").build();
     private final CharMatcher linkDestinationNeedsAngleBrackets =
             AsciiMatcher.builder().c(' ').c('(').c(')').c('<').c('>').c('\\').build();
     private final CharMatcher linkDestinationEscapeInAngleBrackets =
@@ -366,11 +368,13 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             }
         }
 
+        CharMatcher escape = text.getParent() instanceof Heading ? textEscapeInHeading : textEscape;
+
         if (literal.endsWith("!") && text.getNext() instanceof Link) {
-            writer.writeEscaped(literal.substring(0, literal.length() - 1), textEscape);
+            writer.writeEscaped(literal.substring(0, literal.length() - 1), escape);
             writer.write("\\!");
         } else {
-            writer.writeEscaped(literal, textEscape);
+            writer.writeEscaped(literal, escape);
         }
     }
 

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -103,6 +103,8 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(HardLineBreak hardLineBreak) {
+        writer.write("  ");
+        writer.line();
     }
 
     @Override
@@ -157,6 +159,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(SoftLineBreak softLineBreak) {
+        writer.line();
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -205,23 +205,21 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(BulletList bulletList) {
-        boolean oldTight = writer.getTight();
-        writer.setTight(bulletList.isTight());
+        writer.pushTight(bulletList.isTight());
         listHolder = new BulletListHolder(listHolder, bulletList);
         visitChildren(bulletList);
         listHolder = listHolder.parent;
-        writer.setTight(oldTight);
+        writer.popTight();
         writer.block();
     }
 
     @Override
     public void visit(OrderedList orderedList) {
-        boolean oldTight = writer.getTight();
-        writer.setTight(orderedList.isTight());
+        writer.pushTight(orderedList.isTight());
         listHolder = new OrderedListHolder(listHolder, orderedList);
         visitChildren(orderedList);
         listHolder = listHolder.parent;
-        writer.setTight(oldTight);
+        writer.popTight();
         writer.block();
     }
 

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -15,6 +15,8 @@ import java.util.Set;
  */
 public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRenderer {
 
+    private final CharMatcher textEscape =
+            AsciiMatcher.builder().c('[').c(']').c('<').c('>').c('`').build();
     private final CharMatcher linkDestinationNeedsAngleBrackets =
             AsciiMatcher.builder().c(' ').c('(').c(')').c('<').c('>').c('\\').build();
     private final CharMatcher linkDestinationEscapeInAngleBrackets =
@@ -268,7 +270,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(Text text) {
-        writeText(text.getLiteral());
+        writer.writeEscaped(text.getLiteral(), textEscape);
     }
 
     @Override
@@ -311,10 +313,6 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             sb.append(s);
         }
         return sb.toString();
-    }
-
-    private void writeText(String text) {
-        writer.write(text);
     }
 
     private void writeLinkLike(String title, String destination, Node node, String opener) {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -88,7 +88,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(ThematicBreak thematicBreak) {
-        writer.write("***");
+        writer.raw("***");
         writer.block();
     }
 
@@ -106,9 +106,9 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
                 if (heading.getLevel() == 1) {
                     // Note that it would be nice to match the length of the contents instead of just using 3, but that's
                     // not easy.
-                    writer.write("===");
+                    writer.raw("===");
                 } else {
-                    writer.write("---");
+                    writer.raw("---");
                 }
                 writer.block();
                 return;
@@ -117,9 +117,9 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
         // ATX headings: Can't have multiple lines, but up to level 6.
         for (int i = 0; i < heading.getLevel(); i++) {
-            writer.write('#');
+            writer.raw('#');
         }
-        writer.write(' ');
+        writer.raw(' ');
         visitChildren(heading);
 
         writer.block();
@@ -135,7 +135,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         List<String> lines = getLines(literal);
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i);
-            writer.write(line);
+            writer.raw(line);
             if (i != lines.size() - 1) {
                 writer.line();
             }
@@ -156,19 +156,19 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             writer.pushPrefix(indentPrefix);
         }
 
-        writer.write(fence);
+        writer.raw(fence);
         if (fencedCodeBlock.getInfo() != null) {
-            writer.write(fencedCodeBlock.getInfo());
+            writer.raw(fencedCodeBlock.getInfo());
         }
         writer.line();
         if (!literal.isEmpty()) {
             List<String> lines = getLines(literal);
             for (String line : lines) {
-                writer.write(line);
+                writer.raw(line);
                 writer.line();
             }
         }
-        writer.write(fence);
+        writer.raw(fence);
         if (indent > 0) {
             writer.popPrefix();
         }
@@ -180,7 +180,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         List<String> lines = getLines(htmlBlock.getLiteral());
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i);
-            writer.write(line);
+            writer.raw(line);
             if (i != lines.size() - 1) {
                 writer.line();
             }
@@ -262,7 +262,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         // If the literal includes backticks, we can surround them by using one more backtick.
         int backticks = findMaxRunLength('`', literal);
         for (int i = 0; i < backticks + 1; i++) {
-            writer.write('`');
+            writer.raw('`');
         }
         // If the literal starts or ends with a backtick, surround it with a single space.
         // If it starts and ends with a space (but is not only spaces), add an additional space (otherwise they would
@@ -270,14 +270,14 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         boolean addSpace = literal.startsWith("`") || literal.endsWith("`") ||
                 (literal.startsWith(" ") && literal.endsWith(" ") && Parsing.hasNonSpace(literal));
         if (addSpace) {
-            writer.write(' ');
+            writer.raw(' ');
         }
-        writer.write(literal);
+        writer.raw(literal);
         if (addSpace) {
-            writer.write(' ');
+            writer.raw(' ');
         }
         for (int i = 0; i < backticks + 1; i++) {
-            writer.write('`');
+            writer.raw('`');
         }
     }
 
@@ -285,16 +285,16 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
     public void visit(Emphasis emphasis) {
         // When emphasis is nested, a different delimiter needs to be used
         char delimiter = writer.getLastChar() == '*' ? '_' : '*';
-        writer.write(delimiter);
+        writer.raw(delimiter);
         super.visit(emphasis);
-        writer.write(delimiter);
+        writer.raw(delimiter);
     }
 
     @Override
     public void visit(StrongEmphasis strongEmphasis) {
-        writer.write("**");
+        writer.raw("**");
         super.visit(strongEmphasis);
-        writer.write("**");
+        writer.raw("**");
     }
 
     @Override
@@ -309,12 +309,12 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(HtmlInline htmlInline) {
-        writer.write(htmlInline.getLiteral());
+        writer.raw(htmlInline.getLiteral());
     }
 
     @Override
     public void visit(HardLineBreak hardLineBreak) {
-        writer.write("  ");
+        writer.raw("  ");
         writer.line();
     }
 
@@ -339,19 +339,19 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             switch (c) {
                 case '-': {
                     // Would be ambiguous with a bullet list marker, escape
-                    writer.write("\\-");
+                    writer.raw("\\-");
                     literal = literal.substring(1);
                     break;
                 }
                 case '#': {
                     // Would be ambiguous with an ATX heading, escape
-                    writer.write("\\#");
+                    writer.raw("\\#");
                     literal = literal.substring(1);
                     break;
                 }
                 case '=': {
                     // Would be ambiguous with a Setext heading, escape
-                    writer.write("\\=");
+                    writer.raw("\\=");
                     literal = literal.substring(1);
                     break;
                 }
@@ -368,19 +368,19 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
                     // Check for ordered list marker
                     Matcher m = orderedListMarkerPattern.matcher(literal);
                     if (m.find()) {
-                        writer.write(m.group(1));
-                        writer.write("\\" + m.group(2));
+                        writer.raw(m.group(1));
+                        writer.raw("\\" + m.group(2));
                         literal = literal.substring(m.end());
                     }
                     break;
                 }
                 case '\t': {
-                    writer.write("&#9;");
+                    writer.raw("&#9;");
                     literal = literal.substring(1);
                     break;
                 }
                 case ' ': {
-                    writer.write("&#32;");
+                    writer.raw("&#32;");
                     literal = literal.substring(1);
                     break;
                 }
@@ -391,10 +391,10 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
         if (literal.endsWith("!") && text.getNext() instanceof Link) {
             // If we wrote the `!` unescaped, it would turn the link into an image instead.
-            writer.writeEscaped(literal.substring(0, literal.length() - 1), escape);
-            writer.write("\\!");
+            writer.text(literal.substring(0, literal.length() - 1), escape);
+            writer.raw("\\!");
         } else {
-            writer.writeEscaped(literal, escape);
+            writer.text(literal, escape);
         }
     }
 
@@ -455,24 +455,24 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
     }
 
     private void writeLinkLike(String title, String destination, Node node, String opener) {
-        writer.write(opener);
+        writer.raw(opener);
         visitChildren(node);
-        writer.write(']');
-        writer.write('(');
+        writer.raw(']');
+        writer.raw('(');
         if (contains(destination, linkDestinationNeedsAngleBrackets)) {
-            writer.write('<');
-            writer.writeEscaped(destination, linkDestinationEscapeInAngleBrackets);
-            writer.write('>');
+            writer.raw('<');
+            writer.text(destination, linkDestinationEscapeInAngleBrackets);
+            writer.raw('>');
         } else {
-            writer.write(destination);
+            writer.raw(destination);
         }
         if (title != null) {
-            writer.write(' ');
-            writer.write('"');
-            writer.writeEscaped(title, linkTitleEscapeInQuotes);
-            writer.write('"');
+            writer.raw(' ');
+            writer.raw('"');
+            writer.text(title, linkTitleEscapeInQuotes);
+            writer.raw('"');
         }
-        writer.write(')');
+        writer.raw(')');
     }
 
     private static class ListHolder {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -1,0 +1,152 @@
+package org.commonmark.renderer.markdown;
+
+import org.commonmark.node.*;
+import org.commonmark.renderer.NodeRenderer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The node renderer that renders all the core nodes (comes last in the order of node renderers).
+ */
+public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRenderer {
+
+    protected final MarkdownNodeRendererContext context;
+    private final MarkdownWriter writer;
+
+    public CoreMarkdownNodeRenderer(MarkdownNodeRendererContext context) {
+        this.context = context;
+        this.writer = context.getWriter();
+    }
+
+    @Override
+    public Set<Class<? extends Node>> getNodeTypes() {
+        return new HashSet<>(Arrays.asList(
+                Document.class,
+                Heading.class,
+                Paragraph.class,
+                BlockQuote.class,
+                BulletList.class,
+                FencedCodeBlock.class,
+                HtmlBlock.class,
+                ThematicBreak.class,
+                IndentedCodeBlock.class,
+                Link.class,
+                ListItem.class,
+                OrderedList.class,
+                Image.class,
+                Emphasis.class,
+                StrongEmphasis.class,
+                Text.class,
+                Code.class,
+                HtmlInline.class,
+                SoftLineBreak.class,
+                HardLineBreak.class
+        ));
+    }
+
+    @Override
+    public void render(Node node) {
+        node.accept(this);
+    }
+
+    @Override
+    public void visit(Document document) {
+        // No rendering itself
+        visitChildren(document);
+    }
+
+    @Override
+    public void visit(BlockQuote blockQuote) {
+    }
+
+    @Override
+    public void visit(BulletList bulletList) {
+    }
+
+    @Override
+    public void visit(Code code) {
+    }
+
+    @Override
+    public void visit(FencedCodeBlock fencedCodeBlock) {
+    }
+
+    @Override
+    public void visit(HardLineBreak hardLineBreak) {
+    }
+
+    @Override
+    public void visit(Heading heading) {
+        for (int i = 0; i < heading.getLevel(); i++) {
+            writer.write('#');
+        }
+        writer.write(' ');
+        visitChildren(heading);
+        writer.block();
+    }
+
+    @Override
+    public void visit(ThematicBreak thematicBreak) {
+        writer.write("***");
+        writer.block();
+    }
+
+    @Override
+    public void visit(HtmlInline htmlInline) {
+    }
+
+    @Override
+    public void visit(HtmlBlock htmlBlock) {
+    }
+
+    @Override
+    public void visit(Image image) {
+    }
+
+    @Override
+    public void visit(IndentedCodeBlock indentedCodeBlock) {
+    }
+
+    @Override
+    public void visit(Link link) {
+    }
+
+    @Override
+    public void visit(ListItem listItem) {
+    }
+
+    @Override
+    public void visit(OrderedList orderedList) {
+    }
+
+    @Override
+    public void visit(Paragraph paragraph) {
+        visitChildren(paragraph);
+        writer.block();
+    }
+
+    @Override
+    public void visit(SoftLineBreak softLineBreak) {
+    }
+
+    @Override
+    public void visit(Text text) {
+        writeText(text.getLiteral());
+    }
+
+    @Override
+    protected void visitChildren(Node parent) {
+        Node node = parent.getFirstChild();
+        while (node != null) {
+            Node next = node.getNext();
+            context.render(node);
+            node = next;
+        }
+    }
+
+    private void writeText(String text) {
+        writer.write(text);
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -45,7 +45,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         this.context = context;
         this.writer = context.getWriter();
 
-        textEscape = AsciiMatcher.builder().anyOf("[]<>`*&\n\\").anyOf(context.getSpecialCharacters()).build();
+        textEscape = AsciiMatcher.builder().anyOf("[]<>`*_&\n\\").anyOf(context.getSpecialCharacters()).build();
         textEscapeInHeading = AsciiMatcher.builder(textEscape).anyOf("#").build();
     }
 
@@ -282,8 +282,12 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(Emphasis emphasis) {
-        // When emphasis is nested, a different delimiter needs to be used
-        char delimiter = writer.getLastChar() == '*' ? '_' : '*';
+        String delimiter = emphasis.getOpeningDelimiter();
+        // Use delimiter that was parsed if available
+        if (delimiter == null) {
+            // When emphasis is nested, a different delimiter needs to be used
+            delimiter = writer.getLastChar() == '*' ? "_" : "*";
+        }
         writer.raw(delimiter);
         super.visit(emphasis);
         writer.raw(delimiter);

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -89,6 +89,15 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
     }
 
     @Override
+    public void visit(Emphasis emphasis) {
+        // When emphasis is nested, a different delimiter needs to be used
+        char delimiter = writer.getLastChar() == '*' ? '_' : '*';
+        writer.write(delimiter);
+        super.visit(emphasis);
+        writer.write(delimiter);
+    }
+
+    @Override
     public void visit(FencedCodeBlock fencedCodeBlock) {
     }
 
@@ -148,6 +157,13 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(SoftLineBreak softLineBreak) {
+    }
+
+    @Override
+    public void visit(StrongEmphasis strongEmphasis) {
+        writer.write("**");
+        super.visit(strongEmphasis);
+        writer.write("**");
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -259,7 +259,14 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(HtmlBlock htmlBlock) {
-        writer.write(htmlBlock.getLiteral());
+        List<String> lines = getLines(htmlBlock.getLiteral());
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
+            writer.write(line);
+            if (i != lines.size() - 1) {
+                writer.line();
+            }
+        }
         writer.block();
     }
 

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -134,10 +134,13 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(HtmlInline htmlInline) {
+        writer.write(htmlInline.getLiteral());
     }
 
     @Override
     public void visit(HtmlBlock htmlBlock) {
+        writer.write(htmlBlock.getLiteral());
+        writer.block();
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -89,7 +89,8 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(ThematicBreak thematicBreak) {
-        writer.raw("***");
+        // Let's use ___ as it doesn't introduce ambiguity with * or - list item markers
+        writer.raw("___");
         writer.block();
     }
 

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -22,10 +22,8 @@ import java.util.regex.Pattern;
  */
 public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRenderer {
 
-    private final AsciiMatcher textEscape =
-            AsciiMatcher.builder().anyOf("[]<>`*&\n\\").build();
-    private final CharMatcher textEscapeInHeading =
-            AsciiMatcher.builder(textEscape).anyOf("#").build();
+    private final AsciiMatcher textEscape;
+    private final CharMatcher textEscapeInHeading;
     private final CharMatcher linkDestinationNeedsAngleBrackets =
             AsciiMatcher.builder().c(' ').c('(').c(')').c('<').c('>').c('\n').c('\\').build();
     private final CharMatcher linkDestinationEscapeInAngleBrackets =
@@ -46,6 +44,9 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
     public CoreMarkdownNodeRenderer(MarkdownNodeRendererContext context) {
         this.context = context;
         this.writer = context.getWriter();
+
+        textEscape = AsciiMatcher.builder().anyOf("[]<>`*&\n\\").anyOf(context.getSpecialCharacters()).build();
+        textEscapeInHeading = AsciiMatcher.builder(textEscape).anyOf("#").build();
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -114,6 +114,32 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(FencedCodeBlock fencedCodeBlock) {
+        String literal = fencedCodeBlock.getLiteral();
+        String fence = repeat(String.valueOf(fencedCodeBlock.getFenceChar()), fencedCodeBlock.getFenceLength());
+        int indent = fencedCodeBlock.getFenceIndent();
+
+        if (indent > 0) {
+            String indentPrefix = repeat(" ", indent);
+            writer.write(indentPrefix);
+            writer.pushPrefix(indentPrefix);
+        }
+
+        writer.write(fence);
+        if (fencedCodeBlock.getInfo() != null) {
+            writer.write(fencedCodeBlock.getInfo());
+        }
+        writer.line();
+        String[] lines = literal.split("\n");
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            writer.write(line);
+            writer.line();
+        }
+        writer.write(fence);
+        if (indent > 0) {
+            writer.popPrefix();
+        }
+        writer.block();
     }
 
     @Override
@@ -160,8 +186,8 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         String[] lines = literal.split("\n");
         // We need to respect line prefixes which is why we need to write it line by line (e.g. an indented code block
         // within a block quote)
-        writer.pushPrefix("    ");
         writer.write("    ");
+        writer.pushPrefix("    ");
         for (int i = 0; i < lines.length; i++) {
             String line = lines[i];
             writer.write(line);
@@ -241,6 +267,14 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             }
         }
         return false;
+    }
+
+    private static String repeat(String s, int count) {
+        StringBuilder sb = new StringBuilder(s.length() * count);
+        for (int i = 0; i < count; i++) {
+            sb.append(s);
+        }
+        return sb.toString();
     }
 
     private void writeText(String text) {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -223,19 +223,22 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(ListItem listItem) {
+        int contentIndent = listItem.getContentIndent();
         boolean pushedPrefix = false;
         if (listHolder instanceof BulletListHolder) {
             BulletListHolder bulletListHolder = (BulletListHolder) listHolder;
-            String prefix = bulletListHolder.bulletMarker + " ";
-            writer.write(prefix);
-            writer.pushPrefix(repeat(" ", prefix.length()));
+            String marker = repeat(" ", listItem.getMarkerIndent()) + bulletListHolder.bulletMarker;
+            writer.write(marker);
+            writer.write(repeat(" ", contentIndent - marker.length()));
+            writer.pushPrefix(repeat(" ", contentIndent));
             pushedPrefix = true;
         } else if (listHolder instanceof OrderedListHolder) {
             OrderedListHolder orderedListHolder = (OrderedListHolder) listHolder;
-            String prefix = String.valueOf(orderedListHolder.number) + orderedListHolder.delimiter + " ";
+            String marker = repeat(" ", listItem.getMarkerIndent()) + orderedListHolder.number + orderedListHolder.delimiter;
             orderedListHolder.number++;
-            writer.write(prefix);
-            writer.pushPrefix(repeat(" ", prefix.length()));
+            writer.write(marker);
+            writer.write(repeat(" ", contentIndent - marker.length()));
+            writer.pushPrefix(repeat(" ", contentIndent));
             pushedPrefix = true;
         }
         visitChildren(listItem);

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -23,15 +23,15 @@ import java.util.regex.Pattern;
 public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRenderer {
 
     private final AsciiMatcher textEscape =
-            AsciiMatcher.builder().anyOf("[]<>`*&").build();
+            AsciiMatcher.builder().anyOf("[]<>`*&\n\\").build();
     private final CharMatcher textEscapeInHeading =
             AsciiMatcher.builder(textEscape).anyOf("#").build();
     private final CharMatcher linkDestinationNeedsAngleBrackets =
-            AsciiMatcher.builder().c(' ').c('(').c(')').c('<').c('>').c('\\').build();
+            AsciiMatcher.builder().c(' ').c('(').c(')').c('<').c('>').c('\n').c('\\').build();
     private final CharMatcher linkDestinationEscapeInAngleBrackets =
-            AsciiMatcher.builder().c('<').c('>').build();
+            AsciiMatcher.builder().c('<').c('>').c('\n').c('\\').build();
     private final CharMatcher linkTitleEscapeInQuotes =
-            AsciiMatcher.builder().c('"').build();
+            AsciiMatcher.builder().c('"').c('\n').c('\\').build();
 
     private final Pattern orderedListMarkerPattern = Pattern.compile("^([0-9]{1,9})([.)])");
 

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -86,9 +86,12 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(BulletList bulletList) {
+        boolean oldTight = writer.getTight();
+        writer.setTight(bulletList.isTight());
         listHolder = new BulletListHolder(listHolder, bulletList);
         visitChildren(bulletList);
         listHolder = listHolder.parent;
+        writer.setTight(oldTight);
     }
 
     @Override
@@ -243,9 +246,12 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(OrderedList orderedList) {
+        boolean oldTight = writer.getTight();
+        writer.setTight(orderedList.isTight());
         listHolder = new OrderedListHolder(listHolder, orderedList);
         visitChildren(orderedList);
         listHolder = listHolder.parent;
+        writer.setTight(oldTight);
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -156,6 +156,21 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(IndentedCodeBlock indentedCodeBlock) {
+        String literal = indentedCodeBlock.getLiteral();
+        String[] lines = literal.split("\n");
+        // We need to respect line prefixes which is why we need to write it line by line (e.g. an indented code block
+        // within a block quote)
+        writer.pushPrefix("    ");
+        writer.write("    ");
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            writer.write(line);
+            if (i != lines.length - 1) {
+                writer.line();
+            }
+        }
+        writer.popPrefix();
+        writer.block();
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -98,7 +98,10 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             writer.write('`');
         }
         // If the literal starts or ends with a backtick, surround it with a single space.
-        boolean addSpace = literal.startsWith("`") || literal.endsWith("`");
+        // If it starts and ends with a space (but is not only spaces), add an additional space (otherwise they would
+        // get removed on parsing).
+        boolean addSpace = literal.startsWith("`") || literal.endsWith("`") ||
+                (literal.startsWith(" ") && literal.endsWith(" ") && Parsing.hasNonSpace(literal));
         if (addSpace) {
             writer.write(' ');
         }

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -241,7 +241,12 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             writer.pushPrefix(repeat(" ", contentIndent));
             pushedPrefix = true;
         }
-        visitChildren(listItem);
+        if (listItem.getFirstChild() == null) {
+            // Empty list item
+            writer.block();
+        } else {
+            visitChildren(listItem);
+        }
         if (pushedPrefix) {
             writer.popPrefix();
         }

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererContext.java
@@ -2,6 +2,8 @@ package org.commonmark.renderer.markdown;
 
 import org.commonmark.node.Node;
 
+import java.util.Set;
+
 public interface MarkdownNodeRendererContext {
 
     /**
@@ -16,4 +18,10 @@ public interface MarkdownNodeRendererContext {
      * @param node the node to render
      */
     void render(Node node);
+
+    /**
+     * @return additional special characters that need to be escaped if they occur in normal text; currently only ASCII
+     * characters are allowed
+     */
+    Set<Character> getSpecialCharacters();
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererContext.java
@@ -1,0 +1,19 @@
+package org.commonmark.renderer.markdown;
+
+import org.commonmark.node.Node;
+
+public interface MarkdownNodeRendererContext {
+
+    /**
+     * @return the writer to use
+     */
+    MarkdownWriter getWriter();
+
+    /**
+     * Render the specified node and its children using the configured renderers. This should be used to render child
+     * nodes; be careful not to pass the node that is being rendered, that would result in an endless loop.
+     *
+     * @param node the node to render
+     */
+    void render(Node node);
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererFactory.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererFactory.java
@@ -1,0 +1,17 @@
+package org.commonmark.renderer.markdown;
+
+import org.commonmark.renderer.NodeRenderer;
+
+/**
+ * Factory for instantiating new node renderers ƒor rendering.
+ */
+public interface MarkdownNodeRendererFactory {
+
+    /**
+     * Create a new node renderer for the specified rendering context.
+     *
+     * @param context the context for rendering (normally passed on to the node renderer)
+     * @return a node renderer
+     */
+    NodeRenderer create(MarkdownNodeRendererContext context);
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererFactory.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererFactory.java
@@ -2,6 +2,8 @@ package org.commonmark.renderer.markdown;
 
 import org.commonmark.renderer.NodeRenderer;
 
+import java.util.Set;
+
 /**
  * Factory for instantiating new node renderers ƒor rendering.
  */
@@ -14,4 +16,10 @@ public interface MarkdownNodeRendererFactory {
      * @return a node renderer
      */
     NodeRenderer create(MarkdownNodeRendererContext context);
+
+    /**
+     * @return the additional special characters that this factory would like to have escaped in normal text; currently
+     * only ASCII characters are allowed
+     */
+    Set<Character> getSpecialCharacters();
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
@@ -15,6 +15,8 @@ import java.util.List;
  * Note that it does not currently attempt to preserve the exact syntax of the original input Markdown (if any):
  * <ul>
  *     <li>Headings are always output as ATX headings for simplicity</li>
+ *     <li>Escaping might be over-eager, e.g. a plain {@code *} might be escaped
+ *     even though it doesn't need to be in that particular context</li>
  * </ul>
  */
 public class MarkdownRenderer implements Renderer {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
@@ -14,7 +14,7 @@ import java.util.List;
  * <p>
  * Note that it does not currently attempt to preserve the exact syntax of the original input Markdown (if any):
  * <ul>
- *     <li>Headings are always output as ATX headings for simplicity</li>
+ *     <li>Headings are output as ATX headings if possible (multi-line headings need Setext headings)</li>
  *     <li>Escaping might be over-eager, e.g. a plain {@code *} might be escaped
  *     even though it doesn't need to be in that particular context</li>
  * </ul>

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
@@ -1,0 +1,134 @@
+package org.commonmark.renderer.markdown;
+
+import org.commonmark.Extension;
+import org.commonmark.internal.renderer.NodeRendererMap;
+import org.commonmark.node.Node;
+import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.Renderer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Renders nodes to CommonMark Markdown.
+ * <p>
+ * Note that it does not currently attempt to preserve the exact syntax of the original input Markdown (if any):
+ * <ul>
+ *     <li>Headings are always output as ATX headings for simplicity</li>
+ * </ul>
+ */
+public class MarkdownRenderer implements Renderer {
+
+    private final List<MarkdownNodeRendererFactory> nodeRendererFactories;
+
+    private MarkdownRenderer(Builder builder) {
+        this.nodeRendererFactories = new ArrayList<>(builder.nodeRendererFactories.size() + 1);
+        this.nodeRendererFactories.addAll(builder.nodeRendererFactories);
+        // Add as last. This means clients can override the rendering of core nodes if they want.
+        this.nodeRendererFactories.add(new MarkdownNodeRendererFactory() {
+            @Override
+            public NodeRenderer create(MarkdownNodeRendererContext context) {
+                return new CoreMarkdownNodeRenderer(context);
+            }
+        });
+    }
+
+    /**
+     * Create a new builder for configuring a {@link MarkdownRenderer}.
+     *
+     * @return a builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public void render(Node node, Appendable output) {
+        RendererContext context = new RendererContext(new MarkdownWriter(output));
+        context.render(node);
+    }
+
+    @Override
+    public String render(Node node) {
+        StringBuilder sb = new StringBuilder();
+        render(node, sb);
+        return sb.toString();
+    }
+
+    /**
+     * Builder for configuring a {@link MarkdownRenderer}. See methods for default configuration.
+     */
+    public static class Builder {
+
+        private List<MarkdownNodeRendererFactory> nodeRendererFactories = new ArrayList<>();
+
+        /**
+         * @return the configured {@link MarkdownRenderer}
+         */
+        public MarkdownRenderer build() {
+            return new MarkdownRenderer(this);
+        }
+
+        /**
+         * Add a factory for instantiating a node renderer (done when rendering). This allows to override the rendering
+         * of node types or define rendering for custom node types.
+         * <p>
+         * If multiple node renderers for the same node type are created, the one from the factory that was added first
+         * "wins". (This is how the rendering for core node types can be overridden; the default rendering comes last.)
+         *
+         * @param nodeRendererFactory the factory for creating a node renderer
+         * @return {@code this}
+         */
+        public Builder nodeRendererFactory(MarkdownNodeRendererFactory nodeRendererFactory) {
+            this.nodeRendererFactories.add(nodeRendererFactory);
+            return this;
+        }
+
+        /**
+         * @param extensions extensions to use on this renderer
+         * @return {@code this}
+         */
+        public Builder extensions(Iterable<? extends Extension> extensions) {
+            for (Extension extension : extensions) {
+                if (extension instanceof MarkdownRendererExtension) {
+                    MarkdownRendererExtension markdownRendererExtension = (MarkdownRendererExtension) extension;
+                    markdownRendererExtension.extend(this);
+                }
+            }
+            return this;
+        }
+    }
+
+    /**
+     * Extension for {@link MarkdownRenderer}.
+     */
+    public interface MarkdownRendererExtension extends Extension {
+        void extend(Builder rendererBuilder);
+    }
+
+    private class RendererContext implements MarkdownNodeRendererContext {
+        private final MarkdownWriter writer;
+        private final NodeRendererMap nodeRendererMap = new NodeRendererMap();
+
+        private RendererContext(MarkdownWriter writer) {
+            this.writer = writer;
+
+            // The first node renderer for a node type "wins".
+            for (int i = nodeRendererFactories.size() - 1; i >= 0; i--) {
+                MarkdownNodeRendererFactory nodeRendererFactory = nodeRendererFactories.get(i);
+                NodeRenderer nodeRenderer = nodeRendererFactory.create(this);
+                nodeRendererMap.add(nodeRenderer);
+            }
+        }
+
+        @Override
+        public MarkdownWriter getWriter() {
+            return writer;
+        }
+
+        @Override
+        public void render(Node node) {
+            nodeRendererMap.render(node);
+        }
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -7,9 +7,14 @@ public class MarkdownWriter {
     private final Appendable buffer;
 
     private boolean prependLine = false;
+    private char lastChar;
 
     public MarkdownWriter(Appendable out) {
         buffer = out;
+    }
+
+    public char getLastChar() {
+        return lastChar;
     }
 
     public void block() {
@@ -32,6 +37,11 @@ public class MarkdownWriter {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+
+        int length = s.length();
+        if (length != 0) {
+            lastChar = s.charAt(length - 1);
+        }
     }
 
     private void append(char c) {
@@ -41,6 +51,8 @@ public class MarkdownWriter {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+
+        lastChar = c;
     }
 
     private void appendLineIfNeeded() throws IOException {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -11,7 +11,7 @@ public class MarkdownWriter {
 
     private int blockSeparator = 0;
     private boolean tight;
-    private char lastChar;
+    private char lastChar = '\n';
     private final LinkedList<String> prefixes = new LinkedList<>();
 
     public MarkdownWriter(Appendable out) {
@@ -20,6 +20,10 @@ public class MarkdownWriter {
 
     public char getLastChar() {
         return lastChar;
+    }
+
+    public boolean isAtLineStart() {
+        return lastChar == '\n' || blockSeparator > 0;
     }
 
     public void write(String s) {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -48,10 +48,15 @@ public class MarkdownWriter {
         try {
             for (int i = 0; i < s.length(); i++) {
                 char ch = s.charAt(i);
-                if (ch == '\\' || escape.matches(ch)) {
-                    buffer.append('\\');
+                if (ch == '\n') {
+                    // Can't escape this with \, use numeric character reference
+                    buffer.append("&#10;");
+                } else {
+                    if (ch == '\\' || escape.matches(ch)) {
+                        buffer.append('\\');
+                    }
+                    buffer.append(ch);
                 }
-                buffer.append(ch);
             }
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -11,7 +11,8 @@ public class MarkdownWriter {
 
     private int blockSeparator = 0;
     private boolean tight;
-    private char lastChar = '\n';
+    private char lastChar;
+    private boolean atLineStart = true;
     private final LinkedList<String> prefixes = new LinkedList<>();
 
     public MarkdownWriter(Appendable out) {
@@ -22,8 +23,11 @@ public class MarkdownWriter {
         return lastChar;
     }
 
+    /**
+     * @return whether we're at the line start (not counting any prefixes), i.e. after a {@link #line} or {@link #block}.
+     */
     public boolean isAtLineStart() {
-        return lastChar == '\n' || blockSeparator > 0;
+        return atLineStart;
     }
 
     public void write(String s) {
@@ -54,11 +58,13 @@ public class MarkdownWriter {
         }
 
         lastChar = s.charAt(s.length() - 1);
+        atLineStart = false;
     }
 
     public void line() {
         append('\n');
         writePrefixes();
+        atLineStart = true;
     }
 
     /**
@@ -69,10 +75,17 @@ public class MarkdownWriter {
         // Remember whether this should be a tight or loose separator now because tight could get changed in between
         // this and the next flush.
         blockSeparator = tight ? 1 : 2;
+        atLineStart = true;
     }
 
     public void pushPrefix(String prefix) {
         prefixes.addLast(prefix);
+    }
+
+    public void writePrefix(String prefix) {
+        boolean tmp = atLineStart;
+        write(prefix);
+        atLineStart = tmp;
     }
 
     public void popPrefix() {
@@ -90,6 +103,7 @@ public class MarkdownWriter {
         if (length != 0) {
             lastChar = s.charAt(length - 1);
         }
+        atLineStart = false;
     }
 
     private void append(char c) {
@@ -100,6 +114,7 @@ public class MarkdownWriter {
         }
 
         lastChar = c;
+        atLineStart = false;
     }
 
     private void writePrefixes() {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -1,0 +1,52 @@
+package org.commonmark.renderer.markdown;
+
+import java.io.IOException;
+
+public class MarkdownWriter {
+
+    private final Appendable buffer;
+
+    private boolean prependLine = false;
+
+    public MarkdownWriter(Appendable out) {
+        buffer = out;
+    }
+
+    public void block() {
+        append('\n');
+        prependLine = true;
+    }
+
+    public void write(String s) {
+        append(s);
+    }
+
+    public void write(char c) {
+        append(c);
+    }
+
+    private void append(String s) {
+        try {
+            appendLineIfNeeded();
+            buffer.append(s);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void append(char c) {
+        try {
+            appendLineIfNeeded();
+            buffer.append(c);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void appendLineIfNeeded() throws IOException {
+        if (prependLine) {
+            buffer.append('\n');
+            prependLine = false;
+        }
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -1,5 +1,7 @@
 package org.commonmark.renderer.markdown;
 
+import org.commonmark.internal.util.CharMatcher;
+
 import java.io.IOException;
 
 public class MarkdownWriter {
@@ -32,6 +34,26 @@ public class MarkdownWriter {
 
     public void write(char c) {
         append(c);
+    }
+
+    public void writeEscaped(String s, CharMatcher escape) {
+        if (s.isEmpty()) {
+            return;
+        }
+        try {
+            appendLineIfNeeded();
+            for (int i = 0; i < s.length(); i++) {
+                char ch = s.charAt(i);
+                if (ch == '\\' || escape.matches(ch)) {
+                    buffer.append('\\');
+                }
+                buffer.append(ch);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        lastChar = s.charAt(s.length() - 1);
     }
 
     private void append(String s) {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -5,6 +5,9 @@ import org.commonmark.internal.util.CharMatcher;
 import java.io.IOException;
 import java.util.LinkedList;
 
+/**
+ * Writer for Markdown (CommonMark) text.
+ */
 public class MarkdownWriter {
 
     private final Appendable buffer;
@@ -19,28 +22,29 @@ public class MarkdownWriter {
         buffer = out;
     }
 
-    public char getLastChar() {
-        return lastChar;
-    }
-
     /**
-     * @return whether we're at the line start (not counting any prefixes), i.e. after a {@link #line} or {@link #block}.
+     * Write the supplied string (raw/unescaped).
      */
-    public boolean isAtLineStart() {
-        return atLineStart;
-    }
-
-    public void write(String s) {
+    public void raw(String s) {
         flushBlockSeparator();
         append(s);
     }
 
-    public void write(char c) {
+    /**
+     * Write the supplied character (raw/unescaped).
+     */
+    public void raw(char c) {
         flushBlockSeparator();
         append(c);
     }
 
-    public void writeEscaped(String s, CharMatcher escape) {
+    /**
+     * Write the supplied string with escaping.
+     *
+     * @param s      the string to write
+     * @param escape which characters to escape
+     */
+    public void text(String s, CharMatcher escape) {
         if (s.isEmpty()) {
             return;
         }
@@ -66,6 +70,9 @@ public class MarkdownWriter {
         atLineStart = false;
     }
 
+    /**
+     * Write a newline (line terminator).
+     */
     public void line() {
         append('\n');
         writePrefixes();
@@ -83,18 +90,65 @@ public class MarkdownWriter {
         atLineStart = true;
     }
 
+    /**
+     * Push a prefix onto the top of the stack. All prefixes are written at the beginning of each line, until the
+     * prefix is popped again.
+     *
+     * @param prefix the raw prefix string
+     */
     public void pushPrefix(String prefix) {
         prefixes.addLast(prefix);
     }
 
+    /**
+     * Write a prefix.
+     *
+     * @param prefix the raw prefix string to write
+     */
     public void writePrefix(String prefix) {
         boolean tmp = atLineStart;
-        write(prefix);
+        raw(prefix);
         atLineStart = tmp;
     }
 
+    /**
+     * Remove the last prefix from the top of the stack.
+     */
     public void popPrefix() {
         prefixes.removeLast();
+    }
+
+    /**
+     * @return the last character that was written
+     */
+    public char getLastChar() {
+        return lastChar;
+    }
+
+    /**
+     * @return whether we're at the line start (not counting any prefixes), i.e. after a {@link #line} or {@link #block}.
+     */
+    public boolean isAtLineStart() {
+        return atLineStart;
+    }
+
+    /**
+     * @return whether blocks are currently set to tight or loose, see {@link #setTight(boolean)}
+     */
+    public boolean getTight() {
+        return tight;
+    }
+
+    /**
+     * Change whether blocks are tight or loose. Loose is the default where blocks are separated by a blank line. Tight
+     * is where blocks are not separated by a blank line. Tight blocks are used in lists, if there are no blank lines
+     * within the list.
+     * <p>
+     * Note that changing this does not affect block separators that have already been enqueued (with {@link #block()},
+     * only future ones.
+     */
+    public void setTight(boolean tight) {
+        this.tight = tight;
     }
 
     private void append(String s) {
@@ -143,24 +197,5 @@ public class MarkdownWriter {
             }
             blockSeparator = 0;
         }
-    }
-
-    /**
-     * @return whether blocks are currently set to tight or loose, see {@link #setTight(boolean)}
-     */
-    public boolean getTight() {
-        return tight;
-    }
-
-    /**
-     * Change whether blocks are tight or loose. Loose is the default where blocks are separated by a blank line. Tight
-     * is where blocks are not separated by a blank line. Tight blocks are used in lists, if there are no blank lines
-     * within the list.
-     * <p>
-     * Note that changing this does not affect block separators that have already been enqueued (with {@link #block()},
-     * only future ones.
-     */
-    public void setTight(boolean tight) {
-        this.tight = tight;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -10,6 +10,7 @@ public class MarkdownWriter {
     private final Appendable buffer;
 
     private boolean finishBlock = false;
+    private boolean tight;
     private char lastChar;
     private final LinkedList<String> prefixes = new LinkedList<>();
 
@@ -96,8 +97,10 @@ public class MarkdownWriter {
             finishBlock = false;
             append('\n');
             writePrefixes();
-            append('\n');
-            writePrefixes();
+            if (!tight) {
+                append('\n');
+                writePrefixes();
+            }
         }
     }
 
@@ -107,5 +110,13 @@ public class MarkdownWriter {
                 append(prefix);
             }
         }
+    }
+
+    public boolean getTight() {
+        return tight;
+    }
+
+    public void setTight(boolean tight) {
+        this.tight = tight;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -22,6 +22,10 @@ public class MarkdownWriter {
         prependLine = true;
     }
 
+    public void line() {
+        append('\n');
+    }
+
     public void write(String s) {
         append(s);
     }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -53,6 +53,7 @@ public class MarkdownRendererTest {
     @Test
     public void testHtmlBlocks() {
         assertRoundTrip("<div>test</div>\n");
+        assertRoundTrip("> <div>\n> test\n> </div>\n");
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -32,6 +32,13 @@ public class MarkdownRendererTest {
     }
 
     @Test
+    public void testIndentedCodeBlocks() {
+        assertRoundTrip("    hi\n");
+        assertRoundTrip("    hi\n    code\n");
+        assertRoundTrip(">     hi\n>     code\n");
+    }
+
+    @Test
     public void testHtmlBlocks() {
         assertRoundTrip("<div>test</div>\n");
     }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -44,6 +44,24 @@ public class MarkdownRendererTest {
         assertRoundTrip("`` `foo ``\n");
     }
 
+    @Test
+    public void testEmphasis() {
+        assertRoundTrip("*foo*\n");
+        assertRoundTrip("foo*bar*\n");
+        // When nesting, a different delimiter needs to be used
+        assertRoundTrip("*_foo_*\n");
+        assertRoundTrip("*_*foo*_*\n");
+
+        // Not emphasis (needs * inside words)
+        assertRoundTrip("foo_bar_\n");
+    }
+
+    @Test
+    public void testStrongEmphasis() {
+        assertRoundTrip("**foo**\n");
+        assertRoundTrip("foo**bar**\n");
+    }
+
     private Node parse(String source) {
         return Parser.builder().build().parse(source);
     }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -194,6 +194,9 @@ public class MarkdownRendererTest {
         assertRoundTrip("[a](<b\\>c>)\n");
         assertRoundTrip("[a](<b\\\\\\>c>)\n");
         assertRoundTrip("[a](/uri \"foo \\\" bar\")\n");
+        assertRoundTrip("[link](/uri \"tes\\\\\")\n");
+        assertRoundTrip("[link](/url \"test&#10;&#10;\")\n");
+        assertRoundTrip("[link](</url&#10;&#10;>)\n");
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -82,6 +82,8 @@ public class MarkdownRendererTest {
 
         // Tight list
         assertRoundTrip("* foo\n* bar\n");
+        // Tight list where the second item contains a loose list
+        assertRoundTrip("- Foo\n  - Bar\n  \n  - Baz\n");
 
         // List item indent. This is a tricky one, but here the amount of space between the list marker and "one"
         // determines whether "two" is part of the list item or an indented code block.
@@ -102,6 +104,8 @@ public class MarkdownRendererTest {
 
         // Tight list
         assertRoundTrip("1. foo\n2. bar\n");
+        // Tight list where the second item contains a loose list
+        assertRoundTrip("1. Foo\n   1. Bar\n   \n   2. Baz\n");
 
         assertRoundTrip(" 1.  one\n\n    two\n");
     }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -1,0 +1,50 @@
+package org.commonmark.renderer.markdown;
+
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MarkdownRendererTest {
+
+    @Test
+    public void testThematicBreaks() {
+        assertRoundTrip("***\n");
+        // TODO: spec: If you want a thematic break in a list item, use a different bullet:
+
+        assertRoundTrip("***\n\nfoo\n");
+    }
+
+    @Test
+    public void testHeadings() {
+        // Type of heading is currently not preserved
+        assertRoundTrip("# foo\n");
+        assertRoundTrip("## foo\n");
+        assertRoundTrip("### foo\n");
+        assertRoundTrip("#### foo\n");
+        assertRoundTrip("##### foo\n");
+        assertRoundTrip("###### foo\n");
+
+        assertRoundTrip("# foo\n\nbar\n");
+    }
+
+    @Test
+    public void testParagraphs() {
+        assertRoundTrip("foo\n");
+        assertRoundTrip("foo\n\nbar\n");
+    }
+
+    private Node parse(String source) {
+        return Parser.builder().build().parse(source);
+    }
+
+    private String render(String source) {
+        return MarkdownRenderer.builder().build().render(parse(source));
+    }
+
+    private void assertRoundTrip(String input) {
+        String rendered = render(input);
+        assertEquals(input, rendered);
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -148,6 +148,11 @@ public class MarkdownRendererTest {
         assertRoundTrip("999\\. Foo\n");
         assertRoundTrip("1\\.\n");
         assertRoundTrip("1\\) Foo\n");
+
+        // Escaped whitespace, wow
+        assertRoundTrip("&#9;foo\n");
+        assertRoundTrip("&#32;   foo\n");
+        assertRoundTrip("foo&#10;&#10;bar\n");
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -116,6 +116,11 @@ public class MarkdownRendererTest {
     // Inlines
 
     @Test
+    public void testTabs() {
+        assertRoundTrip("a\tb\n");
+    }
+
+    @Test
     public void testEscaping() {
         // These are a bit tricky. We always escape some characters, even though they only need escaping if they would
         // otherwise result in a different parse result (e.g. a link):

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -30,6 +30,11 @@ public class MarkdownRendererTest {
     }
 
     @Test
+    public void testHtmlBlocks() {
+        assertRoundTrip("<div>test</div>\n");
+    }
+
+    @Test
     public void testParagraphs() {
         assertRoundTrip("foo\n");
         assertRoundTrip("foo\n\nbar\n");
@@ -84,6 +89,11 @@ public class MarkdownRendererTest {
         assertRoundTrip("![a](<b\\>c>)\n");
         assertRoundTrip("![a](<b\\\\\\>c>)\n");
         assertRoundTrip("![a](/uri \"foo \\\" bar\")\n");
+    }
+
+    @Test
+    public void testHtmlInline() {
+        assertRoundTrip("<del>*foo*</del>\n");
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -63,6 +63,30 @@ public class MarkdownRendererTest {
     }
 
     @Test
+    public void testLinks() {
+        assertRoundTrip("[link](/uri)\n");
+        assertRoundTrip("[link](/uri \"title\")\n");
+        assertRoundTrip("[link](</my uri>)\n");
+        assertRoundTrip("[a](<b)c>)\n");
+        assertRoundTrip("[a](<b(c>)\n");
+        assertRoundTrip("[a](<b\\>c>)\n");
+        assertRoundTrip("[a](<b\\\\\\>c>)\n");
+        assertRoundTrip("[a](/uri \"foo \\\" bar\")\n");
+    }
+
+    @Test
+    public void testImages() {
+        assertRoundTrip("![link](/uri)\n");
+        assertRoundTrip("![link](/uri \"title\")\n");
+        assertRoundTrip("![link](</my uri>)\n");
+        assertRoundTrip("![a](<b)c>)\n");
+        assertRoundTrip("![a](<b(c>)\n");
+        assertRoundTrip("![a](<b\\>c>)\n");
+        assertRoundTrip("![a](<b\\\\\\>c>)\n");
+        assertRoundTrip("![a](/uri \"foo \\\" bar\")\n");
+    }
+
+    @Test
     public void testHardLineBreaks() {
         assertRoundTrip("foo  \nbar\n");
     }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -39,6 +39,14 @@ public class MarkdownRendererTest {
     }
 
     @Test
+    public void testFencedCodeBlocks() {
+        assertRoundTrip("```\ntest\n```\n");
+        assertRoundTrip("~~~~\ntest\n~~~~\n");
+        assertRoundTrip("```info\ntest\n```\n");
+        assertRoundTrip(" ```\n test\n ```\n");
+    }
+
+    @Test
     public void testHtmlBlocks() {
         assertRoundTrip("<div>test</div>\n");
     }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -95,6 +95,8 @@ public class MarkdownRendererTest {
         assertRoundTrip("```foo `` ` bar```\n");
 
         assertRoundTrip("`` `foo ``\n");
+        assertRoundTrip("``  `  ``\n");
+        assertRoundTrip("` `\n");
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -78,13 +78,16 @@ public class MarkdownRendererTest {
         assertRoundTrip("* foo\n\n* bar\n");
 
         // Tight list
-//        assertRoundTrip("* foo\n* bar\n");
+        assertRoundTrip("* foo\n* bar\n");
     }
 
     @Test
     public void testOrderedListItems() {
         assertRoundTrip("1. foo\n");
         assertRoundTrip("2. foo\n\n3. bar\n");
+
+        // Tight list
+        assertRoundTrip("1. foo\n2. bar\n");
     }
 
     // Inlines

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -1,6 +1,6 @@
 package org.commonmark.renderer.markdown;
 
-import org.commonmark.node.Node;
+import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
 import org.junit.Test;
 
@@ -173,9 +173,21 @@ public class MarkdownRendererTest {
         // When nesting, a different delimiter needs to be used
         assertRoundTrip("*_foo_*\n");
         assertRoundTrip("*_*foo*_*\n");
+        assertRoundTrip("_*foo*_\n");
 
         // Not emphasis (needs * inside words)
-        assertRoundTrip("foo_bar_\n");
+        assertRoundTrip("foo\\_bar\\_\n");
+
+        // Even when rendering a manually constructed tree, the emphasis delimiter needs to be chosen correctly.
+        Document doc = new Document();
+        Paragraph p = new Paragraph();
+        doc.appendChild(p);
+        Emphasis e1 = new Emphasis();
+        p.appendChild(e1);
+        Emphasis e2 = new Emphasis();
+        e1.appendChild(e2);
+        e2.appendChild(new Text("hi"));
+        assertEquals("*_hi_*\n", render(doc));
     }
 
     @Test
@@ -226,17 +238,21 @@ public class MarkdownRendererTest {
         assertRoundTrip("foo\nbar\n");
     }
 
+    private void assertRoundTrip(String input) {
+        String rendered = parseAndRender(input);
+        assertEquals(input, rendered);
+    }
+
+    private String parseAndRender(String source) {
+        Node parsed = parse(source);
+        return render(parsed);
+    }
+
     private Node parse(String source) {
         return Parser.builder().build().parse(source);
     }
 
-    private String render(String source) {
-        Node parsed = parse(source);
-        return MarkdownRenderer.builder().build().render(parsed);
-    }
-
-    private void assertRoundTrip(String input) {
-        String rendered = render(input);
-        assertEquals(input, rendered);
+    private String render(Node node) {
+        return MarkdownRenderer.builder().build().render(node);
     }
 }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -89,6 +89,14 @@ public class MarkdownRendererTest {
     // Inlines
 
     @Test
+    public void testEscaping() {
+        // These are a bit tricky. We always escape some characters, even though they only need escaping if they would
+        // otherwise result in a different parse result (e.g. a link):
+        assertRoundTrip("\\[a\\](/uri)\n");
+        assertRoundTrip("\\`abc\\`\n");
+    }
+
+    @Test
     public void testCodeSpans() {
         assertRoundTrip("`foo`\n");
         assertRoundTrip("``foo ` bar``\n");

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -67,6 +67,25 @@ public class MarkdownRendererTest {
         assertRoundTrip("> # Foo\n> \n> bar\n> baz\n");
     }
 
+    @Test
+    public void testBulletListItems() {
+        assertRoundTrip("* foo\n");
+        assertRoundTrip("- foo\n");
+        assertRoundTrip("+ foo\n");
+        assertRoundTrip("* foo\n  bar\n");
+        assertRoundTrip("* ```\n  code\n  ```\n");
+        assertRoundTrip("* foo\n\n* bar\n");
+
+        // Tight list
+//        assertRoundTrip("* foo\n* bar\n");
+    }
+
+    @Test
+    public void testOrderedListItems() {
+        assertRoundTrip("1. foo\n");
+        assertRoundTrip("2. foo\n\n3. bar\n");
+    }
+
     // Inlines
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -90,6 +90,9 @@ public class MarkdownRendererTest {
         // a paragraph in the list item! So it is important for the renderer to preserve the content indent of the list
         // item.
         assertRoundTrip(" -    one\n\n     two\n");
+
+        // Empty list
+        assertRoundTrip("- \n\nFoo\n");
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -28,6 +28,9 @@ public class MarkdownRendererTest {
         assertRoundTrip("##### foo\n");
         assertRoundTrip("###### foo\n");
 
+        assertRoundTrip("Foo\nbar\n===\n");
+        assertRoundTrip("[foo\nbar](/url)\n===\n");
+
         assertRoundTrip("# foo\n\nbar\n");
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -35,6 +35,15 @@ public class MarkdownRendererTest {
         assertRoundTrip("foo\n\nbar\n");
     }
 
+    @Test
+    public void testCodeSpans() {
+        assertRoundTrip("`foo`\n");
+        assertRoundTrip("``foo ` bar``\n");
+        assertRoundTrip("```foo `` ` bar```\n");
+
+        assertRoundTrip("`` `foo ``\n");
+    }
+
     private Node parse(String source) {
         return Parser.builder().build().parse(source);
     }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -62,6 +62,16 @@ public class MarkdownRendererTest {
         assertRoundTrip("foo**bar**\n");
     }
 
+    @Test
+    public void testHardLineBreaks() {
+        assertRoundTrip("foo  \nbar\n");
+    }
+
+    @Test
+    public void testSoftLineBreaks() {
+        assertRoundTrip("foo\nbar\n");
+    }
+
     private Node parse(String source) {
         return Parser.builder().build().parse(source);
     }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -44,6 +44,7 @@ public class MarkdownRendererTest {
         assertRoundTrip("~~~~\ntest\n~~~~\n");
         assertRoundTrip("```info\ntest\n```\n");
         assertRoundTrip(" ```\n test\n ```\n");
+        assertRoundTrip("```\n```\n");
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertEquals;
 
 public class MarkdownRendererTest {
 
+    // Leaf blocks
+
     @Test
     public void testThematicBreaks() {
         assertRoundTrip("***\n");
@@ -39,6 +41,18 @@ public class MarkdownRendererTest {
         assertRoundTrip("foo\n");
         assertRoundTrip("foo\n\nbar\n");
     }
+
+    // Container blocks
+
+    @Test
+    public void testBlockQuotes() {
+        assertRoundTrip("> test\n");
+        assertRoundTrip("> foo\n> bar\n");
+        assertRoundTrip("> > foo\n> > bar\n");
+        assertRoundTrip("> # Foo\n> \n> bar\n> baz\n");
+    }
+
+    // Inlines
 
     @Test
     public void testCodeSpans() {

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -127,6 +127,22 @@ public class MarkdownRendererTest {
         // otherwise result in a different parse result (e.g. a link):
         assertRoundTrip("\\[a\\](/uri)\n");
         assertRoundTrip("\\`abc\\`\n");
+
+        // Some characters only need to be escaped at the beginning of the line
+        assertRoundTrip("\\- Test\n");
+        assertRoundTrip("\\-\n");
+        assertRoundTrip("Test -\n");
+        assertRoundTrip("Abc\n\n\\- Test\n");
+        assertRoundTrip("\\# Test\n");
+        assertRoundTrip("\\## Test\n");
+        assertRoundTrip("\\#\n");
+        assertRoundTrip("Foo\n\\===\n");
+
+        // This is a bit more tricky as we need to check for a list start
+        assertRoundTrip("1\\. Foo\n");
+        assertRoundTrip("999\\. Foo\n");
+        assertRoundTrip("1\\.\n");
+        assertRoundTrip("1\\) Foo\n");
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -12,10 +12,11 @@ public class MarkdownRendererTest {
 
     @Test
     public void testThematicBreaks() {
-        assertRoundTrip("***\n");
-        // TODO: spec: If you want a thematic break in a list item, use a different bullet:
-
-        assertRoundTrip("***\n\nfoo\n");
+        assertRoundTrip("___\n");
+        assertRoundTrip("___\n\nfoo\n");
+        // List item with hr -> hr needs to not use the same as the marker
+        assertRoundTrip("* ___\n");
+        assertRoundTrip("- ___\n");
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -137,6 +137,11 @@ public class MarkdownRendererTest {
         assertRoundTrip("\\## Test\n");
         assertRoundTrip("\\#\n");
         assertRoundTrip("Foo\n\\===\n");
+        // The beginning of the line within the block, so disregarding prefixes
+        assertRoundTrip("> \\- Test\n");
+        assertRoundTrip("- \\- Test\n");
+        // That's not the beginning of the line
+        assertRoundTrip("`a`- foo\n");
 
         // This is a bit more tricky as we need to check for a list start
         assertRoundTrip("1\\. Foo\n");

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -62,7 +62,7 @@ public class SpecMarkdownRendererTest {
             System.out.println();
         }
 
-        int expectedPassed = 621;
+        int expectedPassed = 622;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -52,7 +52,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 613;
+        int expectedPassed = 618;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -44,14 +44,14 @@ public class SpecMarkdownRendererTest {
             }
         }
 
-        System.out.println("Failed examples by section:");
-        printCountsBySection(fails);
+        System.out.println("Passed examples by section (total " + passes.size() + "):");
+        printCountsBySection(passes);
         System.out.println();
 
-        System.out.println("Passed examples by section:");
-        printCountsBySection(passes);
+        System.out.println("Failed examples by section (total " + fails.size() + "):");
+        printCountsBySection(fails);
 
-        int expectedPassed = 151;
+        int expectedPassed = 226;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -62,7 +62,7 @@ public class SpecMarkdownRendererTest {
             System.out.println();
         }
 
-        int expectedPassed = 625;
+        int expectedPassed = 629;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 
@@ -89,6 +89,7 @@ public class SpecMarkdownRendererTest {
     }
 
     private String renderHtml(String source) {
-        return HTML_RENDERER.render(parse(source));
+        // The spec uses "rightwards arrow" to show tabs
+        return HTML_RENDERER.render(parse(source)).replace("\t", "\u2192");
     }
 }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -51,7 +51,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 263;
+        int expectedPassed = 372;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 
@@ -65,7 +65,7 @@ public class SpecMarkdownRendererTest {
             bySection.put(example.getSection(), count + 1);
         }
         for (Map.Entry<String, Integer> entry : bySection.entrySet()) {
-            System.out.println(entry.getKey() + ": " + entry.getValue());
+            System.out.println(entry.getValue() + ": " + entry.getKey());
         }
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -62,7 +62,7 @@ public class SpecMarkdownRendererTest {
             System.out.println();
         }
 
-        int expectedPassed = 630;
+        int expectedPassed = 646;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -27,7 +27,8 @@ import static org.junit.Assert.assertTrue;
 public class SpecMarkdownRendererTest {
 
     public static final MarkdownRenderer MARKDOWN_RENDERER = MarkdownRenderer.builder().build();
-    public static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().build();
+    // The spec says URL-escaping is optional, but the examples assume that it's enabled.
+    public static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().percentEncodeUrls(true).build();
 
     @Test
     public void testCoverage() {
@@ -51,7 +52,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 564;
+        int expectedPassed = 574;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -52,7 +52,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 594;
+        int expectedPassed = 611;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -62,7 +62,7 @@ public class SpecMarkdownRendererTest {
             System.out.println();
         }
 
-        int expectedPassed = 647;
+        int expectedPassed = 650;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -52,7 +52,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 618;
+        int expectedPassed = 621;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -52,7 +52,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 575;
+        int expectedPassed = 590;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -62,7 +62,7 @@ public class SpecMarkdownRendererTest {
             System.out.println();
         }
 
-        int expectedPassed = 622;
+        int expectedPassed = 625;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -51,7 +51,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 481;
+        int expectedPassed = 507;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -51,7 +51,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 372;
+        int expectedPassed = 459;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -52,7 +52,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 574;
+        int expectedPassed = 575;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -52,7 +52,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 611;
+        int expectedPassed = 613;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -51,7 +51,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 459;
+        int expectedPassed = 481;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -62,8 +63,9 @@ public class SpecMarkdownRendererTest {
             System.out.println();
         }
 
-        int expectedPassed = 650;
+        int expectedPassed = 652;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
+        assertEquals(0, fails.size());
     }
 
     private static void printCountsBySection(List<Example> examples) {

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -1,0 +1,56 @@
+package org.commonmark.renderer.markdown;
+
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.testutil.TestResources;
+import org.commonmark.testutil.example.Example;
+import org.commonmark.testutil.example.ExampleReader;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests Markdown rendering using the examples in the spec like this:
+ * <ol>
+ * <li>Parses the source to an AST and then renders it back to Markdown</li>
+ * <li>Parses that to an AST and then renders it to HTML</li>
+ * <li>Compares that HTML to the expected HTML of the example:
+ * If it's the same, then the expected elements were preserved in the Markdown rendering</li>
+ * </ol>
+ */
+public class SpecMarkdownRendererTest {
+
+    public static final MarkdownRenderer MARKDOWN_RENDERER = MarkdownRenderer.builder().build();
+    public static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().build();
+
+    @Test
+    public void testCoverage() {
+        List<Example> examples = ExampleReader.readExamples(TestResources.getSpec());
+        int passed = 0;
+        for (Example example : examples) {
+            String markdown = renderMarkdown(example.getSource());
+            String rendered = renderHtml(markdown);
+            if (rendered.equals(example.getHtml())) {
+                passed++;
+            }
+        }
+
+        int expectedPassed = 151;
+        assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passed, passed >= expectedPassed);
+    }
+
+    private Node parse(String source) {
+        return Parser.builder().build().parse(source);
+    }
+
+    private String renderMarkdown(String source) {
+        return MARKDOWN_RENDERER.render(parse(source));
+    }
+
+    private String renderHtml(String source) {
+        return HTML_RENDERER.render(parse(source));
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -62,7 +62,7 @@ public class SpecMarkdownRendererTest {
             System.out.println();
         }
 
-        int expectedPassed = 646;
+        int expectedPassed = 647;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -51,7 +51,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 507;
+        int expectedPassed = 564;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -51,7 +51,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 226;
+        int expectedPassed = 263;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -8,7 +8,10 @@ import org.commonmark.testutil.example.Example;
 import org.commonmark.testutil.example.ExampleReader;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
 
@@ -29,17 +32,41 @@ public class SpecMarkdownRendererTest {
     @Test
     public void testCoverage() {
         List<Example> examples = ExampleReader.readExamples(TestResources.getSpec());
-        int passed = 0;
+        List<Example> passes = new ArrayList<>();
+        List<Example> fails = new ArrayList<>();
         for (Example example : examples) {
             String markdown = renderMarkdown(example.getSource());
             String rendered = renderHtml(markdown);
             if (rendered.equals(example.getHtml())) {
-                passed++;
+                passes.add(example);
+            } else {
+                fails.add(example);
             }
         }
 
+        System.out.println("Failed examples by section:");
+        printCountsBySection(fails);
+        System.out.println();
+
+        System.out.println("Passed examples by section:");
+        printCountsBySection(passes);
+
         int expectedPassed = 151;
-        assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passed, passed >= expectedPassed);
+        assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
+    }
+
+    private static void printCountsBySection(List<Example> examples) {
+        Map<String, Integer> bySection = new LinkedHashMap<>();
+        for (Example example : examples) {
+            Integer count = bySection.get(example.getSection());
+            if (count == null) {
+                count = 0;
+            }
+            bySection.put(example.getSection(), count + 1);
+        }
+        for (Map.Entry<String, Integer> entry : bySection.entrySet()) {
+            System.out.println(entry.getKey() + ": " + entry.getValue());
+        }
     }
 
     private Node parse(String source) {

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -51,6 +51,16 @@ public class SpecMarkdownRendererTest {
 
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
+        System.out.println();
+
+        System.out.println("Failed examples:");
+        for (Example fail : fails) {
+            System.out.println("Failed: " + fail);
+            System.out.println("````````````````````````````````");
+            System.out.print(fail.getSource());
+            System.out.println("````````````````````````````````");
+            System.out.println();
+        }
 
         int expectedPassed = 621;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -52,7 +52,7 @@ public class SpecMarkdownRendererTest {
         System.out.println("Failed examples by section (total " + fails.size() + "):");
         printCountsBySection(fails);
 
-        int expectedPassed = 590;
+        int expectedPassed = 594;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -62,7 +62,7 @@ public class SpecMarkdownRendererTest {
             System.out.println();
         }
 
-        int expectedPassed = 629;
+        int expectedPassed = 630;
         assertTrue("Expected at least " + expectedPassed + " examples to pass but was " + passes.size(), passes.size() >= expectedPassed);
     }
 


### PR DESCRIPTION
Adds a `MarkdownRenderer` that renders a `Node` tree to CommonMark Markdown. Supports all core nodes as well as "gfm-strikethrough", "gfm-tables" and "ins" extensions. This is very useful for applications that want to produce Markdown, e.g.:

* Parse some input Markdown, modify the nodes (AST), then render back to Markdown
* Create a `Node` tree via code and then render that to Markdown

The goal is that `Node tree -> render to Markdown -> parse to Node tree` results in an equivalent Node tree. That is verified with all the examples from the spec and some manual test cases.

However it does not mean that a `Markdown -> parse to Node tree -> render to Markdown` round-trip produces the same Markdown as the original. The parse step does not preserve enough detail for that yet, e.g. things like insignificant whitespace or what characters were escaped.

___

In the future, we can make changes that preserve more details when parsing and make use of that to bring the rendered Markdown closer to the original. But the Markdown renderer can't rely on those extra details to work correctly, as that would break the use case where there is no parsing (when creating `Node` tree via code).