### PR TITLE
Fix markdown renderer for manually created list nodes

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
@@ -4,6 +4,8 @@ import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.*;
 import org.commonmark.parser.block.*;
 
+import java.util.Objects;
+
 public class ListBlockParser extends AbstractBlockParser {
 
     private final ListBlock block;
@@ -90,7 +92,7 @@ public class ListBlockParser extends AbstractBlockParser {
 
         if (inParagraph) {
             // If the list item is ordered, the start number must be 1 to interrupt a paragraph.
-            if (listBlock instanceof OrderedList && ((OrderedList) listBlock).getStartNumber() != 1) {
+            if (listBlock instanceof OrderedList && ((OrderedList) listBlock).getMarkerStartNumber() != 1) {
                 return null;
             }
             // Empty list item can not interrupt a paragraph.
@@ -116,7 +118,7 @@ public class ListBlockParser extends AbstractBlockParser {
             case '*':
                 if (isSpaceTabOrEnd(line, index + 1)) {
                     BulletList bulletList = new BulletList();
-                    bulletList.setBulletMarker(c);
+                    bulletList.setMarker(String.valueOf(c));
                     return new ListMarkerData(bulletList, index + 1);
                 } else {
                     return null;
@@ -154,8 +156,8 @@ public class ListBlockParser extends AbstractBlockParser {
                     if (digits >= 1 && isSpaceTabOrEnd(line, i + 1)) {
                         String number = line.subSequence(index, i).toString();
                         OrderedList orderedList = new OrderedList();
-                        orderedList.setStartNumber(Integer.parseInt(number));
-                        orderedList.setDelimiter(c);
+                        orderedList.setMarkerStartNumber(Integer.parseInt(number));
+                        orderedList.setMarkerDelimiter(String.valueOf(c));
                         return new ListMarkerData(orderedList, i + 1);
                     } else {
                         return null;
@@ -188,15 +190,11 @@ public class ListBlockParser extends AbstractBlockParser {
      */
     private static boolean listsMatch(ListBlock a, ListBlock b) {
         if (a instanceof BulletList && b instanceof BulletList) {
-            return equals(((BulletList) a).getBulletMarker(), ((BulletList) b).getBulletMarker());
+            return Objects.equals(((BulletList) a).getMarker(), ((BulletList) b).getMarker());
         } else if (a instanceof OrderedList && b instanceof OrderedList) {
-            return equals(((OrderedList) a).getDelimiter(), ((OrderedList) b).getDelimiter());
+            return Objects.equals(((OrderedList) a).getMarkerDelimiter(), ((OrderedList) b).getMarkerDelimiter());
         }
         return false;
-    }
-
-    private static boolean equals(Object a, Object b) {
-        return (a == null) ? (b == null) : a.equals(b);
     }
 
     public static class Factory extends AbstractBlockParserFactory {

--- a/commonmark/src/main/java/org/commonmark/internal/renderer/text/BulletListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/internal/renderer/text/BulletListHolder.java
@@ -3,14 +3,14 @@ package org.commonmark.internal.renderer.text;
 import org.commonmark.node.BulletList;
 
 public class BulletListHolder extends ListHolder {
-    private final char marker;
+    private final String marker;
 
     public BulletListHolder(ListHolder parent, BulletList list) {
         super(parent);
-        marker = list.getBulletMarker();
+        marker = list.getMarker();
     }
 
-    public char getMarker() {
+    public String getMarker() {
         return marker;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/renderer/text/OrderedListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/internal/renderer/text/OrderedListHolder.java
@@ -3,16 +3,16 @@ package org.commonmark.internal.renderer.text;
 import org.commonmark.node.OrderedList;
 
 public class OrderedListHolder extends ListHolder {
-    private final char delimiter;
+    private final String delimiter;
     private int counter;
 
     public OrderedListHolder(ListHolder parent, OrderedList list) {
         super(parent);
-        delimiter = list.getDelimiter();
-        counter = list.getStartNumber();
+        delimiter = list.getMarkerDelimiter() != null ? list.getMarkerDelimiter() : ".";
+        counter = list.getMarkerStartNumber() != null ? list.getMarkerStartNumber() : 1;
     }
 
-    public char getDelimiter() {
+    public String getDelimiter() {
         return delimiter;
     }
 

--- a/commonmark/src/main/java/org/commonmark/node/BulletList.java
+++ b/commonmark/src/main/java/org/commonmark/node/BulletList.java
@@ -2,19 +2,37 @@ package org.commonmark.node;
 
 public class BulletList extends ListBlock {
 
-    private char bulletMarker;
+    private String marker;
 
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
 
+    /**
+     * @return the bullet list marker that was used, e.g. {@code -}, {@code *} or {@code +}, if available, or null otherwise
+     */
+    public String getMarker() {
+        return marker;
+    }
+
+    public void setMarker(String marker) {
+        this.marker = marker;
+    }
+
+    /**
+     * @deprecated use {@link #getMarker()} instead
+     */
+    @Deprecated
     public char getBulletMarker() {
-        return bulletMarker;
+        return marker != null && !marker.isEmpty() ? marker.charAt(0) : '\0';
     }
 
+    /**
+     * @deprecated use {@link #getMarker()} instead
+     */
+    @Deprecated
     public void setBulletMarker(char bulletMarker) {
-        this.bulletMarker = bulletMarker;
+        this.marker = bulletMarker != '\0' ? String.valueOf(bulletMarker) : null;
     }
-
 }

--- a/commonmark/src/main/java/org/commonmark/node/ListItem.java
+++ b/commonmark/src/main/java/org/commonmark/node/ListItem.java
@@ -2,8 +2,8 @@ package org.commonmark.node;
 
 public class ListItem extends Block {
 
-    private int markerIndent;
-    private int contentIndent;
+    private Integer markerIndent;
+    private Integer contentIndent;
 
     @Override
     public void accept(Visitor visitor) {
@@ -11,7 +11,8 @@ public class ListItem extends Block {
     }
 
     /**
-     * Returns the indent of the marker such as "-" or "1." in columns (spaces or tab stop of 4).
+     * Returns the indent of the marker such as "-" or "1." in columns (spaces or tab stop of 4) if available, or null
+     * otherwise.
      * <p>
      * Some examples and their marker indent:
      * <pre>- Foo</pre>
@@ -21,17 +22,17 @@ public class ListItem extends Block {
      * <pre>  1. Foo</pre>
      * Marker indent: 2
      */
-    public int getMarkerIndent() {
+    public Integer getMarkerIndent() {
         return markerIndent;
     }
 
-    public void setMarkerIndent(int markerIndent) {
+    public void setMarkerIndent(Integer markerIndent) {
         this.markerIndent = markerIndent;
     }
 
     /**
-     * Returns the indent of the content in columns (spaces or tab stop of 4). The content indent is counted from the
-     * beginning of the line and includes the marker on the first line.
+     * Returns the indent of the content in columns (spaces or tab stop of 4) if available, or null otherwise.
+     * The content indent is counted from the beginning of the line and includes the marker on the first line.
      * <p>
      * Some examples and their content indent:
      * <pre>- Foo</pre>
@@ -44,11 +45,11 @@ public class ListItem extends Block {
      * Note that subsequent lines in the same list item need to be indented by at least the content indent to be counted
      * as part of the list item.
      */
-    public int getContentIndent() {
+    public Integer getContentIndent() {
         return contentIndent;
     }
 
-    public void setContentIndent(int contentIndent) {
+    public void setContentIndent(Integer contentIndent) {
         this.contentIndent = contentIndent;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/OrderedList.java
+++ b/commonmark/src/main/java/org/commonmark/node/OrderedList.java
@@ -2,28 +2,65 @@ package org.commonmark.node;
 
 public class OrderedList extends ListBlock {
 
-    private int startNumber;
-    private char delimiter;
+    private String markerDelimiter;
+    private Integer markerStartNumber;
 
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
 
+    /**
+     * @return the start number used in the marker, e.g. {@code 1}, if available, or null otherwise
+     */
+    public Integer getMarkerStartNumber() {
+        return markerStartNumber;
+    }
+
+    public void setMarkerStartNumber(Integer markerStartNumber) {
+        this.markerStartNumber = markerStartNumber;
+    }
+
+    /**
+     * @return the delimiter used in the marker, e.g. {@code .} or {@code )}, if available, or null otherwise
+     */
+    public String getMarkerDelimiter() {
+        return markerDelimiter;
+    }
+
+    public void setMarkerDelimiter(String markerDelimiter) {
+        this.markerDelimiter = markerDelimiter;
+    }
+
+    /**
+     * @deprecated use {@link #getMarkerStartNumber()} instead
+     */
+    @Deprecated
     public int getStartNumber() {
-        return startNumber;
+        return markerStartNumber != null ? markerStartNumber : 0;
     }
 
+    /**
+     * @deprecated use {@link #setMarkerStartNumber} instead
+     */
+    @Deprecated
     public void setStartNumber(int startNumber) {
-        this.startNumber = startNumber;
+        this.markerStartNumber = startNumber != 0 ? startNumber : null;
     }
 
+    /**
+     * @deprecated use {@link #getMarkerDelimiter()} instead
+     */
+    @Deprecated
     public char getDelimiter() {
-        return delimiter;
+        return markerDelimiter != null && !markerDelimiter.isEmpty() ? markerDelimiter.charAt(0) : '\0';
     }
 
+    /**
+     * @deprecated use {@link #setMarkerDelimiter} instead
+     */
+    @Deprecated
     public void setDelimiter(char delimiter) {
-        this.delimiter = delimiter;
+        this.markerDelimiter = delimiter != '\0' ? String.valueOf(delimiter) : null;
     }
-
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
@@ -168,7 +168,7 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
 
     @Override
     public void visit(OrderedList orderedList) {
-        int start = orderedList.getStartNumber();
+        int start = orderedList.getMarkerStartNumber() != null ? orderedList.getMarkerStartNumber() : 1;
         Map<String, String> attrs = new LinkedHashMap<>();
         if (start != 1) {
             attrs.put("start", String.valueOf(start));

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -2,8 +2,10 @@ package org.commonmark.renderer.markdown;
 
 import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
+import org.commonmark.testutil.Asserts;
 import org.junit.Test;
 
+import static org.commonmark.testutil.Asserts.assertRendering;
 import static org.junit.Assert.assertEquals;
 
 public class MarkdownRendererTest {
@@ -104,6 +106,21 @@ public class MarkdownRendererTest {
     }
 
     @Test
+    public void testBulletListItemsFromAst() {
+        var doc = new Document();
+        var list = new BulletList();
+        var item = new ListItem();
+        item.appendChild(new Text("Test"));
+        list.appendChild(item);
+        doc.appendChild(list);
+
+        assertRendering("", "- Test\n", render(doc));
+
+        list.setMarker("*");
+        assertRendering("", "* Test\n", render(doc));
+    }
+
+    @Test
     public void testOrderedListItems() {
         assertRoundTrip("1. foo\n");
         assertRoundTrip("2. foo\n\n3. bar\n");
@@ -114,6 +131,22 @@ public class MarkdownRendererTest {
         assertRoundTrip("1. Foo\n   1. Bar\n   \n   2. Baz\n");
 
         assertRoundTrip(" 1.  one\n\n    two\n");
+    }
+
+    @Test
+    public void testOrderedListItemsFromAst() {
+        var doc = new Document();
+        var list = new OrderedList();
+        var item = new ListItem();
+        item.appendChild(new Text("Test"));
+        list.appendChild(item);
+        doc.appendChild(list);
+
+        assertRendering("", "1. Test\n", render(doc));
+
+        list.setMarkerStartNumber(2);
+        list.setMarkerDelimiter(")");
+        assertRendering("", "2) Test\n", render(doc));
     }
 
     // Inlines

--- a/commonmark/src/test/java/org/commonmark/test/ListBlockParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ListBlockParserTest.java
@@ -60,7 +60,7 @@ public class ListBlockParserTest {
     private void assertListItemIndents(String input, int expectedMarkerIndent, int expectedContentIndent) {
         Node doc = PARSER.parse(input);
         ListItem listItem = Nodes.find(doc, ListItem.class);
-        assertEquals(expectedMarkerIndent, listItem.getMarkerIndent());
-        assertEquals(expectedContentIndent, listItem.getContentIndent());
+        assertEquals(expectedMarkerIndent, (int) listItem.getMarkerIndent());
+        assertEquals(expectedContentIndent, (int) listItem.getContentIndent());
     }
 }


### PR DESCRIPTION
Manually created `BulletList` or `OrderedList` nodes don't necessarily have a marker/start number set, so when rendering them we need to check for that and use defaults. This adds alternative methods that return nullable values for these properties and deprecates the old ones.

Note that an alternative would have been to give default values to the properties on `BulletList` and `OrderedList` but it seems better to have them nullable because:
* It makes it possible for renderers or other code to decide what to do in the nullable case instead of the class itself deciding on a default value
* It more closely models what is happening (a list was created without setting a marker vs a list was created with setting a marker)
* Some other methods such as `getContentIndent` don't really have a good way to set the default, so they have to be nullable