### PR TITLE
Fix markdown renderer for manually created fenced code blocks

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
@@ -12,13 +12,17 @@ import static org.commonmark.internal.util.Escaping.unescapeString;
 public class FencedCodeBlockParser extends AbstractBlockParser {
 
     private final FencedCodeBlock block = new FencedCodeBlock();
+    private final char fenceChar;
+    private final int openingFenceLength;
 
     private String firstLine;
     private StringBuilder otherLines = new StringBuilder();
 
     public FencedCodeBlockParser(char fenceChar, int fenceLength, int fenceIndent) {
-        block.setFenceChar(fenceChar);
-        block.setFenceLength(fenceLength);
+        this.fenceChar = fenceChar;
+        this.openingFenceLength = fenceLength;
+        block.setFenceCharacter(String.valueOf(fenceChar));
+        block.setOpeningFenceLength(fenceLength);
         block.setFenceIndent(fenceIndent);
     }
 
@@ -32,7 +36,7 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
         int nextNonSpace = state.getNextNonSpaceIndex();
         int newIndex = state.getIndex();
         CharSequence line = state.getLine().getContent();
-        if (state.getIndent() < Parsing.CODE_BLOCK_INDENT && nextNonSpace < line.length() && line.charAt(nextNonSpace) == block.getFenceChar() && isClosing(line, nextNonSpace)) {
+        if (state.getIndent() < Parsing.CODE_BLOCK_INDENT && nextNonSpace < line.length() && tryClosing(line, nextNonSpace)) {
             // closing fence - we're at end of line, so we can finalize now
             return BlockContinue.finished();
         } else {
@@ -76,7 +80,7 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
             int nextNonSpace = state.getNextNonSpaceIndex();
             FencedCodeBlockParser blockParser = checkOpener(state.getLine().getContent(), nextNonSpace, indent);
             if (blockParser != null) {
-                return BlockStart.of(blockParser).atIndex(nextNonSpace + blockParser.block.getFenceLength());
+                return BlockStart.of(blockParser).atIndex(nextNonSpace + blockParser.block.getOpeningFenceLength());
             } else {
                 return BlockStart.none();
             }
@@ -119,15 +123,17 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
     // spec: The content of the code block consists of all subsequent lines, until a closing code fence of the same type
     // as the code block began with (backticks or tildes), and with at least as many backticks or tildes as the opening
     // code fence.
-    private boolean isClosing(CharSequence line, int index) {
-        char fenceChar = block.getFenceChar();
-        int fenceLength = block.getFenceLength();
+    private boolean tryClosing(CharSequence line, int index) {
         int fences = Characters.skip(fenceChar, line, index, line.length()) - index;
-        if (fences < fenceLength) {
+        if (fences < openingFenceLength) {
             return false;
         }
         // spec: The closing code fence [...] may be followed only by spaces, which are ignored.
         int after = Characters.skipSpaceTab(line, index + fences, line.length());
-        return after == line.length();
+        if (after == line.length()) {
+            block.setClosingFenceLength(fences);
+            return true;
+        }
+        return false;
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/FencedCodeBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/FencedCodeBlock.java
@@ -2,8 +2,9 @@ package org.commonmark.node;
 
 public class FencedCodeBlock extends Block {
 
-    private char fenceChar;
-    private int fenceLength;
+    private String fenceCharacter;
+    private Integer openingFenceLength;
+    private Integer closingFenceLength;
     private int fenceIndent;
 
     private String info;
@@ -14,20 +15,47 @@ public class FencedCodeBlock extends Block {
         visitor.visit(this);
     }
 
-    public char getFenceChar() {
-        return fenceChar;
+    /**
+     * @return the fence character that was used, e.g. {@code `} or {@code ~}, if available, or null otherwise
+     */
+    public String getFenceCharacter() {
+        return fenceCharacter;
     }
 
-    public void setFenceChar(char fenceChar) {
-        this.fenceChar = fenceChar;
+    public void setFenceCharacter(String fenceCharacter) {
+        this.fenceCharacter = fenceCharacter;
     }
 
-    public int getFenceLength() {
-        return fenceLength;
+    /**
+     * @return the length of the opening fence (how many of {{@link #getFenceCharacter()}} were used to start the code
+     * block) if available, or null otherwise
+     */
+    public Integer getOpeningFenceLength() {
+        return openingFenceLength;
     }
 
-    public void setFenceLength(int fenceLength) {
-        this.fenceLength = fenceLength;
+    public void setOpeningFenceLength(Integer openingFenceLength) {
+        if (openingFenceLength != null && openingFenceLength < 3) {
+            throw new IllegalArgumentException("openingFenceLength needs to be >= 3");
+        }
+        checkFenceLengths(openingFenceLength, closingFenceLength);
+        this.openingFenceLength = openingFenceLength;
+    }
+
+    /**
+     * @return the length of the closing fence (how many of {@link #getFenceCharacter()} were used to end the code
+     * block) if available, or null otherwise
+     */
+    public Integer getClosingFenceLength() {
+        return closingFenceLength;
+    }
+
+    public void setClosingFenceLength(Integer closingFenceLength) {
+        if (closingFenceLength != null && closingFenceLength < 3) {
+            throw new IllegalArgumentException("closingFenceLength needs to be >= 3");
+        }
+        checkFenceLengths(openingFenceLength, closingFenceLength);
+        this.closingFenceLength = closingFenceLength;
     }
 
     public int getFenceIndent() {
@@ -55,5 +83,45 @@ public class FencedCodeBlock extends Block {
 
     public void setLiteral(String literal) {
         this.literal = literal;
+    }
+
+    /**
+     * @deprecated use {@link #getFenceCharacter()} instead
+     */
+    @Deprecated
+    public char getFenceChar() {
+        return fenceCharacter != null && !fenceCharacter.isEmpty() ? fenceCharacter.charAt(0) : '\0';
+    }
+
+    /**
+     * @deprecated use {@link #setFenceCharacter} instead
+     */
+    @Deprecated
+    public void setFenceChar(char fenceChar) {
+        this.fenceCharacter = fenceChar != '\0' ? String.valueOf(fenceChar) : null;
+    }
+
+    /**
+     * @deprecated use {@link #getOpeningFenceLength} instead
+     */
+    @Deprecated
+    public int getFenceLength() {
+        return openingFenceLength != null ? openingFenceLength : 0;
+    }
+
+    /**
+     * @deprecated use {@link #setOpeningFenceLength} instead
+     */
+    @Deprecated
+    public void setFenceLength(int fenceLength) {
+        this.openingFenceLength = fenceLength != 0 ? fenceLength : null;
+    }
+
+    private static void checkFenceLengths(Integer openingFenceLength, Integer closingFenceLength) {
+        if (openingFenceLength != null && closingFenceLength != null) {
+            if (closingFenceLength < openingFenceLength) {
+                throw new IllegalArgumentException("fence lengths required to be: closingFenceLength >= openingFenceLength");
+            }
+        }
     }
 }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -52,6 +52,23 @@ public class MarkdownRendererTest {
         assertRoundTrip("```info\ntest\n```\n");
         assertRoundTrip(" ```\n test\n ```\n");
         assertRoundTrip("```\n```\n");
+
+        // Preserve the length
+        assertRoundTrip("````\ntest\n````\n");
+        assertRoundTrip("~~~\ntest\n~~~~~~\n");
+    }
+
+    @Test
+    public void testFencedCodeBlocksFromAst() {
+        var doc = new Document();
+        var codeBlock = new FencedCodeBlock();
+        codeBlock.setLiteral("hi code");
+        doc.appendChild(codeBlock);
+
+        assertRendering("", "```\nhi code\n```\n", render(doc));
+
+        codeBlock.setLiteral("hi`\n```\n``test");
+        assertRendering("", "````\nhi`\n```\n``test\n````\n", render(doc));
     }
 
     @Test


### PR DESCRIPTION
Similar to #311, manually creating a fenced code block should just work without having to set fence characters or fence lengths.