### PR TITLE
Allow to add inline parsers to built-in implementation

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -76,6 +76,12 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         return scanner;
     }
 
+    public InlineParser addInlineParser(Character c, List<InlineContentParser> parsers) {
+        this.inlineParsers.put(c, parsers);
+        this.specialCharacters.set(c);
+        return this;
+    }
+
     private static void addDelimiterProcessors(Iterable<DelimiterProcessor> delimiterProcessors, Map<Character, DelimiterProcessor> map) {
         for (DelimiterProcessor delimiterProcessor : delimiterProcessors) {
             char opening = delimiterProcessor.getOpeningCharacter();


### PR DESCRIPTION
This is a minimal proposal for allowing the current internal implementation to customize inline parsing of special characters, following @robinst advice to provide a starting POC :-).

I quickly tested this in combination with `Parser.Builder.inlineParserFactory` in the context of a clojure application for parsing inline latex delimited between pairs of $ characters, but proper testing is still missing. It's a first step to see what's possible, far from providing enough fine-grained customization.

Addresses #263. Closes #317.