### PR TITLE
Clean up usages of some old Java APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ class IndentedCodeBlockNodeRenderer implements NodeRenderer {
     @Override
     public Set<Class<? extends Node>> getNodeTypes() {
         // Return the node types we want to use this renderer for.
-        return Collections.<Class<? extends Node>>singleton(IndentedCodeBlock.class);
+        return Set.of(IndentedCodeBlock.class);
     }
 
     @Override
@@ -274,7 +274,7 @@ Then, configure the extension on the builders:
 ```java
 import org.commonmark.ext.gfm.tables.TablesExtension;
 
-List<Extension> extensions = Arrays.asList(TablesExtension.create());
+List<Extension> extensions = List.of(TablesExtension.create());
 Parser parser = Parser.builder()
         .extensions(extensions)
         .build();

--- a/commonmark-ext-autolink/src/test/java/org/commonmark/ext/autolink/AutolinkTest.java
+++ b/commonmark-ext-autolink/src/test/java/org/commonmark/ext/autolink/AutolinkTest.java
@@ -8,17 +8,15 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class AutolinkTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(AutolinkExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(AutolinkExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
@@ -73,43 +71,43 @@ public class AutolinkTest extends RenderingTestCase {
 
         Paragraph paragraph = (Paragraph) document.getFirstChild();
         Text abc = (Text) paragraph.getFirstChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 3)),
+        assertEquals(List.of(SourceSpan.of(0, 0, 3)),
                 abc.getSourceSpans());
 
         assertTrue(abc.getNext() instanceof SoftLineBreak);
 
         Link one = (Link) abc.getNext().getNext();
         assertEquals("http://example.com/one", one.getDestination());
-        assertEquals(Arrays.asList(SourceSpan.of(1, 0, 22)),
+        assertEquals(List.of(SourceSpan.of(1, 0, 22)),
                 one.getSourceSpans());
 
         assertTrue(one.getNext() instanceof SoftLineBreak);
 
         Text def = (Text) one.getNext().getNext();
         assertEquals("def ", def.getLiteral());
-        assertEquals(Arrays.asList(SourceSpan.of(2, 0, 4)),
+        assertEquals(List.of(SourceSpan.of(2, 0, 4)),
                 def.getSourceSpans());
 
         Link two = (Link) def.getNext();
         assertEquals("http://example.com/two", two.getDestination());
-        assertEquals(Arrays.asList(SourceSpan.of(2, 4, 22)),
+        assertEquals(List.of(SourceSpan.of(2, 4, 22)),
                 two.getSourceSpans());
 
         assertTrue(two.getNext() instanceof SoftLineBreak);
 
         Text ghi = (Text) two.getNext().getNext();
         assertEquals("ghi ", ghi.getLiteral());
-        assertEquals(Arrays.asList(SourceSpan.of(3, 0, 4)),
+        assertEquals(List.of(SourceSpan.of(3, 0, 4)),
                 ghi.getSourceSpans());
 
         Link three = (Link) ghi.getNext();
         assertEquals("http://example.com/three", three.getDestination());
-        assertEquals(Arrays.asList(SourceSpan.of(3, 4, 24)),
+        assertEquals(List.of(SourceSpan.of(3, 4, 24)),
                 three.getSourceSpans());
 
         Text jkl = (Text) three.getNext();
         assertEquals(" jkl", jkl.getLiteral());
-        assertEquals(Arrays.asList(SourceSpan.of(3, 28, 4)),
+        assertEquals(List.of(SourceSpan.of(3, 28, 4)),
                 jkl.getSourceSpans());
     }
 

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
@@ -17,7 +17,6 @@ import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentNodeRendererFactory;
 import org.commonmark.renderer.text.TextContentRenderer;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -106,7 +105,7 @@ public class StrikethroughExtension implements Parser.ParserExtension, HtmlRende
 
             @Override
             public Set<Character> getSpecialCharacters() {
-                return Collections.singleton('~');
+                return Set.of('~');
             }
         });
     }

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughHtmlNodeRenderer.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughHtmlNodeRenderer.java
@@ -1,10 +1,9 @@
 package org.commonmark.ext.gfm.strikethrough.internal;
 
-import org.commonmark.renderer.html.HtmlWriter;
-import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.node.Node;
+import org.commonmark.renderer.html.HtmlNodeRendererContext;
+import org.commonmark.renderer.html.HtmlWriter;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class StrikethroughHtmlNodeRenderer extends StrikethroughNodeRenderer {
@@ -19,7 +18,7 @@ public class StrikethroughHtmlNodeRenderer extends StrikethroughNodeRenderer {
 
     @Override
     public void render(Node node) {
-        Map<String, String> attributes = context.extendAttributes(node, "del", Collections.<String, String>emptyMap());
+        Map<String, String> attributes = context.extendAttributes(node, "del", Map.of());
         html.tag("del", attributes);
         renderChildren(node);
         html.tag("/del");

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughNodeRenderer.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughNodeRenderer.java
@@ -4,13 +4,12 @@ import org.commonmark.ext.gfm.strikethrough.Strikethrough;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.NodeRenderer;
 
-import java.util.Collections;
 import java.util.Set;
 
 abstract class StrikethroughNodeRenderer implements NodeRenderer {
 
     @Override
     public Set<Class<? extends Node>> getNodeTypes() {
-        return Collections.<Class<? extends Node>>singleton(Strikethrough.class);
+        return Set.of(Strikethrough.class);
     }
 }

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughMarkdownRendererTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughMarkdownRendererTest.java
@@ -5,14 +5,13 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
 public class StrikethroughMarkdownRendererTest {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(StrikethroughExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(StrikethroughExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughSpecTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughSpecTest.java
@@ -12,14 +12,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 @RunWith(Parameterized.class)
 public class StrikethroughSpecTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(StrikethroughExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(StrikethroughExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughTest.java
@@ -14,15 +14,14 @@ import org.commonmark.renderer.text.TextContentRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
-import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 
 public class StrikethroughTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = singleton(StrikethroughExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(StrikethroughExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
     private static final TextContentRenderer CONTENT_RENDERER = TextContentRenderer.builder()
@@ -98,7 +97,7 @@ public class StrikethroughTest extends RenderingTestCase {
     @Test
     public void requireTwoTildesOption() {
         Parser parser = Parser.builder()
-                .extensions(singleton(StrikethroughExtension.builder()
+                .extensions(Set.of(StrikethroughExtension.builder()
                         .requireTwoTildes(true)
                         .build()))
                 .customDelimiterProcessor(new SubscriptDelimiterProcessor())
@@ -118,7 +117,7 @@ public class StrikethroughTest extends RenderingTestCase {
         Node document = parser.parse("hey ~~there~~\n");
         Paragraph block = (Paragraph) document.getFirstChild();
         Node strikethrough = block.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 4, 9)),
+        assertEquals(List.of(SourceSpan.of(0, 4, 9)),
                 strikethrough.getSourceSpans());
     }
 

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
@@ -17,7 +17,6 @@ import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentNodeRendererFactory;
 import org.commonmark.renderer.text.TextContentRenderer;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -78,7 +77,7 @@ public class TablesExtension implements Parser.ParserExtension, HtmlRenderer.Htm
 
             @Override
             public Set<Character> getSpecialCharacters() {
-                return Collections.singleton('|');
+                return Set.of('|');
             }
         });
     }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableHtmlNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableHtmlNodeRenderer.java
@@ -5,7 +5,6 @@ import org.commonmark.node.Node;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlWriter;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class TableHtmlNodeRenderer extends TableNodeRenderer {
@@ -60,14 +59,14 @@ public class TableHtmlNodeRenderer extends TableNodeRenderer {
     }
 
     private Map<String, String> getAttributes(Node node, String tagName) {
-        return context.extendAttributes(node, tagName, Collections.<String, String>emptyMap());
+        return context.extendAttributes(node, tagName, Map.of());
     }
 
     private Map<String, String> getCellAttributes(TableCell tableCell, String tagName) {
         if (tableCell.getAlignment() != null) {
-            return context.extendAttributes(tableCell, tagName, Collections.singletonMap("align", getAlignValue(tableCell.getAlignment())));
+            return context.extendAttributes(tableCell, tagName, Map.of("align", getAlignValue(tableCell.getAlignment())));
         } else {
-            return context.extendAttributes(tableCell, tagName, Collections.<String, String>emptyMap());
+            return context.extendAttributes(tableCell, tagName, Map.of());
         }
     }
 

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableNodeRenderer.java
@@ -1,28 +1,22 @@
 package org.commonmark.ext.gfm.tables.internal;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.commonmark.ext.gfm.tables.TableBlock;
-import org.commonmark.ext.gfm.tables.TableBody;
-import org.commonmark.ext.gfm.tables.TableCell;
-import org.commonmark.ext.gfm.tables.TableHead;
-import org.commonmark.ext.gfm.tables.TableRow;
+import org.commonmark.ext.gfm.tables.*;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.NodeRenderer;
+
+import java.util.Set;
 
 abstract class TableNodeRenderer implements NodeRenderer {
 
     @Override
     public Set<Class<? extends Node>> getNodeTypes() {
-        return new HashSet<>(Arrays.asList(
+        return Set.of(
                 TableBlock.class,
                 TableHead.class,
                 TableBody.class,
                 TableRow.class,
                 TableCell.class
-        ));
+        );
     }
 
     @Override

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TableMarkdownRendererTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TableMarkdownRendererTest.java
@@ -5,14 +5,13 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
 public class TableMarkdownRendererTest {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(TablesExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesSpecTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesSpecTest.java
@@ -12,15 +12,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 @RunWith(Parameterized.class)
 public class TablesSpecTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(TablesExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -12,10 +12,7 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -23,7 +20,7 @@ import static org.junit.Assert.assertThat;
 
 public class TablesTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(TablesExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
@@ -794,49 +791,49 @@ public class TablesTest extends RenderingTestCase {
         Node document = parser.parse("Abc|Def\n---|---\n|1|2\n 3|four|\n|||\n");
 
         TableBlock block = (TableBlock) document.getFirstChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 7),
+        assertEquals(List.of(SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 7),
                         SourceSpan.of(2, 0, 4), SourceSpan.of(3, 0, 8), SourceSpan.of(4, 0, 3)),
                 block.getSourceSpans());
 
         TableHead head = (TableHead) block.getFirstChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 7)), head.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 7)), head.getSourceSpans());
 
         TableRow headRow = (TableRow) head.getFirstChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 7)), headRow.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 7)), headRow.getSourceSpans());
         TableCell headRowCell1 = (TableCell) headRow.getFirstChild();
         TableCell headRowCell2 = (TableCell) headRow.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 3)), headRowCell1.getSourceSpans());
-        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 3)), headRowCell1.getFirstChild().getSourceSpans());
-        assertEquals(Arrays.asList(SourceSpan.of(0, 4, 3)), headRowCell2.getSourceSpans());
-        assertEquals(Arrays.asList(SourceSpan.of(0, 4, 3)), headRowCell2.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 3)), headRowCell1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 3)), headRowCell1.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 4, 3)), headRowCell2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 4, 3)), headRowCell2.getFirstChild().getSourceSpans());
 
         TableBody body = (TableBody) block.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(2, 0, 4), SourceSpan.of(3, 0, 8), SourceSpan.of(4, 0, 3)), body.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 0, 4), SourceSpan.of(3, 0, 8), SourceSpan.of(4, 0, 3)), body.getSourceSpans());
 
         TableRow bodyRow1 = (TableRow) body.getFirstChild();
-        assertEquals(Arrays.asList(SourceSpan.of(2, 0, 4)), bodyRow1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 0, 4)), bodyRow1.getSourceSpans());
         TableCell bodyRow1Cell1 = (TableCell) bodyRow1.getFirstChild();
         TableCell bodyRow1Cell2 = (TableCell) bodyRow1.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(2, 1, 1)), bodyRow1Cell1.getSourceSpans());
-        assertEquals(Arrays.asList(SourceSpan.of(2, 1, 1)), bodyRow1Cell1.getFirstChild().getSourceSpans());
-        assertEquals(Arrays.asList(SourceSpan.of(2, 3, 1)), bodyRow1Cell2.getSourceSpans());
-        assertEquals(Arrays.asList(SourceSpan.of(2, 3, 1)), bodyRow1Cell2.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 1, 1)), bodyRow1Cell1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 1, 1)), bodyRow1Cell1.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 3, 1)), bodyRow1Cell2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 3, 1)), bodyRow1Cell2.getFirstChild().getSourceSpans());
 
         TableRow bodyRow2 = (TableRow) body.getFirstChild().getNext();
-        assertEquals(Arrays.asList(SourceSpan.of(3, 0, 8)), bodyRow2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 0, 8)), bodyRow2.getSourceSpans());
         TableCell bodyRow2Cell1 = (TableCell) bodyRow2.getFirstChild();
         TableCell bodyRow2Cell2 = (TableCell) bodyRow2.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getSourceSpans());
-        assertEquals(Arrays.asList(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getFirstChild().getSourceSpans());
-        assertEquals(Arrays.asList(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getSourceSpans());
-        assertEquals(Arrays.asList(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getFirstChild().getSourceSpans());
 
         TableRow bodyRow3 = (TableRow) body.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(4, 0, 3)), bodyRow3.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(4, 0, 3)), bodyRow3.getSourceSpans());
         TableCell bodyRow3Cell1 = (TableCell) bodyRow3.getFirstChild();
         TableCell bodyRow3Cell2 = (TableCell) bodyRow3.getLastChild();
-        assertEquals(Collections.emptyList(), bodyRow3Cell1.getSourceSpans());
-        assertEquals(Collections.emptyList(), bodyRow3Cell2.getSourceSpans());
+        assertEquals(List.of(), bodyRow3Cell1.getSourceSpans());
+        assertEquals(List.of(), bodyRow3Cell2.getSourceSpans());
     }
 
     @Override

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTextContentTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTextContentTest.java
@@ -6,12 +6,11 @@ import org.commonmark.renderer.text.TextContentRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Set;
 
 public class TablesTextContentTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(TablesExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final TextContentRenderer RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS).build();
 

--- a/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorConfigurationTest.java
+++ b/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorConfigurationTest.java
@@ -5,7 +5,7 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,14 +21,14 @@ public class HeadingAnchorConfigurationTest {
                 .idSuffix(suffix)
                 .build();
         return HtmlRenderer.builder()
-                .extensions(Arrays.asList(ext))
+                .extensions(List.of(ext))
                 .build();
     }
 
     @Test
     public void testDefaultConfigurationHasNoAdditions() {
         HtmlRenderer renderer = HtmlRenderer.builder()
-                .extensions(Arrays.asList(HeadingAnchorExtension.create()))
+                .extensions(List.of(HeadingAnchorExtension.create()))
                 .build();
         assertThat(doRender(renderer, "# "), equalTo("<h1 id=\"id\"></h1>\n"));
     }

--- a/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorTest.java
+++ b/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorTest.java
@@ -6,12 +6,11 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Set;
 
 public class HeadingAnchorTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(HeadingAnchorExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(HeadingAnchorExtension.create());
     private static final Parser PARSER = Parser.builder().build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 

--- a/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesDelimiterProcessor.java
+++ b/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesDelimiterProcessor.java
@@ -13,8 +13,7 @@ import java.util.*;
 public class ImageAttributesDelimiterProcessor implements DelimiterProcessor {
 
     // Only allow a defined set of attributes to be used.
-    private static final Set<String> SUPPORTED_ATTRIBUTES = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList("width", "height")));
+    private static final Set<String> SUPPORTED_ATTRIBUTES = Set.of("width", "height");
 
     @Override
     public char getOpeningCharacter() {

--- a/commonmark-ext-image-attributes/src/test/java/org/commonmark/ext/image/attributes/ImageAttributesTest.java
+++ b/commonmark-ext-image-attributes/src/test/java/org/commonmark/ext/image/attributes/ImageAttributesTest.java
@@ -10,15 +10,14 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
 public class ImageAttributesTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(ImageAttributesExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(ImageAttributesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
@@ -132,7 +131,7 @@ public class ImageAttributesTest extends RenderingTestCase {
         Node document = parser.parse("x{height=3 width=4}\n");
         Paragraph block = (Paragraph) document.getFirstChild();
         Node text = block.getFirstChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 19)),
+        assertEquals(List.of(SourceSpan.of(0, 0, 19)),
                 text.getSourceSpans());
     }
 

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/InsExtension.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/InsExtension.java
@@ -17,7 +17,6 @@ import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentNodeRendererFactory;
 import org.commonmark.renderer.text.TextContentRenderer;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -77,7 +76,7 @@ public class InsExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRe
             public Set<Character> getSpecialCharacters() {
                 // We technically don't need to escape single occurrences of +, but that's all the extension API
                 // exposes currently.
-                return Collections.singleton('+');
+                return Set.of('+');
             }
         });
     }

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsHtmlNodeRenderer.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsHtmlNodeRenderer.java
@@ -4,7 +4,6 @@ import org.commonmark.node.Node;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlWriter;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class InsHtmlNodeRenderer extends InsNodeRenderer {
@@ -19,7 +18,7 @@ public class InsHtmlNodeRenderer extends InsNodeRenderer {
 
     @Override
     public void render(Node node) {
-        Map<String, String> attributes = context.extendAttributes(node, "ins", Collections.<String, String>emptyMap());
+        Map<String, String> attributes = context.extendAttributes(node, "ins", Map.of());
         html.tag("ins", attributes);
         renderChildren(node);
         html.tag("/ins");

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsNodeRenderer.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsNodeRenderer.java
@@ -4,13 +4,12 @@ import org.commonmark.ext.ins.Ins;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.NodeRenderer;
 
-import java.util.Collections;
 import java.util.Set;
 
 abstract class InsNodeRenderer implements NodeRenderer {
 
     @Override
     public Set<Class<? extends Node>> getNodeTypes() {
-        return Collections.<Class<? extends Node>>singleton(Ins.class);
+        return Set.of(Ins.class);
     }
 }

--- a/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsMarkdownRendererTest.java
+++ b/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsMarkdownRendererTest.java
@@ -5,14 +5,13 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
 public class InsMarkdownRendererTest {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(InsExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(InsExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 

--- a/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsTest.java
+++ b/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsTest.java
@@ -11,15 +11,14 @@ import org.commonmark.renderer.text.TextContentRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
 public class InsTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(InsExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(InsExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
     private static final TextContentRenderer CONTENT_RENDERER = TextContentRenderer.builder()
@@ -103,7 +102,7 @@ public class InsTest extends RenderingTestCase {
         Node document = parser.parse("hey ++there++\n");
         Paragraph block = (Paragraph) document.getFirstChild();
         Node ins = block.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 4, 9)),
+        assertEquals(List.of(SourceSpan.of(0, 4, 9)),
                 ins.getSourceSpans());
     }
 

--- a/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/internal/TaskListItemHtmlNodeRenderer.java
+++ b/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/internal/TaskListItemHtmlNodeRenderer.java
@@ -6,7 +6,6 @@ import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlWriter;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -23,7 +22,7 @@ public class TaskListItemHtmlNodeRenderer implements NodeRenderer {
 
     @Override
     public Set<Class<? extends Node>> getNodeTypes() {
-        return Collections.<Class<? extends Node>>singleton(TaskListItemMarker.class);
+        return Set.of(TaskListItemMarker.class);
     }
 
     @Override

--- a/commonmark-ext-task-list-items/src/test/java/org/commonmark/ext/task/list/items/TaskListItemsTest.java
+++ b/commonmark-ext-task-list-items/src/test/java/org/commonmark/ext/task/list/items/TaskListItemsTest.java
@@ -6,12 +6,11 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Set;
 
 public class TaskListItemsTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(TaskListItemsExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(TaskListItemsExtension.create());
     private static final String HTML_CHECKED = "<input type=\"checkbox\" disabled=\"\" checked=\"\">";
     private static final String HTML_UNCHECKED = "<input type=\"checkbox\" disabled=\"\">";
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();

--- a/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterTest.java
+++ b/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterTest.java
@@ -8,7 +8,6 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -17,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class YamlFrontMatterTest extends RenderingTestCase {
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(YamlFrontMatterExtension.create());
+    private static final Set<Extension> EXTENSIONS = Set.of(YamlFrontMatterExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
@@ -243,7 +242,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
         Map<String, List<String>> data = visitor.getData();
         assertEquals(1, data.size());
         assertTrue(data.containsKey("hello"));
-        assertEquals(Collections.singletonList("world"), data.get("hello"));
+        assertEquals(List.of("world"), data.get("hello"));
     }
 
     @Test
@@ -256,7 +255,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
         Node document = PARSER.parse(input);
         YamlFrontMatterNode node = (YamlFrontMatterNode) document.getFirstChild().getFirstChild();
         node.setKey("see");
-        node.setValues(Collections.singletonList("you"));
+        node.setValues(List.of("you"));
 
         YamlFrontMatterVisitor visitor = new YamlFrontMatterVisitor();
         document.accept(visitor);
@@ -264,7 +263,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
         Map<String, List<String>> data = visitor.getData();
         assertEquals(1, data.size());
         assertTrue(data.containsKey("see"));
-        assertEquals(Collections.singletonList("you"), data.get("see"));
+        assertEquals(List.of("you"), data.get("see"));
     }
 
     @Test

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/Extensions.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/Extensions.java
@@ -9,12 +9,11 @@ import org.commonmark.ext.image.attributes.ImageAttributesExtension;
 import org.commonmark.ext.ins.InsExtension;
 import org.commonmark.ext.task.list.items.TaskListItemsExtension;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class Extensions {
 
-    static final List<Extension> ALL_EXTENSIONS = Arrays.asList(
+    static final List<Extension> ALL_EXTENSIONS = List.of(
             AutolinkExtension.create(),
             ImageAttributesExtension.create(),
             InsExtension.create(),

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/MarkdownRendererIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/MarkdownRendererIntegrationTest.java
@@ -12,14 +12,13 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class MarkdownRendererIntegrationTest {
 
-    private static final List<Extension> EXTENSIONS = Arrays.asList(
+    private static final List<Extension> EXTENSIONS = List.of(
             AutolinkExtension.create(),
             ImageAttributesExtension.create(),
             InsExtension.create(),

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/PegDownBenchmark.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/PegDownBenchmark.java
@@ -12,7 +12,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.pegdown.Extensions;
 import org.pegdown.PegDownProcessor;
 
-import java.util.Collections;
 import java.util.List;
 
 @State(Scope.Benchmark)
@@ -32,7 +31,7 @@ public class PegDownBenchmark {
 
     @Benchmark
     public long wholeSpec() {
-        return parseAndRender(Collections.singletonList(SPEC));
+        return parseAndRender(List.of(SPEC));
     }
 
     @Benchmark

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.List;
 
 public class TestResources {
@@ -19,7 +18,7 @@ public class TestResources {
     }
 
     public static List<URL> getRegressions() {
-        return Arrays.asList(
+        return List.of(
                 TestResources.class.getResource("/cmark-regression.txt"),
                 TestResources.class.getResource("/commonmark.js-regression.txt")
         );

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
@@ -4,7 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class TestResources {
@@ -26,7 +26,7 @@ public class TestResources {
 
     public static String readAsString(URL url) {
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), Charset.forName("UTF-8")))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 sb.append(line);

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/example/ExampleReader.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/example/ExampleReader.java
@@ -2,7 +2,7 @@ package org.commonmark.testutil.example;
 
 import java.io.*;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -66,7 +66,7 @@ public class ExampleReader {
         resetContents();
 
         try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(inputStream, Charset.forName("UTF-8")))) {
+                new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 processLine(line);

--- a/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
@@ -15,7 +15,7 @@ import java.util.*;
 
 public class DocumentParser implements ParserState {
 
-    private static final Set<Class<? extends Block>> CORE_FACTORY_TYPES = new LinkedHashSet<>(Arrays.asList(
+    private static final Set<Class<? extends Block>> CORE_FACTORY_TYPES = new LinkedHashSet<>(List.of(
             BlockQuote.class,
             Heading.class,
             FencedCodeBlock.class,

--- a/commonmark/src/main/java/org/commonmark/internal/util/Escaping.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Escaping.java
@@ -1,6 +1,7 @@
 package org.commonmark.internal.util;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -49,7 +50,7 @@ public class Escaping {
                     sb.append(input, 1, input.length());
                 }
             } else {
-                byte[] bytes = input.getBytes(Charset.forName("UTF-8"));
+                byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
                 for (byte b : bytes) {
                     sb.append('%');
                     sb.append(HEX_DIGITS[(b >> 4) & 0xF]);

--- a/commonmark/src/main/java/org/commonmark/node/Node.java
+++ b/commonmark/src/main/java/org/commonmark/node/Node.java
@@ -120,7 +120,7 @@ public abstract class Node {
      * @since 0.16.0
      */
     public List<SourceSpan> getSourceSpans() {
-        return sourceSpans != null ? Collections.unmodifiableList(sourceSpans) : Collections.<SourceSpan>emptyList();
+        return sourceSpans != null ? Collections.unmodifiableList(sourceSpans) : List.of();
     }
 
     /**

--- a/commonmark/src/main/java/org/commonmark/node/SourceSpans.java
+++ b/commonmark/src/main/java/org/commonmark/node/SourceSpans.java
@@ -1,7 +1,6 @@
 package org.commonmark.node;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -18,7 +17,7 @@ public class SourceSpans {
     }
 
     public List<SourceSpan> getSourceSpans() {
-        return sourceSpans != null ? sourceSpans : Collections.<SourceSpan>emptyList();
+        return sourceSpans != null ? sourceSpans : List.of();
     }
 
     public void addAllFrom(Iterable<? extends Node> nodes) {

--- a/commonmark/src/main/java/org/commonmark/parser/Parser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/Parser.java
@@ -169,7 +169,7 @@ public class Parser {
          * E.g., to only parse headings and lists:
          * <pre>
          *     {@code
-         *     Parser.builder().enabledBlockTypes(new HashSet<>(Arrays.asList(Heading.class, ListBlock.class)));
+         *     Parser.builder().enabledBlockTypes(Set.of(Heading.class, ListBlock.class));
          *     }
          * </pre>
          *

--- a/commonmark/src/main/java/org/commonmark/parser/Parser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/Parser.java
@@ -67,9 +67,7 @@ public class Parser {
      * @return the root node
      */
     public Node parse(String input) {
-        if (input == null) {
-            throw new NullPointerException("input must not be null");
-        }
+        Objects.requireNonNull(input, "input must not be null");
         DocumentParser documentParser = createDocumentParser();
         Node document = documentParser.parse(input);
         return postProcess(document);
@@ -94,10 +92,7 @@ public class Parser {
      * @throws IOException when reading throws an exception
      */
     public Node parseReader(Reader input) throws IOException {
-        if (input == null) {
-            throw new NullPointerException("input must not be null");
-        }
-
+        Objects.requireNonNull(input, "input must not be null");
         DocumentParser documentParser = createDocumentParser();
         Node document = documentParser.parse(input);
         return postProcess(document);
@@ -138,9 +133,7 @@ public class Parser {
          * @return {@code this}
          */
         public Builder extensions(Iterable<? extends Extension> extensions) {
-            if (extensions == null) {
-                throw new NullPointerException("extensions must not be null");
-            }
+            Objects.requireNonNull(extensions, "extensions must not be null");
             for (Extension extension : extensions) {
                 if (extension instanceof ParserExtension) {
                     ParserExtension parserExtension = (ParserExtension) extension;
@@ -178,9 +171,7 @@ public class Parser {
          * @return {@code this}
          */
         public Builder enabledBlockTypes(Set<Class<? extends Block>> enabledBlockTypes) {
-            if (enabledBlockTypes == null) {
-                throw new NullPointerException("enabledBlockTypes must not be null");
-            }
+            Objects.requireNonNull(enabledBlockTypes, "enabledBlockTypes must not be null");
             DocumentParser.checkEnabledBlockTypes(enabledBlockTypes);
             this.enabledBlockTypes = enabledBlockTypes;
             return this;
@@ -211,9 +202,7 @@ public class Parser {
          * @return {@code this}
          */
         public Builder customBlockParserFactory(BlockParserFactory blockParserFactory) {
-            if (blockParserFactory == null) {
-                throw new NullPointerException("blockParserFactory must not be null");
-            }
+            Objects.requireNonNull(blockParserFactory, "blockParserFactory must not be null");
             blockParserFactories.add(blockParserFactory);
             return this;
         }
@@ -246,17 +235,13 @@ public class Parser {
          * @return {@code this}
          */
         public Builder customDelimiterProcessor(DelimiterProcessor delimiterProcessor) {
-            if (delimiterProcessor == null) {
-                throw new NullPointerException("delimiterProcessor must not be null");
-            }
+            Objects.requireNonNull(delimiterProcessor, "delimiterProcessor must not be null");
             delimiterProcessors.add(delimiterProcessor);
             return this;
         }
 
         public Builder postProcessor(PostProcessor postProcessor) {
-            if (postProcessor == null) {
-                throw new NullPointerException("postProcessor must not be null");
-            }
+            Objects.requireNonNull(postProcessor, "postProcessor must not be null");
             postProcessors.add(postProcessor);
             return this;
         }

--- a/commonmark/src/main/java/org/commonmark/parser/SourceLine.java
+++ b/commonmark/src/main/java/org/commonmark/parser/SourceLine.java
@@ -2,6 +2,8 @@ package org.commonmark.parser;
 
 import org.commonmark.node.SourceSpan;
 
+import java.util.Objects;
+
 /**
  * A line or part of a line from the input source.
  *
@@ -17,10 +19,7 @@ public class SourceLine {
     }
 
     private SourceLine(CharSequence content, SourceSpan sourceSpan) {
-        if (content == null) {
-            throw new NullPointerException("content must not be null");
-        }
-        this.content = content;
+        this.content = Objects.requireNonNull(content, "content must not be null");
         this.sourceSpan = sourceSpan;
     }
 

--- a/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
@@ -3,7 +3,9 @@ package org.commonmark.renderer.html;
 import org.commonmark.node.*;
 import org.commonmark.renderer.NodeRenderer;
 
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * The node renderer that renders all the core nodes (comes last in the order of node renderers).
@@ -20,7 +22,7 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
 
     @Override
     public Set<Class<? extends Node>> getNodeTypes() {
-        return new HashSet<>(Arrays.asList(
+        return Set.of(
                 Document.class,
                 Heading.class,
                 Paragraph.class,
@@ -41,7 +43,7 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
                 HtmlInline.class,
                 SoftLineBreak.class,
                 HardLineBreak.class
-        ));
+        );
     }
 
     @Override
@@ -135,7 +137,7 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
 
     @Override
     public void visit(IndentedCodeBlock indentedCodeBlock) {
-        renderCodeBlock(indentedCodeBlock.getLiteral(), indentedCodeBlock, Collections.<String, String>emptyMap());
+        renderCodeBlock(indentedCodeBlock.getLiteral(), indentedCodeBlock, Map.of());
     }
 
     @Override
@@ -287,7 +289,7 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
     }
 
     private Map<String, String> getAttrs(Node node, String tagName) {
-        return getAttrs(node, tagName, Collections.<String, String>emptyMap());
+        return getAttrs(node, tagName, Map.of());
     }
 
     private Map<String, String> getAttrs(Node node, String tagName, Map<String, String> defaultAttributes) {

--- a/commonmark/src/main/java/org/commonmark/renderer/html/DefaultUrlSanitizer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/DefaultUrlSanitizer.java
@@ -1,9 +1,6 @@
 package org.commonmark.renderer.html;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 /**
  *
@@ -15,7 +12,7 @@ public class DefaultUrlSanitizer implements UrlSanitizer {
     private Set<String> protocols;
 
     public DefaultUrlSanitizer() {
-        this(Arrays.asList("http", "https", "mailto"));
+        this(List.of("http", "https", "mailto"));
     }
 
     public DefaultUrlSanitizer(Collection<String> protocols) {

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
@@ -7,10 +7,7 @@ import org.commonmark.node.*;
 import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.Renderer;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Renders a tree of nodes to HTML.
@@ -61,18 +58,14 @@ public class HtmlRenderer implements Renderer {
 
     @Override
     public void render(Node node, Appendable output) {
-        if (node == null) {
-            throw new NullPointerException("node must not be null");
-        }
+        Objects.requireNonNull(node, "node must not be null");
         RendererContext context = new RendererContext(new HtmlWriter(output));
         context.render(node);
     }
 
     @Override
     public String render(Node node) {
-        if (node == null) {
-            throw new NullPointerException("node must not be null");
-        }
+        Objects.requireNonNull(node, "node must not be null");
         StringBuilder sb = new StringBuilder();
         render(node, sb);
         return sb.toString();
@@ -178,9 +171,7 @@ public class HtmlRenderer implements Renderer {
          * @return {@code this}
          */
         public Builder attributeProviderFactory(AttributeProviderFactory attributeProviderFactory) {
-            if (attributeProviderFactory == null) {
-                throw new NullPointerException("attributeProviderFactory must not be null");
-            }
+            Objects.requireNonNull(attributeProviderFactory, "attributeProviderFactory must not be null");
             this.attributeProviderFactories.add(attributeProviderFactory);
             return this;
         }
@@ -196,9 +187,7 @@ public class HtmlRenderer implements Renderer {
          * @return {@code this}
          */
         public Builder nodeRendererFactory(HtmlNodeRendererFactory nodeRendererFactory) {
-            if (nodeRendererFactory == null) {
-                throw new NullPointerException("nodeRendererFactory must not be null");
-            }
+            Objects.requireNonNull(nodeRendererFactory, "nodeRendererFactory must not be null");
             this.nodeRendererFactories.add(nodeRendererFactory);
             return this;
         }
@@ -208,9 +197,7 @@ public class HtmlRenderer implements Renderer {
          * @return {@code this}
          */
         public Builder extensions(Iterable<? extends Extension> extensions) {
-            if (extensions == null) {
-                throw new NullPointerException("extensions must not be null");
-            }
+            Objects.requireNonNull(extensions, "extensions must not be null");
             for (Extension extension : extensions) {
                 if (extension instanceof HtmlRendererExtension) {
                     HtmlRendererExtension htmlRendererExtension = (HtmlRendererExtension) extension;

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlWriter.java
@@ -3,12 +3,11 @@ package org.commonmark.renderer.html;
 import org.commonmark.internal.util.Escaping;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 
 public class HtmlWriter {
 
-    private static final Map<String, String> NO_ATTRIBUTES = Collections.emptyMap();
+    private static final Map<String, String> NO_ATTRIBUTES = Map.of();
 
     private final Appendable buffer;
     private char lastChar = 0;

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlWriter.java
@@ -4,6 +4,7 @@ import org.commonmark.internal.util.Escaping;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 public class HtmlWriter {
 
@@ -13,9 +14,7 @@ public class HtmlWriter {
     private char lastChar = 0;
 
     public HtmlWriter(Appendable out) {
-        if (out == null) {
-            throw new NullPointerException("out must not be null");
-        }
+        Objects.requireNonNull(out, "out must not be null");
         this.buffer = out;
     }
 

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -1,13 +1,11 @@
 package org.commonmark.renderer.markdown;
 
-import org.commonmark.text.AsciiMatcher;
 import org.commonmark.node.*;
-import org.commonmark.text.CharMatcher;
 import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.text.AsciiMatcher;
+import org.commonmark.text.CharMatcher;
 import org.commonmark.text.Characters;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -51,7 +49,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public Set<Class<? extends Node>> getNodeTypes() {
-        return new HashSet<>(Arrays.asList(
+        return Set.of(
                 BlockQuote.class,
                 BulletList.class,
                 Code.class,
@@ -72,7 +70,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
                 StrongEmphasis.class,
                 Text.class,
                 ThematicBreak.class
-        ));
+        );
     }
 
     @Override
@@ -470,9 +468,9 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         if (parts[parts.length - 1].isEmpty()) {
             // But we don't want the last empty string, as "\n" is used as a line terminator (not a separator),
             // so return without the last element.
-            return Arrays.asList(parts).subList(0, parts.length - 1);
+            return List.of(parts).subList(0, parts.length - 1);
         } else {
-            return Arrays.asList(parts);
+            return List.of(parts);
         }
     }
 

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
@@ -38,7 +38,7 @@ public class MarkdownRenderer implements Renderer {
 
             @Override
             public Set<Character> getSpecialCharacters() {
-                return Collections.emptySet();
+                return Set.of();
             }
         });
     }

--- a/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
@@ -1,13 +1,11 @@
 package org.commonmark.renderer.text;
 
-import org.commonmark.node.*;
-import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.internal.renderer.text.BulletListHolder;
 import org.commonmark.internal.renderer.text.ListHolder;
 import org.commonmark.internal.renderer.text.OrderedListHolder;
+import org.commonmark.node.*;
+import org.commonmark.renderer.NodeRenderer;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -27,7 +25,7 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
 
     @Override
     public Set<Class<? extends Node>> getNodeTypes() {
-        return new HashSet<>(Arrays.asList(
+        return Set.of(
                 Document.class,
                 Heading.class,
                 Paragraph.class,
@@ -48,7 +46,7 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
                 HtmlInline.class,
                 SoftLineBreak.class,
                 HardLineBreak.class
-        ));
+        );
     }
 
     @Override

--- a/commonmark/src/test/java/org/commonmark/ProfilingMain.java
+++ b/commonmark/src/test/java/org/commonmark/ProfilingMain.java
@@ -6,7 +6,6 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.TestResources;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class ProfilingMain {
@@ -20,7 +19,7 @@ public class ProfilingMain {
         System.out.println("Attach profiler, then press enter to start parsing.");
         System.in.read();
         System.out.println("Parsing");
-        List<Node> nodes = parse(Collections.singletonList(SPEC));
+        List<Node> nodes = parse(List.of(SPEC));
         System.out.println("Finished parsing, press enter to start rendering");
         System.in.read();
         System.out.println(render(nodes));

--- a/commonmark/src/test/java/org/commonmark/internal/DocumentParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/internal/DocumentParserTest.java
@@ -4,18 +4,16 @@ import org.commonmark.node.*;
 import org.commonmark.parser.block.BlockParserFactory;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.HashSet;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DocumentParserTest {
-    private static List<BlockParserFactory> CORE_FACTORIES = Arrays.<BlockParserFactory>asList(
+    private static final List<BlockParserFactory> CORE_FACTORIES = List.of(
             new BlockQuoteParser.Factory(),
             new HeadingParser.Factory(),
             new FencedCodeBlockParser.Factory(),
@@ -26,10 +24,10 @@ public class DocumentParserTest {
 
     @Test
     public void calculateBlockParserFactories_givenAFullListOfAllowedNodes_includesAllCoreFactories() {
-        List<BlockParserFactory> customParserFactories = Collections.emptyList();
-        Set<Class<? extends Block>> nodes = new HashSet<>(Arrays.asList(BlockQuote.class, Heading.class, FencedCodeBlock.class, HtmlBlock.class, ThematicBreak.class, ListBlock.class, IndentedCodeBlock.class));
+        List<BlockParserFactory> customParserFactories = List.of();
+        var enabledBlockTypes = Set.of(BlockQuote.class, Heading.class, FencedCodeBlock.class, HtmlBlock.class, ThematicBreak.class, ListBlock.class, IndentedCodeBlock.class);
 
-        List<BlockParserFactory> blockParserFactories = DocumentParser.calculateBlockParserFactories(customParserFactories, nodes);
+        List<BlockParserFactory> blockParserFactories = DocumentParser.calculateBlockParserFactories(customParserFactories, enabledBlockTypes);
         assertThat(blockParserFactories.size(), is(CORE_FACTORIES.size()));
 
         for (BlockParserFactory factory : CORE_FACTORIES) {
@@ -39,7 +37,7 @@ public class DocumentParserTest {
 
     @Test
     public void calculateBlockParserFactories_givenAListOfAllowedNodes_includesAssociatedFactories() {
-        List<BlockParserFactory> customParserFactories = Collections.emptyList();
+        List<BlockParserFactory> customParserFactories = List.of();
         Set<Class<? extends Block>> nodes = new HashSet<>();
         nodes.add(IndentedCodeBlock.class);
 

--- a/commonmark/src/test/java/org/commonmark/parser/beta/ScannerTest.java
+++ b/commonmark/src/test/java/org/commonmark/parser/beta/ScannerTest.java
@@ -3,12 +3,9 @@ package org.commonmark.parser.beta;
 import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.SourceLines;
-import org.commonmark.parser.beta.Position;
-import org.commonmark.parser.beta.Scanner;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -16,7 +13,7 @@ public class ScannerTest {
 
     @Test
     public void testNext() {
-        Scanner scanner = new Scanner(Collections.singletonList(
+        Scanner scanner = new Scanner(List.of(
                 SourceLine.of("foo bar", null)),
                 0, 4);
         assertEquals('b', scanner.peek());
@@ -30,7 +27,7 @@ public class ScannerTest {
 
     @Test
     public void testMultipleLines() {
-        Scanner scanner = new Scanner(Arrays.asList(
+        Scanner scanner = new Scanner(List.of(
                 SourceLine.of("ab", null),
                 SourceLine.of("cde", null)),
                 0, 0);
@@ -71,7 +68,7 @@ public class ScannerTest {
 
     @Test
     public void testCodePoints() {
-        Scanner scanner = new Scanner(Arrays.asList(SourceLine.of("\uD83D\uDE0A", null)), 0, 0);
+        Scanner scanner = new Scanner(List.of(SourceLine.of("\uD83D\uDE0A", null)), 0, 0);
 
         assertTrue(scanner.hasNext());
         assertEquals('\0', scanner.peekPreviousCodePoint());
@@ -87,7 +84,7 @@ public class ScannerTest {
 
     @Test
     public void testTextBetween() {
-        Scanner scanner = new Scanner(Arrays.asList(
+        Scanner scanner = new Scanner(List.of(
                 SourceLine.of("ab", SourceSpan.of(10, 3, 2)),
                 SourceLine.of("cde", SourceSpan.of(11, 4, 3))),
                 0, 0);
@@ -143,12 +140,12 @@ public class ScannerTest {
 
     private void assertSourceLines(SourceLines sourceLines, String expectedContent, SourceSpan... expectedSourceSpans) {
         assertEquals(expectedContent, sourceLines.getContent());
-        assertEquals(Arrays.asList(expectedSourceSpans), sourceLines.getSourceSpans());
+        assertEquals(List.of(expectedSourceSpans), sourceLines.getSourceSpans());
     }
 
     @Test
     public void nextString() {
-        Scanner scanner = Scanner.of(SourceLines.of(Arrays.asList(
+        Scanner scanner = Scanner.of(SourceLines.of(List.of(
                 SourceLine.of("hey ya", null),
                 SourceLine.of("hi", null))));
         assertFalse(scanner.next("hoy"));

--- a/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
@@ -13,7 +13,6 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 
@@ -159,7 +158,7 @@ public class DelimiterProcessorTest extends RenderingTestCase {
 
         @Override
         public Set<Class<? extends Node>> getNodeTypes() {
-            return Collections.<Class<? extends Node>>singleton(UpperCaseNode.class);
+            return Set.of(UpperCaseNode.class);
         }
 
         @Override

--- a/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
@@ -7,7 +7,10 @@ import org.commonmark.renderer.html.*;
 import org.commonmark.testutil.TestResources;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -214,7 +217,7 @@ public class HtmlRendererTest {
                 return new NodeRenderer() {
                     @Override
                     public Set<Class<? extends Node>> getNodeTypes() {
-                        return Collections.<Class<? extends Node>>singleton(Link.class);
+                        return Set.of(Link.class);
                     }
 
                     @Override

--- a/commonmark/src/test/java/org/commonmark/test/InlineParserContextTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/InlineParserContextTest.java
@@ -12,7 +12,6 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -29,7 +28,7 @@ public class InlineParserContextTest {
         String rendered = HtmlRenderer.builder().build().render(parser.parse(input));
 
         // Lookup should pass original label to context
-        assertEquals(Collections.singletonList("FooBarBaz"), inlineParserFactory.lookups);
+        assertEquals(List.of("FooBarBaz"), inlineParserFactory.lookups);
 
         // Context should normalize label for finding reference
         assertEquals("<p><a href=\"/url\">link with special label</a></p>\n", rendered);

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -11,7 +11,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -75,7 +78,7 @@ public class ParserTest {
     @Test(expected = IllegalArgumentException.class)
     public void enabledBlockTypesThrowsWhenGivenUnknownClass() {
         // BulletList can't be enabled separately at the moment, only all ListBlock types
-        Parser.builder().enabledBlockTypes(new HashSet<>(Arrays.asList(Heading.class, BulletList.class))).build();
+        Parser.builder().enabledBlockTypes(Set.of(Heading.class, BulletList.class)).build();
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -32,7 +32,7 @@ public class ParserTest {
 
         InputStream input1 = TestResources.getSpec().openStream();
         Node document1;
-        try (InputStreamReader reader = new InputStreamReader(input1, Charset.forName("UTF-8"))) {
+        try (InputStreamReader reader = new InputStreamReader(input1, StandardCharsets.UTF_8)) {
             document1 = parser.parseReader(reader);
         }
 

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
@@ -6,7 +6,6 @@ import org.commonmark.parser.Parser;
 import org.junit.Test;
 
 import java.util.ArrayDeque;
-import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
 
@@ -91,7 +90,7 @@ public class SourceSpansTest {
 
         Node document = PARSER.parse("```\nfoo\n```\nbar\n");
         Paragraph paragraph = (Paragraph) document.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(3, 0, 3)), paragraph.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 0, 3)), paragraph.getSourceSpans());
     }
 
     @Test
@@ -134,7 +133,7 @@ public class SourceSpansTest {
 
         Node document = PARSER.parse("* foo\n  * bar\n");
         ListBlock listBlock = (ListBlock) document.getFirstChild().getFirstChild().getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(1, 2, 5)), listBlock.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(1, 2, 5)), listBlock.getSourceSpans());
     }
 
     @Test
@@ -159,10 +158,10 @@ public class SourceSpansTest {
         Node document = PARSER.parse("[foo]: /url\ntext\n");
 
         LinkReferenceDefinition linkReferenceDefinition = (LinkReferenceDefinition) document.getFirstChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 11)), linkReferenceDefinition.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 11)), linkReferenceDefinition.getSourceSpans());
 
         Paragraph paragraph = (Paragraph) document.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(1, 0, 4)), paragraph.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(1, 0, 4)), paragraph.getSourceSpans());
     }
 
     @Test
@@ -199,10 +198,10 @@ public class SourceSpansTest {
         Node document = PARSER.parse("[foo]: /url\nHeading\n===\n");
 
         LinkReferenceDefinition linkReferenceDefinition = (LinkReferenceDefinition) document.getFirstChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 11)), linkReferenceDefinition.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 11)), linkReferenceDefinition.getSourceSpans());
 
         Heading heading = (Heading) document.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(1, 0, 7), SourceSpan.of(2, 0, 3)), heading.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(1, 0, 7), SourceSpan.of(2, 0, 3)), heading.getSourceSpans());
     }
 
     @Test
@@ -296,7 +295,7 @@ public class SourceSpansTest {
 
         Node document = INLINES_PARSER.parse("*hey**");
         Node lastText = document.getFirstChild().getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(0, 5, 1)), lastText.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 5, 1)), lastText.getSourceSpans());
     }
 
     @Test
@@ -322,7 +321,7 @@ public class SourceSpansTest {
 
     private static void assertSpans(Node rootNode, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
         Node node = findNode(rootNode, nodeClass);
-        assertEquals(Arrays.asList(expectedSourceSpans), node.getSourceSpans());
+        assertEquals(List.of(expectedSourceSpans), node.getSourceSpans());
     }
 
     private static Node findNode(Node rootNode, Class<? extends Node> nodeClass) {

--- a/commonmark/src/test/java/org/commonmark/test/SpecBenchmark.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecBenchmark.java
@@ -11,7 +11,6 @@ import org.openjdk.jmh.runner.options.CommandLineOptions;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.util.Collections;
 import java.util.List;
 
 @State(Scope.Benchmark)
@@ -37,7 +36,7 @@ public class SpecBenchmark {
 
     @Benchmark
     public long parseWholeSpec() {
-        return parse(Collections.singletonList(SPEC));
+        return parse(List.of(SPEC));
     }
 
     @Benchmark
@@ -47,7 +46,7 @@ public class SpecBenchmark {
 
     @Benchmark
     public long parseAndRenderWholeSpec() {
-        return parseAndRender(Collections.singletonList(SPEC));
+        return parseAndRender(List.of(SPEC));
     }
 
     @Benchmark

--- a/commonmark/src/test/java/org/commonmark/test/UsageExampleTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/UsageExampleTest.java
@@ -12,7 +12,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -126,7 +125,7 @@ public class UsageExampleTest {
         @Override
         public Set<Class<? extends Node>> getNodeTypes() {
             // Return the node types we want to use this renderer for.
-            return Collections.<Class<? extends Node>>singleton(IndentedCodeBlock.class);
+            return Set.of(IndentedCodeBlock.class);
         }
 
         @Override


### PR DESCRIPTION
- Use `List.of`, `Set.of`, `Map.of` instead of the various `Collections` methods
- Use `StandardCharsets` instead of `Charset.forName`
- Use `Objects.requireNonNull` instead of throwing manually

There's probably more but yeah.