### PR TITLE
Don't escape `=` text if it's the first node in a block

### DIFF
--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -366,9 +366,11 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
                     break;
                 }
                 case '=': {
-                    // Would be ambiguous with a Setext heading, escape
-                    writer.raw("\\=");
-                    literal = literal.substring(1);
+                    // Would be ambiguous with a Setext heading, escape unless it's the first line in the block
+                    if (text.getPrevious() != null) {
+                        writer.raw("\\=");
+                        literal = literal.substring(1);
+                    }
                     break;
                 }
                 case '0':

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -189,6 +189,9 @@ public class MarkdownRendererTest {
         assertRoundTrip("\\## Test\n");
         assertRoundTrip("\\#\n");
         assertRoundTrip("Foo\n\\===\n");
+        // Only needs to be escaped after some text, not at beginning of paragraph
+        assertRoundTrip("===\n");
+        assertRoundTrip("a\n\n===\n");
         // The beginning of the line within the block, so disregarding prefixes
         assertRoundTrip("> \\- Test\n");
         assertRoundTrip("- \\- Test\n");


### PR DESCRIPTION
Fixes #335