### PR TITLE
Add omitSingleParagraphP option to HtmlRenderer.Builder

### DIFF
--- a/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
@@ -69,13 +69,15 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
 
     @Override
     public void visit(Paragraph paragraph) {
-        boolean inTightList = isInTightList(paragraph);
-        if (!inTightList) {
+        boolean omitP = isInTightList(paragraph) || //
+                (context.shouldOmitSingleParagraphP() && paragraph.getParent() instanceof Document && //
+                        paragraph.getPrevious() == null && paragraph.getNext() == null);
+        if (!omitP) {
             html.line();
             html.tag("p", getAttrs(paragraph, "p"));
         }
         visitChildren(paragraph);
-        if (!inTightList) {
+        if (!omitP) {
             html.tag("/p");
             html.line();
         }

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlNodeRendererContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlNodeRendererContext.java
@@ -17,8 +17,8 @@ public interface HtmlNodeRendererContext {
     /**
      * Let extensions modify the HTML tag attributes.
      *
-     * @param node the node for which the attributes are applied
-     * @param tagName the HTML tag name that these attributes are for (e.g. {@code h1}, {@code pre}, {@code code}).
+     * @param node       the node for which the attributes are applied
+     * @param tagName    the HTML tag name that these attributes are for (e.g. {@code h1}, {@code pre}, {@code code}).
      * @param attributes the attributes that were calculated by the renderer
      * @return the extended attributes with added/updated/removed entries
      */
@@ -46,6 +46,11 @@ public interface HtmlNodeRendererContext {
      * @return whether HTML blocks and tags should be escaped or not
      */
     boolean shouldEscapeHtml();
+
+    /**
+     * @return whether documents that only contain a single paragraph should be rendered without the {@code <p>} tag
+     */
+    boolean shouldOmitSingleParagraphP();
 
     /**
      * @return true if the {@link UrlSanitizer} should be used.

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
@@ -22,17 +22,19 @@ public class HtmlRenderer implements Renderer {
 
     private final String softbreak;
     private final boolean escapeHtml;
+    private final boolean percentEncodeUrls;
+    private final boolean omitSingleParagraphP;
     private final boolean sanitizeUrls;
     private final UrlSanitizer urlSanitizer;
-    private final boolean percentEncodeUrls;
     private final List<AttributeProviderFactory> attributeProviderFactories;
     private final List<HtmlNodeRendererFactory> nodeRendererFactories;
 
     private HtmlRenderer(Builder builder) {
         this.softbreak = builder.softbreak;
         this.escapeHtml = builder.escapeHtml;
-        this.sanitizeUrls = builder.sanitizeUrls;
         this.percentEncodeUrls = builder.percentEncodeUrls;
+        this.omitSingleParagraphP = builder.omitSingleParagraphP;
+        this.sanitizeUrls = builder.sanitizeUrls;
         this.urlSanitizer = builder.urlSanitizer;
         this.attributeProviderFactories = new ArrayList<>(builder.attributeProviderFactories);
 
@@ -83,6 +85,7 @@ public class HtmlRenderer implements Renderer {
         private boolean sanitizeUrls = false;
         private UrlSanitizer urlSanitizer = new DefaultUrlSanitizer();
         private boolean percentEncodeUrls = false;
+        private boolean omitSingleParagraphP = false;
         private List<AttributeProviderFactory> attributeProviderFactories = new ArrayList<>();
         private List<HtmlNodeRendererFactory> nodeRendererFactories = new ArrayList<>();
 
@@ -167,6 +170,17 @@ public class HtmlRenderer implements Renderer {
         }
 
         /**
+         * Whether documents that only contain a single paragraph should be rendered without the {@code <p>} tag. Set to
+         * {@code true} to render without the tag; the default of {@code false} always renders the tag.
+         *
+         * @return {@code this}
+         */
+        public Builder omitSingleParagraphP(boolean omitSingleParagraphP) {
+            this.omitSingleParagraphP = omitSingleParagraphP;
+            return this;
+        }
+
+        /**
          * Add a factory for an attribute provider for adding/changing HTML attributes to the rendered tags.
          *
          * @param attributeProviderFactory the attribute provider factory to add
@@ -240,6 +254,11 @@ public class HtmlRenderer implements Renderer {
         @Override
         public boolean shouldEscapeHtml() {
             return escapeHtml;
+        }
+
+        @Override
+        public boolean shouldOmitSingleParagraphP() {
+            return omitSingleParagraphP;
         }
 
         @Override

--- a/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
@@ -4,6 +4,8 @@ import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.html.*;
+import org.commonmark.testutil.Asserts;
+import org.commonmark.testutil.RenderingTestCase;
 import org.commonmark.testutil.TestResources;
 import org.junit.Test;
 
@@ -306,6 +308,12 @@ public class HtmlRendererTest {
 
         assertEquals("Here I have a test <a href=\"http://www.google.com\">link</a>",
                 defaultRenderer().render(document));
+    }
+
+    @Test
+    public void omitSingleParagraphP() {
+        var renderer = HtmlRenderer.builder().omitSingleParagraphP(true).build();
+        assertEquals("hi <em>there</em>", renderer.render(parse("hi *there*")));
     }
 
     @Test


### PR DESCRIPTION
This is useful for rendering single lines where wrapping in a `<p>` tag might be undesirable.

Fixes #150.