### PR TITLE
Text content line break rendering

### DIFF
--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableTextContentNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableTextContentNodeRenderer.java
@@ -23,10 +23,11 @@ public class TableTextContentNodeRenderer extends TableNodeRenderer {
     }
 
     protected void renderBlock(TableBlock tableBlock) {
+        // Render rows tight
+        textContentWriter.pushTight(true);
         renderChildren(tableBlock);
-        if (tableBlock.getNext() != null) {
-            textContentWriter.write("\n");
-        }
+        textContentWriter.popTight();
+        textContentWriter.block();
     }
 
     protected void renderHead(TableHead tableHead) {
@@ -38,33 +39,24 @@ public class TableTextContentNodeRenderer extends TableNodeRenderer {
     }
 
     protected void renderRow(TableRow tableRow) {
-        textContentWriter.line();
         renderChildren(tableRow);
-        textContentWriter.line();
+        textContentWriter.block();
     }
 
     protected void renderCell(TableCell tableCell) {
         renderChildren(tableCell);
-        textContentWriter.write('|');
-        textContentWriter.whitespace();
-    }
-
-    private void renderLastCell(TableCell tableCell) {
-        renderChildren(tableCell);
+        // For the last cell in row, don't render the delimiter
+        if (tableCell.getNext() != null) {
+            textContentWriter.write('|');
+            textContentWriter.whitespace();
+        }
     }
 
     private void renderChildren(Node parent) {
         Node node = parent.getFirstChild();
         while (node != null) {
             Node next = node.getNext();
-
-            // For last cell in row, we dont render the delimiter.
-            if (node instanceof TableCell && next == null) {
-                renderLastCell((TableCell) node);
-            } else {
-                context.render(node);
-            }
-
+            context.render(node);
             node = next;
         }
     }

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTextContentTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTextContentTest.java
@@ -2,137 +2,165 @@ package org.commonmark.ext.gfm.tables;
 
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
+import org.commonmark.renderer.text.LineBreakRendering;
 import org.commonmark.renderer.text.TextContentRenderer;
-import org.commonmark.testutil.RenderingTestCase;
+import org.commonmark.testutil.Asserts;
 import org.junit.Test;
 
 import java.util.Set;
 
-public class TablesTextContentTest extends RenderingTestCase {
+public class TablesTextContentTest {
 
     private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final TextContentRenderer RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS).build();
 
+    private static final TextContentRenderer COMPACT_RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS).build();
+    private static final TextContentRenderer SEPARATE_RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS)
+            .lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS).build();
+    private static final TextContentRenderer STRIPPED_RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS)
+            .lineBreakRendering(LineBreakRendering.STRIP).build();
+
     @Test
     public void oneHeadNoBody() {
-        assertRendering("Abc|Def\n---|---", "Abc| Def\n");
+        assertCompact("Abc|Def\n---|---", "Abc| Def");
     }
 
     @Test
     public void oneColumnOneHeadNoBody() {
-        String expected = "Abc\n";
-        assertRendering("|Abc\n|---\n", expected);
-        assertRendering("|Abc|\n|---|\n", expected);
-        assertRendering("Abc|\n---|\n", expected);
+        String expected = "Abc";
+        assertCompact("|Abc\n|---\n", expected);
+        assertCompact("|Abc|\n|---|\n", expected);
+        assertCompact("Abc|\n---|\n", expected);
 
         // Pipe required on separator
-        assertRendering("|Abc\n---\n", "|Abc");
+        assertCompact("|Abc\n---\n", "|Abc");
         // Pipe required on head
-        assertRendering("Abc\n|---\n", "Abc\n|---");
+        assertCompact("Abc\n|---\n", "Abc\n|---");
     }
 
     @Test
     public void oneColumnOneHeadOneBody() {
-        String expected = "Abc\n1\n";
-        assertRendering("|Abc\n|---\n|1", expected);
-        assertRendering("|Abc|\n|---|\n|1|", expected);
-        assertRendering("Abc|\n---|\n1|", expected);
+        String expected = "Abc\n1";
+        assertCompact("|Abc\n|---\n|1", expected);
+        assertCompact("|Abc|\n|---|\n|1|", expected);
+        assertCompact("Abc|\n---|\n1|", expected);
 
         // Pipe required on separator
-        assertRendering("|Abc\n---\n|1", "|Abc\n|1");
+        assertCompact("|Abc\n---\n|1", "|Abc\n|1");
     }
 
     @Test
     public void oneHeadOneBody() {
-        assertRendering("Abc|Def\n---|---\n1|2", "Abc| Def\n1| 2\n");
+        assertCompact("Abc|Def\n---|---\n1|2", "Abc| Def\n1| 2");
     }
 
     @Test
     public void separatorMustNotHaveLessPartsThanHead() {
-        assertRendering("Abc|Def|Ghi\n---|---\n1|2|3", "Abc|Def|Ghi\n---|---\n1|2|3");
+        assertCompact("Abc|Def|Ghi\n---|---\n1|2|3", "Abc|Def|Ghi\n---|---\n1|2|3");
     }
 
     @Test
     public void padding() {
-        assertRendering(" Abc  | Def \n --- | --- \n 1 | 2 ", "Abc| Def\n1| 2\n");
+        assertCompact(" Abc  | Def \n --- | --- \n 1 | 2 ", "Abc| Def\n1| 2");
     }
 
     @Test
     public void paddingWithCodeBlockIndentation() {
-        assertRendering("Abc|Def\n---|---\n    1|2", "Abc| Def\n1| 2\n");
+        assertCompact("Abc|Def\n---|---\n    1|2", "Abc| Def\n1| 2");
     }
 
     @Test
     public void pipesOnOutside() {
-        assertRendering("|Abc|Def|\n|---|---|\n|1|2|", "Abc| Def\n1| 2\n");
+        assertCompact("|Abc|Def|\n|---|---|\n|1|2|", "Abc| Def\n1| 2");
     }
 
     @Test
     public void inlineElements() {
-        assertRendering("*Abc*|Def\n---|---\n1|2", "Abc| Def\n1| 2\n");
+        assertCompact("*Abc*|Def\n---|---\n1|2", "Abc| Def\n1| 2");
     }
 
     @Test
     public void escapedPipe() {
-        assertRendering("Abc|Def\n---|---\n1\\|2|20", "Abc| Def\n1|2| 20\n");
+        assertCompact("Abc|Def\n---|---\n1\\|2|20", "Abc| Def\n1|2| 20");
     }
 
     @Test
     public void alignLeft() {
-        assertRendering("Abc|Def\n:---|---\n1|2", "Abc| Def\n1| 2\n");
+        assertCompact("Abc|Def\n:---|---\n1|2", "Abc| Def\n1| 2");
     }
 
     @Test
     public void alignRight() {
-        assertRendering("Abc|Def\n---:|---\n1|2", "Abc| Def\n1| 2\n");
+        assertCompact("Abc|Def\n---:|---\n1|2", "Abc| Def\n1| 2");
     }
 
     @Test
     public void alignCenter() {
-        assertRendering("Abc|Def\n:---:|---\n1|2", "Abc| Def\n1| 2\n");
+        assertCompact("Abc|Def\n:---:|---\n1|2", "Abc| Def\n1| 2");
     }
 
     @Test
     public void alignCenterSecond() {
-        assertRendering("Abc|Def\n---|:---:\n1|2", "Abc| Def\n1| 2\n");
+        assertCompact("Abc|Def\n---|:---:\n1|2", "Abc| Def\n1| 2");
     }
 
     @Test
     public void alignLeftWithSpaces() {
-        assertRendering("Abc|Def\n :--- |---\n1|2", "Abc| Def\n1| 2\n");
+        assertCompact("Abc|Def\n :--- |---\n1|2", "Abc| Def\n1| 2");
     }
 
     @Test
     public void alignmentMarkerMustBeNextToDashes() {
-        assertRendering("Abc|Def\n: ---|---", "Abc|Def\n: ---|---");
-        assertRendering("Abc|Def\n--- :|---", "Abc|Def\n--- :|---");
-        assertRendering("Abc|Def\n---|: ---", "Abc|Def\n---|: ---");
-        assertRendering("Abc|Def\n---|--- :", "Abc|Def\n---|--- :");
+        assertCompact("Abc|Def\n: ---|---", "Abc|Def\n: ---|---");
+        assertCompact("Abc|Def\n--- :|---", "Abc|Def\n--- :|---");
+        assertCompact("Abc|Def\n---|: ---", "Abc|Def\n---|: ---");
+        assertCompact("Abc|Def\n---|--- :", "Abc|Def\n---|--- :");
     }
 
     @Test
     public void bodyCanNotHaveMoreColumnsThanHead() {
-        assertRendering("Abc|Def\n---|---\n1|2|3", "Abc| Def\n1| 2\n");
+        assertCompact("Abc|Def\n---|---\n1|2|3", "Abc| Def\n1| 2");
     }
 
     @Test
     public void bodyWithFewerColumnsThanHeadResultsInEmptyCells() {
-        assertRendering("Abc|Def|Ghi\n---|---|---\n1|2", "Abc| Def| Ghi\n1| 2| \n");
+        assertCompact("Abc|Def|Ghi\n---|---|---\n1|2", "Abc| Def| Ghi\n1| 2| ");
     }
 
     @Test
     public void insideBlockQuote() {
-        assertRendering("> Abc|Def\n> ---|---\n> 1|2", "«\nAbc| Def\n1| 2\n»");
+        assertCompact("> Abc|Def\n> ---|---\n> 1|2", "«Abc| Def\n1| 2»");
     }
 
     @Test
     public void tableWithLazyContinuationLine() {
-        assertRendering("Abc|Def\n---|---\n1|2\nlazy", "Abc| Def\n1| 2\nlazy| \n");
+        assertCompact("Abc|Def\n---|---\n1|2\nlazy", "Abc| Def\n1| 2\nlazy| ");
     }
 
-    @Override
-    protected String render(String source) {
-        return RENDERER.render(PARSER.parse(source));
+    @Test
+    public void tableBetweenOtherBlocks() {
+        var s = "Foo\n\nAbc|Def\n---|---\n1|2\n\nBar";
+        assertCompact(s, "Foo\nAbc| Def\n1| 2\nBar");
+        assertSeparate(s, "Foo\n\nAbc| Def\n1| 2\n\nBar");
+        assertStripped(s, "Foo Abc| Def 1| 2 Bar");
+    }
+
+    private void assertCompact(String source, String expected) {
+        var doc = PARSER.parse(source);
+        var actualRendering = COMPACT_RENDERER.render(doc);
+        Asserts.assertRendering(source, expected, actualRendering);
+    }
+
+    private void assertSeparate(String source, String expected) {
+        var doc = PARSER.parse(source);
+        var actualRendering = SEPARATE_RENDERER.render(doc);
+        Asserts.assertRendering(source, expected, actualRendering);
+    }
+
+    private void assertStripped(String source, String expected) {
+        var doc = PARSER.parse(source);
+        var actualRendering = STRIPPED_RENDERER.render(doc);
+        Asserts.assertRendering(source, expected, actualRendering);
     }
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
@@ -74,9 +74,10 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
 
     @Override
     public void visit(BulletList bulletList) {
-        // TODO: isTight()
+        textContent.pushTight(bulletList.isTight());
         listHolder = new BulletListHolder(listHolder, bulletList);
         visitChildren(bulletList);
+        textContent.popTight();
         textContent.block();
         listHolder = listHolder.getParent();
     }
@@ -178,9 +179,10 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
 
     @Override
     public void visit(OrderedList orderedList) {
-        // TODO: isTight()
+        textContent.pushTight(orderedList.isTight());
         listHolder = new OrderedListHolder(listHolder, orderedList);
         visitChildren(orderedList);
+        textContent.popTight();
         textContent.block();
         listHolder = listHolder.getParent();
     }

--- a/commonmark/src/main/java/org/commonmark/renderer/text/LineBreakRendering.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/LineBreakRendering.java
@@ -1,0 +1,19 @@
+package org.commonmark.renderer.text;
+
+/**
+ * Control how line breaks are rendered.
+ */
+public enum LineBreakRendering {
+    /**
+     * Strip all line breaks within blocks and between blocks, resulting in all the text in a single line.
+     */
+    STRIP,
+    /**
+     * Use single line breaks between blocks, not a blank line (also render all lists as tight).
+     */
+    COMPACT,
+    /**
+     * Separate blocks by a blank line (and respect tight vs loose lists).
+     */
+    SEPARATE_BLOCKS,
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentNodeRendererContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentNodeRendererContext.java
@@ -5,9 +5,7 @@ import org.commonmark.node.Node;
 public interface TextContentNodeRendererContext {
 
     /**
-     * TODO
-     *
-     * @return
+     * Controls how line breaks should be rendered, see {@link LineBreakRendering}.
      */
     LineBreakRendering lineBreakRendering();
 

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentNodeRendererContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentNodeRendererContext.java
@@ -5,9 +5,18 @@ import org.commonmark.node.Node;
 public interface TextContentNodeRendererContext {
 
     /**
+     * TODO
+     *
+     * @return
+     */
+    LineBreakRendering lineBreakRendering();
+
+    /**
      * @return true for stripping new lines and render text as "single line",
      * false for keeping all line breaks.
+     * @deprecated Use {@link #lineBreakRendering()} instead
      */
+    @Deprecated
     boolean stripNewlines();
 
     /**

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
@@ -14,12 +14,12 @@ import java.util.List;
  */
 public class TextContentRenderer implements Renderer {
 
-    private final boolean stripNewlines;
+    private final LineBreakRendering lineBreakRendering;
 
     private final List<TextContentNodeRendererFactory> nodeRendererFactories;
 
     private TextContentRenderer(Builder builder) {
-        this.stripNewlines = builder.stripNewlines;
+        this.lineBreakRendering = builder.lineBreakRendering;
 
         this.nodeRendererFactories = new ArrayList<>(builder.nodeRendererFactories.size() + 1);
         this.nodeRendererFactories.addAll(builder.nodeRendererFactories);
@@ -43,7 +43,7 @@ public class TextContentRenderer implements Renderer {
 
     @Override
     public void render(Node node, Appendable output) {
-        RendererContext context = new RendererContext(new TextContentWriter(output));
+        RendererContext context = new RendererContext(new TextContentWriter(output, lineBreakRendering));
         context.render(node);
     }
 
@@ -59,8 +59,8 @@ public class TextContentRenderer implements Renderer {
      */
     public static class Builder {
 
-        private boolean stripNewlines = false;
         private List<TextContentNodeRendererFactory> nodeRendererFactories = new ArrayList<>();
+        private LineBreakRendering lineBreakRendering = LineBreakRendering.COMPACT;
 
         /**
          * @return the configured {@link TextContentRenderer}
@@ -70,14 +70,27 @@ public class TextContentRenderer implements Renderer {
         }
 
         /**
+         * TODO
+         *
+         * @param lineBreakRendering
+         * @return
+         */
+        public Builder lineBreakRendering(LineBreakRendering lineBreakRendering) {
+            this.lineBreakRendering = lineBreakRendering;
+            return this;
+        }
+
+        /**
          * Set the value of flag for stripping new lines.
          *
          * @param stripNewlines true for stripping new lines and render text as "single line",
          *                      false for keeping all line breaks
          * @return {@code this}
+         * @deprecated Use {@link #lineBreakRendering(LineBreakRendering)} with {@link LineBreakRendering#STRIP} instead
          */
+        @Deprecated
         public Builder stripNewlines(boolean stripNewlines) {
-            this.stripNewlines = stripNewlines;
+            this.lineBreakRendering = stripNewlines ? LineBreakRendering.STRIP : LineBreakRendering.COMPACT;
             return this;
         }
 
@@ -135,8 +148,13 @@ public class TextContentRenderer implements Renderer {
         }
 
         @Override
+        public LineBreakRendering lineBreakRendering() {
+            return lineBreakRendering;
+        }
+
+        @Override
         public boolean stripNewlines() {
-            return stripNewlines;
+            return lineBreakRendering == LineBreakRendering.STRIP;
         }
 
         @Override

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
@@ -70,10 +70,11 @@ public class TextContentRenderer implements Renderer {
         }
 
         /**
-         * TODO
+         * Configure how line breaks (newlines) are rendered, see {@link LineBreakRendering}.
+         * The default is {@link LineBreakRendering#COMPACT}.
          *
-         * @param lineBreakRendering
-         * @return
+         * @param lineBreakRendering the mode to use
+         * @return {@code this}
          */
         public Builder lineBreakRendering(LineBreakRendering lineBreakRendering) {
             this.lineBreakRendering = lineBreakRendering;

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentWriter.java
@@ -1,45 +1,97 @@
 package org.commonmark.renderer.text;
 
 import java.io.IOException;
+import java.util.LinkedList;
 
 public class TextContentWriter {
 
     private final Appendable buffer;
+    private final LineBreakRendering lineBreakRendering;
 
+    private final LinkedList<Boolean> tight = new LinkedList<>();
+
+    private String blockSeparator = null;
     private char lastChar;
 
     public TextContentWriter(Appendable out) {
-        buffer = out;
+        this(out, LineBreakRendering.COMPACT);
+    }
+
+    public TextContentWriter(Appendable out, LineBreakRendering lineBreakRendering) {
+        this.buffer = out;
+        this.lineBreakRendering = lineBreakRendering;
     }
 
     public void whitespace() {
         if (lastChar != 0 && lastChar != ' ') {
-            append(' ');
+            write(' ');
         }
     }
 
     public void colon() {
         if (lastChar != 0 && lastChar != ':') {
-            append(':');
+            write(':');
         }
     }
 
     public void line() {
-        if (lastChar != 0 && lastChar != '\n') {
-            append('\n');
-        }
+        append('\n');
+    }
+
+    public void block() {
+        blockSeparator = lineBreakRendering == LineBreakRendering.STRIP ? " " : //
+                lineBreakRendering == LineBreakRendering.COMPACT || isTight() ? "\n" : "\n\n";
+    }
+
+    public void resetBlock() {
+        blockSeparator = null;
     }
 
     public void writeStripped(String s) {
-        append(s.replaceAll("[\\r\\n\\s]+", " "));
+        write(s.replaceAll("[\\r\\n\\s]+", " "));
     }
 
     public void write(String s) {
+        flushBlockSeparator();
         append(s);
     }
 
     public void write(char c) {
+        flushBlockSeparator();
         append(c);
+    }
+
+    /**
+     * Change whether blocks are tight or loose. Loose is the default where blocks are separated by a blank line. Tight
+     * is where blocks are not separated by a blank line. Tight blocks are used in lists, if there are no blank lines
+     * within the list.
+     * <p>
+     * Note that changing this does not affect block separators that have already been enqueued with {@link #block()},
+     * only future ones.
+     */
+    public void pushTight(boolean tight) {
+        this.tight.addLast(tight);
+    }
+
+    /**
+     * Remove the last "tight" setting from the top of the stack.
+     */
+    public void popTight() {
+        this.tight.removeLast();
+    }
+
+    private boolean isTight() {
+        return !tight.isEmpty() && tight.getLast();
+    }
+
+    /**
+     * If a block separator has been enqueued with {@link #block()} but not yet written, write it now.
+     */
+    private void flushBlockSeparator() {
+        if (blockSeparator != null) {
+            append(blockSeparator);
+            blockSeparator = null;
+        }
     }
 
     private void append(String s) {

--- a/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
@@ -31,6 +31,13 @@ public class TextContentRendererTest {
     }
 
     @Test
+    public void textContentHeading() {
+        assertCompact("# Heading\n\nFoo", "Heading\nFoo");
+        assertSeparate("# Heading\n\nFoo", "Heading\n\nFoo");
+        assertStripped("# Heading\n\nFoo", "Heading: Foo");
+    }
+
+    @Test
     public void textContentEmphasis() {
         String s;
         String rendered;

--- a/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
@@ -2,7 +2,6 @@ package org.commonmark.test;
 
 import org.commonmark.renderer.text.LineBreakRendering;
 import org.commonmark.renderer.text.TextContentRenderer;
-import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.testutil.Asserts;
 import org.junit.Test;
@@ -10,6 +9,12 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class TextContentRendererTest {
+
+    private static final Parser PARSER = Parser.builder().build();
+    private static final TextContentRenderer COMPACT_RENDERER = TextContentRenderer.builder().build();
+    private static final TextContentRenderer SEPARATE_RENDERER = TextContentRenderer.builder()
+            .lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS).build();
+    private static final TextContentRenderer STRIPPED_RENDERER = TextContentRenderer.builder().stripNewlines(true).build();
 
     @Test
     public void textContentText() {
@@ -179,37 +184,21 @@ public class TextContentRendererTest {
         assertAll(html, html);
     }
 
-    private TextContentRenderer compactRenderer() {
-        return TextContentRenderer.builder().build();
-    }
-
-    private TextContentRenderer separateBlocksRenderer() {
-        return TextContentRenderer.builder().lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS).build();
-    }
-
-    private TextContentRenderer strippedRenderer() {
-        return TextContentRenderer.builder().stripNewlines(true).build();
-    }
-
-    private Node parse(String source) {
-        return Parser.builder().build().parse(source);
-    }
-
     private void assertCompact(String source, String expected) {
-        var doc = parse(source);
-        var actualRendering = compactRenderer().render(doc);
+        var doc = PARSER.parse(source);
+        var actualRendering = COMPACT_RENDERER.render(doc);
         Asserts.assertRendering(source, expected, actualRendering);
     }
 
     private void assertSeparate(String source, String expected) {
-        var doc = parse(source);
-        var actualRendering = separateBlocksRenderer().render(doc);
+        var doc = PARSER.parse(source);
+        var actualRendering = SEPARATE_RENDERER.render(doc);
         Asserts.assertRendering(source, expected, actualRendering);
     }
 
     private void assertStripped(String source, String expected) {
-        var doc = parse(source);
-        var actualRendering = strippedRenderer().render(doc);
+        var doc = PARSER.parse(source);
+        var actualRendering = STRIPPED_RENDERER.render(doc);
         Asserts.assertRendering(source, expected, actualRendering);
     }
 

--- a/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
@@ -3,6 +3,7 @@ package org.commonmark.test;
 import org.commonmark.renderer.text.TextContentRenderer;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
+import org.commonmark.testutil.Asserts;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -248,8 +249,6 @@ public class TextContentRendererTest {
         rendered = strippedRenderer(source);
         assertEquals("foo bar", rendered);
     }
-
-
 
     @Test
     public void textContentHtml() {

--- a/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
@@ -12,248 +12,133 @@ public class TextContentRendererTest {
 
     @Test
     public void textContentText() {
-        String source;
-        String rendered;
+        String s;
 
-        source = "foo bar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo bar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo bar", rendered);
+        s = "foo bar";
+        assertCompact(s, "foo bar");
+        assertStripped(s, "foo bar");
 
-        source = "foo foo\n\nbar\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo foo\nbar\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo foo bar bar", rendered);
+        s = "foo foo\n\nbar\nbar";
+        assertCompact(s, "foo foo\nbar\nbar");
+        assertStripped(s, "foo foo bar bar");
     }
 
     @Test
     public void textContentEmphasis() {
-        String source;
+        String s;
         String rendered;
 
-        source = "***foo***";
-        rendered = defaultRenderer(source, defaultRenderer());
-        assertEquals("foo", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo", rendered);
+        s = "***foo***";
+        assertCompact(s, "foo");
+        assertStripped(s, "foo");
 
-        source = "foo ***foo*** bar ***bar***";
-        rendered = defaultRenderer(source);
-        assertEquals("foo foo bar bar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo foo bar bar", rendered);
+        s = "foo ***foo*** bar ***bar***";
+        assertCompact(s, "foo foo bar bar");
+        assertStripped(s, "foo foo bar bar");
 
-        source = "foo\n***foo***\nbar\n\n***bar***";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\nfoo\nbar\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo foo bar bar", rendered);
-    }
-
-    private String defaultRenderer(String source, TextContentRenderer textContentRenderer) {
-        String rendered;
-        rendered = textContentRenderer.render(parse(source));
-        return rendered;
+        s = "foo\n***foo***\nbar\n\n***bar***";
+        assertCompact(s, "foo\nfoo\nbar\nbar");
+        assertStripped(s, "foo foo bar bar");
     }
 
     @Test
     public void textContentQuotes() {
-        String source;
-        String rendered;
+        String s;
 
-        source = "foo\n>foo\nbar\n\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\n«foo\nbar»\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo «foo bar» bar", rendered);
+        s = "foo\n>foo\nbar\n\nbar";
+        assertCompact(s, "foo\n«foo\nbar»\nbar");
+        assertStripped(s, "foo «foo bar» bar");
     }
 
     @Test
     public void textContentLinks() {
-        String source;
-        String expected;
-        String rendered;
-
-        source = "foo [text](http://link \"title\") bar";
-        expected = "foo \"text\" (title: http://link) bar";
-        rendered = defaultRenderer(source);
-        assertEquals(expected, rendered);
-        rendered = strippedRenderer(source);
-        assertEquals(expected, rendered);
-
-        source = "foo [text](http://link \"http://link\") bar";
-        expected = "foo \"text\" (http://link) bar";
-        rendered = defaultRenderer(source);
-        assertEquals(expected, rendered);
-        rendered = strippedRenderer(source);
-        assertEquals(expected, rendered);
-
-        source = "foo [text](http://link) bar";
-        expected = "foo \"text\" (http://link) bar";
-        rendered = defaultRenderer(source);
-        assertEquals(expected, rendered);
-        rendered = strippedRenderer(source);
-        assertEquals(expected, rendered);
-
-        source = "foo [text]() bar";
-        expected = "foo \"text\" bar";
-        rendered = defaultRenderer(source);
-        assertEquals(expected, rendered);
-        rendered = strippedRenderer(source);
-        assertEquals(expected, rendered);
-
-        source = "foo http://link bar";
-        expected = "foo http://link bar";
-        rendered = defaultRenderer(source);
-        assertEquals(expected, rendered);
-        rendered = strippedRenderer(source);
-        assertEquals(expected, rendered);
+        assertAll("foo [text](http://link \"title\") bar", "foo \"text\" (title: http://link) bar");
+        assertAll("foo [text](http://link \"http://link\") bar", "foo \"text\" (http://link) bar");
+        assertAll("foo [text](http://link) bar", "foo \"text\" (http://link) bar");
+        assertAll("foo [text]() bar", "foo \"text\" bar");
+        assertAll("foo http://link bar", "foo http://link bar");
     }
 
     @Test
     public void textContentImages() {
-        String source;
-        String expected;
-        String rendered;
-
-        source = "foo ![text](http://link \"title\") bar";
-        expected = "foo \"text\" (title: http://link) bar";
-        rendered = defaultRenderer(source);
-        assertEquals(expected, rendered);
-        rendered = strippedRenderer(source);
-        assertEquals(expected, rendered);
-
-        source = "foo ![text](http://link) bar";
-        expected = "foo \"text\" (http://link) bar";
-        rendered = defaultRenderer(source);
-        assertEquals(expected, rendered);
-        rendered = strippedRenderer(source);
-        assertEquals(expected, rendered);
-
-        source = "foo ![text]() bar";
-        expected = "foo \"text\" bar";
-        rendered = defaultRenderer(source);
-        assertEquals(expected, rendered);
-        rendered = strippedRenderer(source);
-        assertEquals(expected, rendered);
+        assertAll("foo ![text](http://link \"title\") bar", "foo \"text\" (title: http://link) bar");
+        assertAll("foo ![text](http://link) bar", "foo \"text\" (http://link) bar");
+        assertAll("foo ![text]() bar", "foo \"text\" bar");
     }
 
     @Test
     public void textContentLists() {
-        String source;
-        String rendered;
+        String s;
 
-        source = "foo\n* foo\n* bar\n\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\n* foo\n* bar\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo foo bar bar", rendered);
+        s = "foo\n* foo\n* bar\n\nbar";
+        assertCompact(s, "foo\n* foo\n* bar\nbar");
+        assertStripped(s, "foo foo bar bar");
 
-        source = "foo\n- foo\n- bar\n\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\n- foo\n- bar\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo foo bar bar", rendered);
+        s = "foo\n- foo\n- bar\n\nbar";
+        assertCompact(s, "foo\n- foo\n- bar\nbar");
+        assertStripped(s, "foo foo bar bar");
 
-        source = "foo\n1. foo\n2. bar\n\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\n1. foo\n2. bar\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo 1. foo 2. bar bar", rendered);
+        s = "foo\n1. foo\n2. bar\n\nbar";
+        assertCompact(s, "foo\n1. foo\n2. bar\nbar");
+        assertStripped(s, "foo 1. foo 2. bar bar");
 
-        source = "foo\n0) foo\n1) bar\n\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\n0) foo\n1) bar\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo 0) foo 1) bar bar", rendered);
+        s = "foo\n0) foo\n1) bar\n\nbar";
+        assertCompact(s, "foo\n0) foo\n1) bar\nbar");
+        assertStripped(s, "foo 0) foo 1) bar bar");
 
-        source = "bar\n1. foo\n   1. bar\n2. foo";
-        rendered = defaultRenderer(source);
-        assertEquals("bar\n1. foo\n   1. bar\n2. foo", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("bar 1. foo 1. bar 2. foo", rendered);
+        s = "bar\n1. foo\n   1. bar\n2. foo";
+        assertCompact(s, "bar\n1. foo\n   1. bar\n2. foo");
+        assertStripped(s, "bar 1. foo 1. bar 2. foo");
 
-        source = "bar\n* foo\n   - bar\n* foo";
-        rendered = defaultRenderer(source);
-        assertEquals("bar\n* foo\n   - bar\n* foo", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("bar foo bar foo", rendered);
+        s = "bar\n* foo\n   - bar\n* foo";
+        assertCompact(s, "bar\n* foo\n   - bar\n* foo");
+        assertStripped(s, "bar foo bar foo");
 
-        source = "bar\n* foo\n   1. bar\n   2. bar\n* foo";
-        rendered = defaultRenderer(source);
-        assertEquals("bar\n* foo\n   1. bar\n   2. bar\n* foo", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("bar foo 1. bar 2. bar foo", rendered);
+        s = "bar\n* foo\n   1. bar\n   2. bar\n* foo";
+        assertCompact(s, "bar\n* foo\n   1. bar\n   2. bar\n* foo");
+        assertStripped(s, "bar foo 1. bar 2. bar foo");
 
-        source = "bar\n1. foo\n   * bar\n   * bar\n2. foo";
-        rendered = defaultRenderer(source);
-        assertEquals("bar\n1. foo\n   * bar\n   * bar\n2. foo", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("bar 1. foo bar bar 2. foo", rendered);
+        s = "bar\n1. foo\n   * bar\n   * bar\n2. foo";
+        assertCompact(s, "bar\n1. foo\n   * bar\n   * bar\n2. foo");
+        assertStripped(s, "bar 1. foo bar bar 2. foo");
     }
 
     @Test
     public void textContentCode() {
-        String source;
-        String expected;
-        String rendered;
-
-        source = "foo `code` bar";
-        expected = "foo \"code\" bar";
-        rendered = defaultRenderer(source);
-        assertEquals(expected, rendered);
-        rendered = strippedRenderer(source);
-        assertEquals(expected, rendered);
+        assertAll("foo `code` bar", "foo \"code\" bar");
     }
 
     @Test
     public void textContentCodeBlock() {
-        String source;
-        String rendered;
+        String s;
+        s = "foo\n```\nfoo\nbar\n```\nbar";
+        assertCompact(s, "foo\nfoo\nbar\nbar");
+        assertStripped(s, "foo foo bar bar");
 
-        source = "foo\n```\nfoo\nbar\n```\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\nfoo\nbar\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo foo bar bar", rendered);
-
-        source = "foo\n\n    foo\n     bar\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\nfoo\n bar\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo foo bar bar", rendered);
+        s = "foo\n\n    foo\n     bar\nbar";
+        assertCompact(s, "foo\nfoo\n bar\nbar");
+        assertStripped(s, "foo foo bar bar");
     }
 
     @Test
-    public void textContentBrakes() {
-        String source;
-        String rendered;
+    public void textContentBreaks() {
+        String s;
 
-        source = "foo\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo bar", rendered);
+        s = "foo\nbar";
+        assertCompact(s, "foo\nbar");
+        assertStripped(s, "foo bar");
 
-        source = "foo  \nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo bar", rendered);
+        s = "foo  \nbar";
+        assertCompact(s, "foo\nbar");
+        assertStripped(s, "foo bar");
 
-        source = "foo\n___\nbar";
-        rendered = defaultRenderer(source);
-        assertEquals("foo\n***\nbar", rendered);
-        rendered = strippedRenderer(source);
-        assertEquals("foo bar", rendered);
+        s = "foo\n___\nbar";
+        assertCompact(s, "foo\n***\nbar");
+        assertStripped(s, "foo bar");
     }
 
     @Test
     public void textContentHtml() {
-        String rendered;
-
         String html = "<table>\n" +
                 "  <tr>\n" +
                 "    <td>\n" +
@@ -261,12 +146,10 @@ public class TextContentRendererTest {
                 "    </td>\n" +
                 "  </tr>\n" +
                 "</table>";
-        rendered = defaultRenderer(html);
-        assertEquals(html, rendered);
+        assertCompact(html, html);
 
         html = "foo <foo>foobar</foo> bar";
-        rendered = defaultRenderer(html);
-        assertEquals(html, rendered);
+        assertCompact(html, html);
     }
 
     private TextContentRenderer defaultRenderer() {
@@ -280,12 +163,22 @@ public class TextContentRendererTest {
     private Node parse(String source) {
         return Parser.builder().build().parse(source);
     }
-
-    private String strippedRenderer(String source) {
-        return strippedRenderer().render(parse(source));
+    
+    private void assertCompact(String source, String expected) {
+        var doc = parse(source);
+        var actualRendering = defaultRenderer().render(doc);
+        Asserts.assertRendering(source, expected, actualRendering);
     }
 
-    private String defaultRenderer(String source) {
-        return defaultRenderer().render(parse(source));
+    private void assertStripped(String source, String expected) {
+        var doc = parse(source);
+        var actualRendering = strippedRenderer().render(doc);
+        Asserts.assertRendering(source, expected, actualRendering);
+    }
+
+    private void assertAll(String source, String expected) {
+        assertCompact(source, expected);
+        assertStripped(source, expected);
+        // TODO
     }
 }


### PR DESCRIPTION
Fixes #264. Users will be able to configure the line break rendering like this:

```java
var renderer = TextContentRenderer.builder().lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS).build();
```

Then input Markdown like this:

```
foo

bar
```

Will be rendered like this:

```
foo

bar
```

Note that it will separate all blocks (which is slightly different from preserving what the input was), e.g. this:

```
foo
1. bar
```

Will be rendered:

```
foo

1. bar
```