### PR TITLE
Also include "input index" in SourceSpan

### DIFF
--- a/commonmark-ext-autolink/src/main/java/org/commonmark/ext/autolink/internal/AutolinkPostProcessor.java
+++ b/commonmark-ext-autolink/src/main/java/org/commonmark/ext/autolink/internal/AutolinkPostProcessor.java
@@ -61,8 +61,7 @@ public class AutolinkPostProcessor implements PostProcessor {
         String text = literal.substring(beginIndex, endIndex);
         Text textNode = new Text(text);
         if (sourceSpan != null) {
-            int length = endIndex - beginIndex;
-            textNode.addSourceSpan(SourceSpan.of(sourceSpan.getLineIndex(), beginIndex, length));
+            textNode.addSourceSpan(sourceSpan.subSpan(beginIndex, endIndex));
         }
         return textNode;
     }

--- a/commonmark-ext-autolink/src/test/java/org/commonmark/ext/autolink/AutolinkTest.java
+++ b/commonmark-ext-autolink/src/test/java/org/commonmark/ext/autolink/AutolinkTest.java
@@ -71,43 +71,43 @@ public class AutolinkTest extends RenderingTestCase {
 
         Paragraph paragraph = (Paragraph) document.getFirstChild();
         Text abc = (Text) paragraph.getFirstChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 3)),
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 3)),
                 abc.getSourceSpans());
 
         assertTrue(abc.getNext() instanceof SoftLineBreak);
 
         Link one = (Link) abc.getNext().getNext();
         assertEquals("http://example.com/one", one.getDestination());
-        assertEquals(List.of(SourceSpan.of(1, 0, 22)),
+        assertEquals(List.of(SourceSpan.of(1, 0, 4, 22)),
                 one.getSourceSpans());
 
         assertTrue(one.getNext() instanceof SoftLineBreak);
 
         Text def = (Text) one.getNext().getNext();
         assertEquals("def ", def.getLiteral());
-        assertEquals(List.of(SourceSpan.of(2, 0, 4)),
+        assertEquals(List.of(SourceSpan.of(2, 0, 27, 4)),
                 def.getSourceSpans());
 
         Link two = (Link) def.getNext();
         assertEquals("http://example.com/two", two.getDestination());
-        assertEquals(List.of(SourceSpan.of(2, 4, 22)),
+        assertEquals(List.of(SourceSpan.of(2, 4, 31, 22)),
                 two.getSourceSpans());
 
         assertTrue(two.getNext() instanceof SoftLineBreak);
 
         Text ghi = (Text) two.getNext().getNext();
         assertEquals("ghi ", ghi.getLiteral());
-        assertEquals(List.of(SourceSpan.of(3, 0, 4)),
+        assertEquals(List.of(SourceSpan.of(3, 0, 54, 4)),
                 ghi.getSourceSpans());
 
         Link three = (Link) ghi.getNext();
         assertEquals("http://example.com/three", three.getDestination());
-        assertEquals(List.of(SourceSpan.of(3, 4, 24)),
+        assertEquals(List.of(SourceSpan.of(3, 4, 58, 24)),
                 three.getSourceSpans());
 
         Text jkl = (Text) three.getNext();
         assertEquals(" jkl", jkl.getLiteral());
-        assertEquals(List.of(SourceSpan.of(3, 28, 4)),
+        assertEquals(List.of(SourceSpan.of(3, 28, 82, 4)),
                 jkl.getSourceSpans());
     }
 

--- a/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnotesTest.java
+++ b/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnotesTest.java
@@ -287,10 +287,10 @@ public class FootnotesTest {
 
         var doc = parser.parse("Test [^foo]\n\n[^foo]: /url\n");
         var ref = find(doc, FootnoteReference.class);
-        assertEquals(ref.getSourceSpans(), List.of(SourceSpan.of(0, 5, 6)));
+        assertEquals(ref.getSourceSpans(), List.of(SourceSpan.of(0, 5, 5, 6)));
 
         var def = find(doc, FootnoteDefinition.class);
-        assertEquals(def.getSourceSpans(), List.of(SourceSpan.of(2, 0, 12)));
+        assertEquals(def.getSourceSpans(), List.of(SourceSpan.of(2, 0, 13, 12)));
     }
 
     private static <T> T find(Node parent, Class<T> nodeClass) {

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughTest.java
@@ -117,7 +117,7 @@ public class StrikethroughTest extends RenderingTestCase {
         Node document = parser.parse("hey ~~there~~\n");
         Paragraph block = (Paragraph) document.getFirstChild();
         Node strikethrough = block.getLastChild();
-        assertEquals(List.of(SourceSpan.of(0, 4, 9)),
+        assertEquals(List.of(SourceSpan.of(0, 4, 4, 9)),
                 strikethrough.getSourceSpans());
     }
 

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -791,45 +791,45 @@ public class TablesTest extends RenderingTestCase {
         Node document = parser.parse("Abc|Def\n---|---\n|1|2\n 3|four|\n|||\n");
 
         TableBlock block = (TableBlock) document.getFirstChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 7),
-                        SourceSpan.of(2, 0, 4), SourceSpan.of(3, 0, 8), SourceSpan.of(4, 0, 3)),
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 7),
+                        SourceSpan.of(2, 0, 16, 4), SourceSpan.of(3, 0, 21, 8), SourceSpan.of(4, 0, 30, 3)),
                 block.getSourceSpans());
 
         TableHead head = (TableHead) block.getFirstChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 7)), head.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 7)), head.getSourceSpans());
 
         TableRow headRow = (TableRow) head.getFirstChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 7)), headRow.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 7)), headRow.getSourceSpans());
         TableCell headRowCell1 = (TableCell) headRow.getFirstChild();
         TableCell headRowCell2 = (TableCell) headRow.getLastChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 3)), headRowCell1.getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(0, 0, 3)), headRowCell1.getFirstChild().getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(0, 4, 3)), headRowCell2.getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(0, 4, 3)), headRowCell2.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 3)), headRowCell1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 3)), headRowCell1.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 4, 4, 3)), headRowCell2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 4, 4, 3)), headRowCell2.getFirstChild().getSourceSpans());
 
         TableBody body = (TableBody) block.getLastChild();
-        assertEquals(List.of(SourceSpan.of(2, 0, 4), SourceSpan.of(3, 0, 8), SourceSpan.of(4, 0, 3)), body.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 0, 16, 4), SourceSpan.of(3, 0, 21, 8), SourceSpan.of(4, 0, 30, 3)), body.getSourceSpans());
 
         TableRow bodyRow1 = (TableRow) body.getFirstChild();
-        assertEquals(List.of(SourceSpan.of(2, 0, 4)), bodyRow1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 0, 16, 4)), bodyRow1.getSourceSpans());
         TableCell bodyRow1Cell1 = (TableCell) bodyRow1.getFirstChild();
         TableCell bodyRow1Cell2 = (TableCell) bodyRow1.getLastChild();
-        assertEquals(List.of(SourceSpan.of(2, 1, 1)), bodyRow1Cell1.getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(2, 1, 1)), bodyRow1Cell1.getFirstChild().getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(2, 3, 1)), bodyRow1Cell2.getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(2, 3, 1)), bodyRow1Cell2.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 1, 17, 1)), bodyRow1Cell1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 1, 17, 1)), bodyRow1Cell1.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 3, 19, 1)), bodyRow1Cell2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(2, 3, 19, 1)), bodyRow1Cell2.getFirstChild().getSourceSpans());
 
         TableRow bodyRow2 = (TableRow) body.getFirstChild().getNext();
-        assertEquals(List.of(SourceSpan.of(3, 0, 8)), bodyRow2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 0, 21, 8)), bodyRow2.getSourceSpans());
         TableCell bodyRow2Cell1 = (TableCell) bodyRow2.getFirstChild();
         TableCell bodyRow2Cell2 = (TableCell) bodyRow2.getLastChild();
-        assertEquals(List.of(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getFirstChild().getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 1, 22, 1)), bodyRow2Cell1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 1, 22, 1)), bodyRow2Cell1.getFirstChild().getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 3, 24, 4)), bodyRow2Cell2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 3, 24, 4)), bodyRow2Cell2.getFirstChild().getSourceSpans());
 
         TableRow bodyRow3 = (TableRow) body.getLastChild();
-        assertEquals(List.of(SourceSpan.of(4, 0, 3)), bodyRow3.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(4, 0, 30, 3)), bodyRow3.getSourceSpans());
         TableCell bodyRow3Cell1 = (TableCell) bodyRow3.getFirstChild();
         TableCell bodyRow3Cell2 = (TableCell) bodyRow3.getLastChild();
         assertEquals(List.of(), bodyRow3Cell1.getSourceSpans());

--- a/commonmark-ext-image-attributes/src/test/java/org/commonmark/ext/image/attributes/ImageAttributesTest.java
+++ b/commonmark-ext-image-attributes/src/test/java/org/commonmark/ext/image/attributes/ImageAttributesTest.java
@@ -131,7 +131,7 @@ public class ImageAttributesTest extends RenderingTestCase {
         Node document = parser.parse("x{height=3 width=4}\n");
         Paragraph block = (Paragraph) document.getFirstChild();
         Node text = block.getFirstChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 19)),
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 19)),
                 text.getSourceSpans());
     }
 

--- a/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsTest.java
+++ b/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsTest.java
@@ -102,7 +102,7 @@ public class InsTest extends RenderingTestCase {
         Node document = parser.parse("hey ++there++\n");
         Paragraph block = (Paragraph) document.getFirstChild();
         Node ins = block.getLastChild();
-        assertEquals(List.of(SourceSpan.of(0, 4, 9)),
+        assertEquals(List.of(SourceSpan.of(0, 4, 4, 9)),
                 ins.getSourceSpans());
     }
 

--- a/commonmark/src/main/java/org/commonmark/internal/util/LineReader.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/LineReader.java
@@ -1,0 +1,149 @@
+package org.commonmark.internal.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * Reads lines from a reader like {@link java.io.BufferedReader} but also returns the line terminators.
+ * <p>
+ * Line terminators can be either a line feed {@code "\n"}, carriage return {@code "\r"}, or a carriage return followed
+ * by a line feed {@code "\r\n"}. Call {@link #getLineTerminator()} after {@link #readLine()} to obtain the
+ * corresponding line terminator. If a stream has a line at the end without a terminator, {@link #getLineTerminator()}
+ * returns {@code null}.
+ */
+public class LineReader implements Closeable {
+
+    // Same as java.io.BufferedReader
+    static final int CHAR_BUFFER_SIZE = 8192;
+    static final int EXPECTED_LINE_LENGTH = 80;
+
+    private Reader reader;
+    private char[] cbuf;
+
+    private int position = 0;
+    private int limit = 0;
+
+    private String lineTerminator = null;
+
+    public LineReader(Reader reader) {
+        this.reader = reader;
+        this.cbuf = new char[CHAR_BUFFER_SIZE];
+    }
+
+    /**
+     * Read a line of text.
+     *
+     * @return the line, or {@code null} when the end of the stream has been reached and no more lines can be read
+     */
+    public String readLine() throws IOException {
+        StringBuilder sb = null;
+        boolean cr = false;
+
+        while (true) {
+            if (position >= limit) {
+                fill();
+            }
+
+            if (cr) {
+                // We saw a CR before, check if we have CR LF or just CR.
+                if (position < limit && cbuf[position] == '\n') {
+                    position++;
+                    return line(sb.toString(), "\r\n");
+                } else {
+                    return line(sb.toString(), "\r");
+                }
+            }
+
+            if (position >= limit) {
+                // End of stream, return either the last line without terminator or null for end.
+                return line(sb != null ? sb.toString() : null, null);
+            }
+
+            int start = position;
+            int i = position;
+            for (; i < limit; i++) {
+                char c = cbuf[i];
+                if (c == '\n') {
+                    position = i + 1;
+                    return line(finish(sb, start, i), "\n");
+                } else if (c == '\r') {
+                    if (i + 1 < limit) {
+                        // We know what the next character is, so we can check now whether we have
+                        // a CR LF or just a CR and return.
+                        if (cbuf[i + 1] == '\n') {
+                            position = i + 2;
+                            return line(finish(sb, start, i), "\r\n");
+                        } else {
+                            position = i + 1;
+                            return line(finish(sb, start, i), "\r");
+                        }
+                    } else {
+                        // We don't know what the next character is yet, check on next iteration.
+                        cr = true;
+                        position = i + 1;
+                        break;
+                    }
+                }
+            }
+
+            if (position < i) {
+                position = i;
+            }
+
+            // Haven't found a finished line yet, copy the data from the buffer so that we can fill
+            // the buffer again.
+            if (sb == null) {
+                sb = new StringBuilder(EXPECTED_LINE_LENGTH);
+            }
+            sb.append(cbuf, start, i - start);
+        }
+    }
+
+    /**
+     * Return the line terminator of the last read line from {@link #readLine()}.
+     *
+     * @return {@code "\n"}, {@code "\r"}, {@code "\r\n"}, or {@code null}
+     */
+    public String getLineTerminator() {
+        return lineTerminator;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (reader == null) {
+            return;
+        }
+        try {
+            reader.close();
+        } finally {
+            reader = null;
+            cbuf = null;
+        }
+    }
+
+    private void fill() throws IOException {
+        int read;
+        do {
+            read = reader.read(cbuf, 0, cbuf.length);
+        } while (read == 0);
+        if (read > 0) {
+            limit = read;
+            position = 0;
+        }
+    }
+
+    private String line(String line, String lineTerminator) {
+        this.lineTerminator = lineTerminator;
+        return line;
+    }
+
+    private String finish(StringBuilder sb, int start, int end) {
+        int len = end - start;
+        if (sb == null) {
+            return new String(cbuf, start, len);
+        } else {
+            return sb.append(cbuf, start, len).toString();
+        }
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/node/SourceSpans.java
+++ b/commonmark/src/main/java/org/commonmark/node/SourceSpans.java
@@ -41,8 +41,8 @@ public class SourceSpans {
             int lastIndex = sourceSpans.size() - 1;
             SourceSpan a = sourceSpans.get(lastIndex);
             SourceSpan b = other.get(0);
-            if (a.getLineIndex() == b.getLineIndex() && a.getColumnIndex() + a.getLength() == b.getColumnIndex()) {
-                sourceSpans.set(lastIndex, SourceSpan.of(a.getLineIndex(), a.getColumnIndex(), a.getLength() + b.getLength()));
+            if (a.getInputIndex() + a.getLength() == b.getInputIndex()) {
+                sourceSpans.set(lastIndex, SourceSpan.of(a.getLineIndex(), a.getColumnIndex(), a.getInputIndex(), a.getLength() + b.getLength()));
                 sourceSpans.addAll(other.subList(1, other.size()));
             } else {
                 sourceSpans.addAll(other);

--- a/commonmark/src/main/java/org/commonmark/parser/SourceLine.java
+++ b/commonmark/src/main/java/org/commonmark/parser/SourceLine.java
@@ -35,10 +35,11 @@ public class SourceLine {
         CharSequence newContent = content.subSequence(beginIndex, endIndex);
         SourceSpan newSourceSpan = null;
         if (sourceSpan != null) {
-            int columnIndex = sourceSpan.getColumnIndex() + beginIndex;
             int length = endIndex - beginIndex;
             if (length != 0) {
-                newSourceSpan = SourceSpan.of(sourceSpan.getLineIndex(), columnIndex, length);
+                int columnIndex = sourceSpan.getColumnIndex() + beginIndex;
+                int inputIndex = sourceSpan.getInputIndex() + beginIndex;
+                newSourceSpan = SourceSpan.of(sourceSpan.getLineIndex(), columnIndex, inputIndex, length);
             }
         }
         return SourceLine.of(newContent, newSourceSpan);

--- a/commonmark/src/main/java/org/commonmark/parser/beta/Scanner.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/Scanner.java
@@ -244,7 +244,7 @@ public class Scanner {
             SourceSpan newSourceSpan = null;
             SourceSpan sourceSpan = line.getSourceSpan();
             if (sourceSpan != null) {
-                newSourceSpan = SourceSpan.of(sourceSpan.getLineIndex(), sourceSpan.getColumnIndex() + begin.index, newContent.length());
+                newSourceSpan = sourceSpan.subSpan(begin.index, end.index);
             }
             return SourceLines.of(SourceLine.of(newContent, newSourceSpan));
         } else {

--- a/commonmark/src/test/java/org/commonmark/internal/util/LineReaderTest.java
+++ b/commonmark/src/test/java/org/commonmark/internal/util/LineReaderTest.java
@@ -1,0 +1,128 @@
+package org.commonmark.internal.util;
+
+import org.junit.Test;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
+
+import static java.util.stream.Collectors.joining;
+import static org.commonmark.internal.util.LineReader.CHAR_BUFFER_SIZE;
+import static org.junit.Assert.*;
+
+public class LineReaderTest {
+
+    @Test
+    public void testReadLine() throws IOException {
+        assertLines();
+
+        assertLines("", "\n");
+        assertLines("foo", "\n", "bar", "\n");
+        assertLines("foo", "\n", "bar", null);
+        assertLines("", "\n", "", "\n");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE - 1), "\n");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE), "\n");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE) + "b", "\n");
+
+        assertLines("", "\r\n");
+        assertLines("foo", "\r\n", "bar", "\r\n");
+        assertLines("foo", "\r\n", "bar", null);
+        assertLines("", "\r\n", "", "\r\n");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE - 2), "\r\n");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE - 1), "\r\n");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE), "\r\n");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE) + "b", "\r\n");
+
+        assertLines("", "\r");
+        assertLines("foo", "\r", "bar", "\r");
+        assertLines("foo", "\r", "bar", null);
+        assertLines("", "\r", "", "\r");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE - 1), "\r");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE), "\r");
+        assertLines(repeat("a", CHAR_BUFFER_SIZE) + "b", "\r");
+
+        assertLines("", "\n", "", "\r", "", "\r\n", "", "\n");
+        assertLines("what", "\r", "are", "\r", "", "\r", "you", "\r\n", "", "\r\n", "even", "\n", "doing", null);
+    }
+
+    @Test
+    public void testClose() throws IOException {
+        var reader = new InputStreamReader(new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)));
+        var lineReader = new LineReader(reader);
+        lineReader.close();
+        lineReader.close();
+        try {
+            reader.read();
+            fail("Expected read to throw after closing reader");
+        } catch (IOException e) {
+            // Expected
+        }
+    }
+
+    private void assertLines(String... s) throws IOException {
+        assertTrue("Expected parts needs to be even (pairs of content and terminator)", s.length % 2 == 0);
+        var input = Arrays.stream(s).filter(Objects::nonNull).collect(joining(""));
+
+        assertLines(new StringReader(input), s);
+        assertLines(new SlowStringReader(input), s);
+    }
+
+    private static void assertLines(Reader reader, String... expectedParts) throws IOException {
+        try (var lineReader = new LineReader(reader)) {
+            var lines = new ArrayList<>();
+            String line;
+            while ((line = lineReader.readLine()) != null) {
+                lines.add(line);
+                lines.add(lineReader.getLineTerminator());
+            }
+            assertNull(lineReader.getLineTerminator());
+            assertEquals(Arrays.asList(expectedParts), lines);
+        }
+    }
+
+    private static String repeat(String s, int count) {
+        StringBuilder sb = new StringBuilder(s.length() * count);
+        for (int i = 0; i < count; i++) {
+            sb.append(s);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Reader that only reads 0 or 1 chars at a time to test the corner cases.
+     */
+    private static class SlowStringReader extends Reader {
+
+        private final String s;
+        private int position = 0;
+        private boolean empty = false;
+
+        private SlowStringReader(String s) {
+            this.s = s;
+        }
+
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            Objects.checkFromIndexSize(off, len, cbuf.length);
+            if (len == 0) {
+                return 0;
+            }
+            empty = !empty;
+            if (empty) {
+                // Return 0 every other time to test handling of 0.
+                return 0;
+            }
+            if (position >= s.length()) {
+                return -1;
+            }
+            cbuf[off] = s.charAt(position++);
+            return 1;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/parser/beta/ScannerTest.java
+++ b/commonmark/src/test/java/org/commonmark/parser/beta/ScannerTest.java
@@ -85,8 +85,8 @@ public class ScannerTest {
     @Test
     public void testTextBetween() {
         Scanner scanner = new Scanner(List.of(
-                SourceLine.of("ab", SourceSpan.of(10, 3, 2)),
-                SourceLine.of("cde", SourceSpan.of(11, 4, 3))),
+                SourceLine.of("ab", SourceSpan.of(10, 3, 13, 2)),
+                SourceLine.of("cde", SourceSpan.of(11, 4, 20, 3))),
                 0, 0);
 
         Position start = scanner.position();
@@ -94,48 +94,48 @@ public class ScannerTest {
         scanner.next();
         assertSourceLines(scanner.getSource(start, scanner.position()),
                 "a",
-                SourceSpan.of(10, 3, 1));
+                SourceSpan.of(10, 3, 13, 1));
 
         Position afterA = scanner.position();
 
         scanner.next();
         assertSourceLines(scanner.getSource(start, scanner.position()),
                 "ab",
-                SourceSpan.of(10, 3, 2));
+                SourceSpan.of(10, 3, 13, 2));
 
         Position afterB = scanner.position();
 
         scanner.next();
         assertSourceLines(scanner.getSource(start, scanner.position()),
                 "ab\n",
-                SourceSpan.of(10, 3, 2));
+                SourceSpan.of(10, 3, 13, 2));
 
         scanner.next();
         assertSourceLines(scanner.getSource(start, scanner.position()),
                 "ab\nc",
-                SourceSpan.of(10, 3, 2),
-                SourceSpan.of(11, 4, 1));
+                SourceSpan.of(10, 3, 13, 2),
+                SourceSpan.of(11, 4, 20, 1));
 
         scanner.next();
         assertSourceLines(scanner.getSource(start, scanner.position()),
                 "ab\ncd",
-                SourceSpan.of(10, 3, 2),
-                SourceSpan.of(11, 4, 2));
+                SourceSpan.of(10, 3, 13, 2),
+                SourceSpan.of(11, 4, 20, 2));
 
         scanner.next();
         assertSourceLines(scanner.getSource(start, scanner.position()),
                 "ab\ncde",
-                SourceSpan.of(10, 3, 2),
-                SourceSpan.of(11, 4, 3));
+                SourceSpan.of(10, 3, 13, 2),
+                SourceSpan.of(11, 4, 20, 3));
 
         assertSourceLines(scanner.getSource(afterA, scanner.position()),
                 "b\ncde",
-                SourceSpan.of(10, 4, 1),
-                SourceSpan.of(11, 4, 3));
+                SourceSpan.of(10, 4, 14, 1),
+                SourceSpan.of(11, 4, 20, 3));
 
         assertSourceLines(scanner.getSource(afterB, scanner.position()),
                 "\ncde",
-                SourceSpan.of(11, 4, 3));
+                SourceSpan.of(11, 4, 20, 3));
     }
 
     private void assertSourceLines(SourceLines sourceLines, String expectedContent, SourceSpan... expectedSourceSpans) {

--- a/commonmark/src/test/java/org/commonmark/test/SourceLineTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceLineTest.java
@@ -10,29 +10,29 @@ public class SourceLineTest {
 
     @Test
     public void testSubstring() {
-        SourceLine line = SourceLine.of("abcd", SourceSpan.of(3, 10, 4));
+        SourceLine line = SourceLine.of("abcd", SourceSpan.of(3, 10, 13, 4));
 
-        assertSourceLine(line.substring(0, 4), "abcd", SourceSpan.of(3, 10, 4));
-        assertSourceLine(line.substring(0, 3), "abc", SourceSpan.of(3, 10, 3));
-        assertSourceLine(line.substring(0, 2), "ab", SourceSpan.of(3, 10, 2));
-        assertSourceLine(line.substring(0, 1), "a", SourceSpan.of(3, 10, 1));
+        assertSourceLine(line.substring(0, 4), "abcd", SourceSpan.of(3, 10, 13, 4));
+        assertSourceLine(line.substring(0, 3), "abc", SourceSpan.of(3, 10, 13, 3));
+        assertSourceLine(line.substring(0, 2), "ab", SourceSpan.of(3, 10, 13, 2));
+        assertSourceLine(line.substring(0, 1), "a", SourceSpan.of(3, 10, 13, 1));
         assertSourceLine(line.substring(0, 0), "", null);
 
-        assertSourceLine(line.substring(1, 4), "bcd", SourceSpan.of(3, 11, 3));
-        assertSourceLine(line.substring(1, 3), "bc", SourceSpan.of(3, 11, 2));
+        assertSourceLine(line.substring(1, 4), "bcd", SourceSpan.of(3, 11, 14, 3));
+        assertSourceLine(line.substring(1, 3), "bc", SourceSpan.of(3, 11, 14, 2));
 
-        assertSourceLine(line.substring(3, 4), "d", SourceSpan.of(3, 13, 1));
+        assertSourceLine(line.substring(3, 4), "d", SourceSpan.of(3, 13, 16, 1));
         assertSourceLine(line.substring(4, 4), "", null);
     }
 
     @Test(expected = StringIndexOutOfBoundsException.class)
     public void testSubstringBeginOutOfBounds() {
-        SourceLine.of("abcd", SourceSpan.of(3, 10, 4)).substring(3, 2);
+        SourceLine.of("abcd", SourceSpan.of(3, 10, 13, 4)).substring(3, 2);
     }
 
     @Test(expected = StringIndexOutOfBoundsException.class)
     public void testSubstringEndOutOfBounds() {
-        SourceLine.of("abcd", SourceSpan.of(3, 10, 4)).substring(0, 5);
+        SourceLine.of("abcd", SourceSpan.of(3, 10, 13, 4)).substring(0, 5);
     }
 
     private static void assertSourceLine(SourceLine sourceLine, String expectedContent, SourceSpan expectedSourceSpan) {

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpanTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpanTest.java
@@ -1,0 +1,63 @@
+package org.commonmark.test;
+
+import org.commonmark.node.SourceSpan;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class SourceSpanTest {
+
+    @Test
+    public void testSubSpan() {
+        var span = SourceSpan.of(1, 2, 3, 5);
+
+        assertSame(span.subSpan(0), span);
+        assertSame(span.subSpan(0, 5), span);
+
+        assertEquals(SourceSpan.of(1, 3, 4, 4), span.subSpan(1));
+        assertEquals(SourceSpan.of(1, 4, 5, 3), span.subSpan(2));
+        assertEquals(SourceSpan.of(1, 5, 6, 2), span.subSpan(3));
+        assertEquals(SourceSpan.of(1, 6, 7, 1), span.subSpan(4));
+        // Not sure if empty spans are useful, but it probably makes sense to mirror how substrings work
+        assertEquals(SourceSpan.of(1, 7, 8, 0), span.subSpan(5));
+        assertEquals("", "abcde".substring(5));
+
+        assertEquals(SourceSpan.of(1, 2, 3, 5), span.subSpan(0, 5));
+        assertEquals(SourceSpan.of(1, 2, 3, 4), span.subSpan(0, 4));
+        assertEquals(SourceSpan.of(1, 2, 3, 3), span.subSpan(0, 3));
+        assertEquals(SourceSpan.of(1, 2, 3, 2), span.subSpan(0, 2));
+        assertEquals(SourceSpan.of(1, 2, 3, 1), span.subSpan(0, 1));
+        assertEquals(SourceSpan.of(1, 2, 3, 0), span.subSpan(0, 0));
+        assertEquals("a", "abcde".substring(0, 1));
+        assertEquals("", "abcde".substring(0, 0));
+
+        assertEquals(SourceSpan.of(1, 3, 4, 3), span.subSpan(1, 4));
+        assertEquals(SourceSpan.of(1, 4, 5, 1), span.subSpan(2, 3));
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSubSpanBeginIndexNegative() {
+        SourceSpan.of(1, 2, 3, 5).subSpan(-1);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSubSpanBeginIndexOutOfBounds() {
+        SourceSpan.of(1, 2, 3, 5).subSpan(6);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSubSpanEndIndexNegative() {
+        SourceSpan.of(1, 2, 3, 5).subSpan(0, -1);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSubSpanEndIndexOutOfBounds() {
+        SourceSpan.of(1, 2, 3, 5).subSpan(0, 6);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSubSpanBeginIndexGreaterThanEndIndex() {
+        SourceSpan.of(1, 2, 3, 5).subSpan(2, 1);
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
@@ -5,6 +5,8 @@ import org.commonmark.parser.IncludeSourceSpans;
 import org.commonmark.parser.Parser;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
@@ -18,137 +20,135 @@ public class SourceSpansTest {
 
     @Test
     public void paragraph() {
-        assertSpans("foo\n", Paragraph.class, SourceSpan.of(0, 0, 3));
-        assertSpans("foo\nbar\n", Paragraph.class, SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3));
-        assertSpans("  foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 5));
-        assertSpans("> foo\n> bar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
-        assertSpans("* foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
-        assertSpans("* foo\nbar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 0, 3));
+        assertSpans("foo\n", Paragraph.class, SourceSpan.of(0, 0, 0, 3));
+        assertSpans("foo\nbar\n", Paragraph.class, SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3));
+        assertSpans("  foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 5));
+        assertSpans("> foo\n> bar\n", Paragraph.class, SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3));
+        assertSpans("* foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3));
+        assertSpans("* foo\nbar\n", Paragraph.class, SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 0, 6, 3));
     }
 
     @Test
     public void thematicBreak() {
-        assertSpans("---\n", ThematicBreak.class, SourceSpan.of(0, 0, 3));
-        assertSpans("  ---\n", ThematicBreak.class, SourceSpan.of(0, 0, 5));
-        assertSpans("> ---\n", ThematicBreak.class, SourceSpan.of(0, 2, 3));
+        assertSpans("---\n", ThematicBreak.class, SourceSpan.of(0, 0, 0, 3));
+        assertSpans("  ---\n", ThematicBreak.class, SourceSpan.of(0, 0, 0, 5));
+        assertSpans("> ---\n", ThematicBreak.class, SourceSpan.of(0, 2, 2, 3));
     }
 
     @Test
     public void atxHeading() {
-        assertSpans("# foo", Heading.class, SourceSpan.of(0, 0, 5));
-        assertSpans(" # foo", Heading.class, SourceSpan.of(0, 0, 6));
-        assertSpans("## foo ##", Heading.class, SourceSpan.of(0, 0, 9));
-        assertSpans("> # foo", Heading.class, SourceSpan.of(0, 2, 5));
+        assertSpans("# foo", Heading.class, SourceSpan.of(0, 0, 0, 5));
+        assertSpans(" # foo", Heading.class, SourceSpan.of(0, 0, 0, 6));
+        assertSpans("## foo ##", Heading.class, SourceSpan.of(0, 0, 0, 9));
+        assertSpans("> # foo", Heading.class, SourceSpan.of(0, 2, 2, 5));
     }
 
     @Test
     public void setextHeading() {
-        assertSpans("foo\n===\n", Heading.class, SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3));
-        assertSpans("foo\nbar\n====\n", Heading.class, SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 4));
-        assertSpans("  foo\n  ===\n", Heading.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 5));
-        assertSpans("> foo\n> ===\n", Heading.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
+        assertSpans("foo\n===\n", Heading.class, SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3));
+        assertSpans("foo\nbar\n====\n", Heading.class, SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3), SourceSpan.of(2, 0, 8, 4));
+        assertSpans("  foo\n  ===\n", Heading.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 5));
+        assertSpans("> foo\n> ===\n", Heading.class, SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3));
     }
 
     @Test
     public void indentedCodeBlock() {
-        assertSpans("    foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7));
-        assertSpans("     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 8));
-        assertSpans("\tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 4));
-        assertSpans(" \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 5));
-        assertSpans("  \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 6));
-        assertSpans("   \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7));
-        assertSpans("    \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 8));
-        assertSpans("    \t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 9));
-        assertSpans("\t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 5));
-        assertSpans("\t  foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 6));
-        assertSpans("    foo\n     bar\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 8));
-        assertSpans("    foo\n\tbar\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 4));
-        assertSpans("    foo\n    \n     \n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 4), SourceSpan.of(2, 0, 5));
-        assertSpans(">     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 2, 7));
+        assertSpans("    foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 7));
+        assertSpans("     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 8));
+        assertSpans("\tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 4));
+        assertSpans(" \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 5));
+        assertSpans("  \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 6));
+        assertSpans("   \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 7));
+        assertSpans("    \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 8));
+        assertSpans("    \t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 9));
+        assertSpans("\t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 5));
+        assertSpans("\t  foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 6));
+        assertSpans("    foo\n     bar\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 8));
+        assertSpans("    foo\n\tbar\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 4));
+        assertSpans("    foo\n    \n     \n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 4), SourceSpan.of(2, 0, 13, 5));
+        assertSpans(">     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 2, 2, 7));
     }
 
     @Test
     public void fencedCodeBlock() {
         assertSpans("```\nfoo\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
+                SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3), SourceSpan.of(2, 0, 8, 3));
         assertSpans("```\n foo\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 4), SourceSpan.of(2, 0, 3));
+                SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 4), SourceSpan.of(2, 0, 9, 3));
         assertSpans("```\nfoo\nbar\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
-        assertSpans("```\nfoo\nbar\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
+                SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3), SourceSpan.of(2, 0, 8, 3), SourceSpan.of(3, 0, 12, 3));
         assertSpans("   ```\n   foo\n   ```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 6), SourceSpan.of(1, 0, 6), SourceSpan.of(2, 0, 6));
+                SourceSpan.of(0, 0, 0, 6), SourceSpan.of(1, 0, 7, 6), SourceSpan.of(2, 0, 14, 6));
         assertSpans(" ```\n foo\nfoo\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 4), SourceSpan.of(1, 0, 4), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
+                SourceSpan.of(0, 0, 0, 4), SourceSpan.of(1, 0, 5, 4), SourceSpan.of(2, 0, 10, 3), SourceSpan.of(3, 0, 14, 3));
         assertSpans("```info\nfoo\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
+                SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 3), SourceSpan.of(2, 0, 12, 3));
         assertSpans("* ```\n  foo\n  ```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3), SourceSpan.of(2, 2, 3));
+                SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3), SourceSpan.of(2, 2, 14, 3));
         assertSpans("> ```\n> foo\n> ```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3), SourceSpan.of(2, 2, 3));
+                SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3), SourceSpan.of(2, 2, 14, 3));
 
         Node document = PARSER.parse("```\nfoo\n```\nbar\n");
         Paragraph paragraph = (Paragraph) document.getLastChild();
-        assertEquals(List.of(SourceSpan.of(3, 0, 3)), paragraph.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(3, 0, 12, 3)), paragraph.getSourceSpans());
     }
 
     @Test
     public void htmlBlock() {
-        assertSpans("<div>\n", HtmlBlock.class, SourceSpan.of(0, 0, 5));
+        assertSpans("<div>\n", HtmlBlock.class, SourceSpan.of(0, 0, 0, 5));
         assertSpans(" <div>\n foo\n </div>\n", HtmlBlock.class,
-                SourceSpan.of(0, 0, 6),
-                SourceSpan.of(1, 0, 4),
-                SourceSpan.of(2, 0, 7));
-        assertSpans("* <div>\n", HtmlBlock.class, SourceSpan.of(0, 2, 5));
+                SourceSpan.of(0, 0, 0, 6),
+                SourceSpan.of(1, 0, 7, 4),
+                SourceSpan.of(2, 0, 12, 7));
+        assertSpans("* <div>\n", HtmlBlock.class, SourceSpan.of(0, 2, 2, 5));
     }
 
     @Test
     public void blockQuote() {
-        assertSpans(">foo\n", BlockQuote.class, SourceSpan.of(0, 0, 4));
-        assertSpans("> foo\n", BlockQuote.class, SourceSpan.of(0, 0, 5));
-        assertSpans(">  foo\n", BlockQuote.class, SourceSpan.of(0, 0, 6));
-        assertSpans(" > foo\n", BlockQuote.class, SourceSpan.of(0, 0, 6));
-        assertSpans("   > foo\n  > bar\n", BlockQuote.class, SourceSpan.of(0, 0, 8), SourceSpan.of(1, 0, 7));
+        assertSpans(">foo\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 4));
+        assertSpans("> foo\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 5));
+        assertSpans(">  foo\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 6));
+        assertSpans(" > foo\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 6));
+        assertSpans("   > foo\n  > bar\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 8), SourceSpan.of(1, 0, 9, 7));
         // Lazy continuations
-        assertSpans("> foo\nbar\n", BlockQuote.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3));
-        assertSpans("> foo\nbar\n> baz\n", BlockQuote.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 5));
-        assertSpans("> > foo\nbar\n", BlockQuote.class, SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 3));
+        assertSpans("> foo\nbar\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3));
+        assertSpans("> foo\nbar\n> baz\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3), SourceSpan.of(2, 0, 10, 5));
+        assertSpans("> > foo\nbar\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 3));
     }
 
     @Test
     public void listBlock() {
-        assertSpans("* foo\n", ListBlock.class, SourceSpan.of(0, 0, 5));
-        assertSpans("* foo\n  bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 5));
-        assertSpans("* foo\n* bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 5));
-        assertSpans("* foo\n  # bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 7));
-        assertSpans("* foo\n  * bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 7));
-        assertSpans("* foo\n> bar\n", ListBlock.class, SourceSpan.of(0, 0, 5));
-        assertSpans("> * foo\n", ListBlock.class, SourceSpan.of(0, 2, 5));
+        assertSpans("* foo\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5));
+        assertSpans("* foo\n  bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 5));
+        assertSpans("* foo\n* bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 5));
+        assertSpans("* foo\n  # bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 7));
+        assertSpans("* foo\n  * bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 7));
+        assertSpans("* foo\n> bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5));
+        assertSpans("> * foo\n", ListBlock.class, SourceSpan.of(0, 2, 2, 5));
 
         // Lazy continuations
-        assertSpans("* foo\nbar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
-        assertSpans("* foo\nbar\n* baz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 5));
-        assertSpans("* foo\n  * bar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 7), SourceSpan.of(2, 0, 3));
+        assertSpans("* foo\nbar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3), SourceSpan.of(2, 0, 10, 3));
+        assertSpans("* foo\nbar\n* baz", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3), SourceSpan.of(2, 0, 10, 5));
+        assertSpans("* foo\n  * bar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 7), SourceSpan.of(2, 0, 14, 3));
 
         Node document = PARSER.parse("* foo\n  * bar\n");
         ListBlock listBlock = (ListBlock) document.getFirstChild().getFirstChild().getLastChild();
-        assertEquals(List.of(SourceSpan.of(1, 2, 5)), listBlock.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(1, 2, 8, 5)), listBlock.getSourceSpans());
     }
 
     @Test
     public void listItem() {
-        assertSpans("* foo\n", ListItem.class, SourceSpan.of(0, 0, 5));
-        assertSpans(" * foo\n", ListItem.class, SourceSpan.of(0, 0, 6));
-        assertSpans("  * foo\n", ListItem.class, SourceSpan.of(0, 0, 7));
-        assertSpans("   * foo\n", ListItem.class, SourceSpan.of(0, 0, 8));
-        assertSpans("*\n  foo\n", ListItem.class, SourceSpan.of(0, 0, 1), SourceSpan.of(1, 0, 5));
-        assertSpans("*\n  foo\n  bar\n", ListItem.class, SourceSpan.of(0, 0, 1), SourceSpan.of(1, 0, 5), SourceSpan.of(2, 0, 5));
-        assertSpans("> * foo\n", ListItem.class, SourceSpan.of(0, 2, 5));
+        assertSpans("* foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 5));
+        assertSpans(" * foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 6));
+        assertSpans("  * foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 7));
+        assertSpans("   * foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 8));
+        assertSpans("*\n  foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 1), SourceSpan.of(1, 0, 2, 5));
+        assertSpans("*\n  foo\n  bar\n", ListItem.class, SourceSpan.of(0, 0, 0, 1), SourceSpan.of(1, 0, 2, 5), SourceSpan.of(2, 0, 8, 5));
+        assertSpans("> * foo\n", ListItem.class, SourceSpan.of(0, 2, 2, 5));
 
         // Lazy continuations
-        assertSpans("* foo\nbar\n", ListItem.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3));
-        assertSpans("* foo\nbar\nbaz\n", ListItem.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
+        assertSpans("* foo\nbar\n", ListItem.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3));
+        assertSpans("* foo\nbar\nbaz\n", ListItem.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3), SourceSpan.of(2, 0, 10, 3));
     }
 
     @Test
@@ -158,10 +158,10 @@ public class SourceSpansTest {
         Node document = PARSER.parse("[foo]: /url\ntext\n");
 
         LinkReferenceDefinition linkReferenceDefinition = (LinkReferenceDefinition) document.getFirstChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 11)), linkReferenceDefinition.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 11)), linkReferenceDefinition.getSourceSpans());
 
         Paragraph paragraph = (Paragraph) document.getLastChild();
-        assertEquals(List.of(SourceSpan.of(1, 0, 4)), paragraph.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(1, 0, 12, 4)), paragraph.getSourceSpans());
     }
 
     @Test
@@ -169,8 +169,8 @@ public class SourceSpansTest {
         var doc = PARSER.parse("[foo]: /foo\n[bar]: /bar\n");
         var def1 = (LinkReferenceDefinition) doc.getFirstChild();
         var def2 = (LinkReferenceDefinition) doc.getLastChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 11)), def1.getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(1, 0, 11)), def2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 11)), def1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(1, 0, 12, 11)), def2.getSourceSpans());
     }
 
     @Test
@@ -178,8 +178,8 @@ public class SourceSpansTest {
         var doc = PARSER.parse("[1]: #not-code \"Text\"\n[foo]: /foo\n");
         var def1 = (LinkReferenceDefinition) doc.getFirstChild();
         var def2 = (LinkReferenceDefinition) doc.getLastChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 21)), def1.getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(1, 0, 11)), def2.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 21)), def1.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(1, 0, 22, 11)), def2.getSourceSpans());
     }
 
     @Test
@@ -187,8 +187,8 @@ public class SourceSpansTest {
         var doc = PARSER.parse("[foo]: /url\n\"title\" ok\n");
         var def = Nodes.find(doc, LinkReferenceDefinition.class);
         var paragraph = Nodes.find(doc, Paragraph.class);
-        assertEquals(List.of(SourceSpan.of(0, 0, 11)), def.getSourceSpans());
-        assertEquals(List.of(SourceSpan.of(1, 0, 10)), paragraph.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 11)), def.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(1, 0, 12, 10)), paragraph.getSourceSpans());
     }
 
     @Test
@@ -198,10 +198,10 @@ public class SourceSpansTest {
         Node document = PARSER.parse("[foo]: /url\nHeading\n===\n");
 
         LinkReferenceDefinition linkReferenceDefinition = (LinkReferenceDefinition) document.getFirstChild();
-        assertEquals(List.of(SourceSpan.of(0, 0, 11)), linkReferenceDefinition.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 0, 0, 11)), linkReferenceDefinition.getSourceSpans());
 
         Heading heading = (Heading) document.getLastChild();
-        assertEquals(List.of(SourceSpan.of(1, 0, 7), SourceSpan.of(2, 0, 3)), heading.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(1, 0, 12, 7), SourceSpan.of(2, 0, 20, 3)), heading.getSourceSpans());
     }
 
     @Test
@@ -212,13 +212,13 @@ public class SourceSpansTest {
             var doc = PARSER.parse("> > > foo\nbar\n");
 
             var bq1 = (BlockQuote) doc.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 0, 9), SourceSpan.of(1, 0, 3)), bq1.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 0, 0, 9), SourceSpan.of(1, 0, 10, 3)), bq1.getSourceSpans());
             var bq2 = (BlockQuote) bq1.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 2, 7), SourceSpan.of(1, 0, 3)), bq2.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 2, 2, 7), SourceSpan.of(1, 0, 10, 3)), bq2.getSourceSpans());
             var bq3 = (BlockQuote) bq2.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 4, 5), SourceSpan.of(1, 0, 3)), bq3.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 4, 4, 5), SourceSpan.of(1, 0, 10, 3)), bq3.getSourceSpans());
             var paragraph = (Paragraph) bq3.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 6, 3), SourceSpan.of(1, 0, 3)), paragraph.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 6, 6, 3), SourceSpan.of(1, 0, 10, 3)), paragraph.getSourceSpans());
         }
 
         {
@@ -226,13 +226,13 @@ public class SourceSpansTest {
             var doc = PARSER.parse("> > > foo\nbars\n");
 
             var bq1 = (BlockQuote) doc.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 0, 9), SourceSpan.of(1, 0, 4)), bq1.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 0, 0, 9), SourceSpan.of(1, 0, 10, 4)), bq1.getSourceSpans());
             var bq2 = (BlockQuote) bq1.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 2, 7), SourceSpan.of(1, 0, 4)), bq2.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 2, 2, 7), SourceSpan.of(1, 0, 10, 4)), bq2.getSourceSpans());
             var bq3 = (BlockQuote) bq2.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 4, 5), SourceSpan.of(1, 0, 4)), bq3.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 4, 4, 5), SourceSpan.of(1, 0, 10, 4)), bq3.getSourceSpans());
             var paragraph = (Paragraph) bq3.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 6, 3), SourceSpan.of(1, 0, 4)), paragraph.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 6, 6, 3), SourceSpan.of(1, 0, 10, 4)), paragraph.getSourceSpans());
         }
 
         {
@@ -240,15 +240,15 @@ public class SourceSpansTest {
             var doc = PARSER.parse("> 1. > Blockquote\ncontinued here.");
 
             var bq1 = (BlockQuote) doc.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 0, 17), SourceSpan.of(1, 0, 15)), bq1.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 0, 0, 17), SourceSpan.of(1, 0, 18, 15)), bq1.getSourceSpans());
             var orderedList = (OrderedList) bq1.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 2, 15), SourceSpan.of(1, 0, 15)), orderedList.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 2, 2, 15), SourceSpan.of(1, 0, 18, 15)), orderedList.getSourceSpans());
             var listItem = (ListItem) orderedList.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 2, 15), SourceSpan.of(1, 0, 15)), listItem.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 2, 2, 15), SourceSpan.of(1, 0, 18, 15)), listItem.getSourceSpans());
             var bq2 = (BlockQuote) listItem.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 5, 12), SourceSpan.of(1, 0, 15)), bq2.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 5, 5, 12), SourceSpan.of(1, 0, 18, 15)), bq2.getSourceSpans());
             var paragraph = (Paragraph) bq2.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 7, 10), SourceSpan.of(1, 0, 15)), paragraph.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 7, 7, 10), SourceSpan.of(1, 0, 18, 15)), paragraph.getSourceSpans());
         }
 
         {
@@ -256,127 +256,151 @@ public class SourceSpansTest {
             var doc = PARSER.parse("> > foo\n> bar\n");
 
             var bq1 = (BlockQuote) doc.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 5)), bq1.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 5)), bq1.getSourceSpans());
             var bq2 = (BlockQuote) bq1.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 2, 5), SourceSpan.of(1, 2, 3)), bq2.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 2, 2, 5), SourceSpan.of(1, 2, 10, 3)), bq2.getSourceSpans());
             var paragraph = (Paragraph) bq2.getLastChild();
-            assertEquals(List.of(SourceSpan.of(0, 4, 3), SourceSpan.of(1, 2, 3)), paragraph.getSourceSpans());
+            assertEquals(List.of(SourceSpan.of(0, 4, 4, 3), SourceSpan.of(1, 2, 10, 3)), paragraph.getSourceSpans());
         }
     }
 
     @Test
     public void visualCheck() {
-        assertEquals("(> {[* <foo>]})\n(> {[  <bar>]})\n(> {⸢* ⸤baz⸥⸣})\n",
-                visualizeSourceSpans("> * foo\n>   bar\n> * baz\n"));
-        assertEquals("(> {[* <```>]})\n(> {[  <foo>]})\n(> {[  <```>]})\n",
-                visualizeSourceSpans("> * ```\n>   foo\n>   ```"));
+        assertVisualize("> * foo\n>   bar\n> * baz\n", "(> {[* <foo>]})\n(> {[  <bar>]})\n(> {⸢* ⸤baz⸥⸣})\n");
+        assertVisualize("> * ```\n>   foo\n>   ```\n", "(> {[* <```>]})\n(> {[  <foo>]})\n(> {[  <```>]})\n");
     }
 
     @Test
     public void inlineText() {
-        assertInlineSpans("foo", Text.class, SourceSpan.of(0, 0, 3));
-        assertInlineSpans("> foo", Text.class, SourceSpan.of(0, 2, 3));
-        assertInlineSpans("* foo", Text.class, SourceSpan.of(0, 2, 3));
+        assertInlineSpans("foo", Text.class, SourceSpan.of(0, 0, 0, 3));
+        assertInlineSpans("> foo", Text.class, SourceSpan.of(0, 2, 2, 3));
+        assertInlineSpans("* foo", Text.class, SourceSpan.of(0, 2, 2, 3));
 
         // SourceSpans should be merged: ` is a separate Text node while inline parsing and gets merged at the end
-        assertInlineSpans("foo`bar", Text.class, SourceSpan.of(0, 0, 7));
-        assertInlineSpans("foo[bar", Text.class, SourceSpan.of(0, 0, 7));
+        assertInlineSpans("foo`bar", Text.class, SourceSpan.of(0, 0, 0, 7));
+        assertInlineSpans("foo[bar", Text.class, SourceSpan.of(0, 0, 0, 7));
+        assertInlineSpans("> foo`bar", Text.class, SourceSpan.of(0, 2, 2, 7));
 
-        assertInlineSpans("[foo](/url)", Text.class, SourceSpan.of(0, 1, 3));
-        assertInlineSpans("*foo*", Text.class, SourceSpan.of(0, 1, 3));
+        assertInlineSpans("[foo](/url)", Text.class, SourceSpan.of(0, 1, 1, 3));
+        assertInlineSpans("*foo*", Text.class, SourceSpan.of(0, 1, 1, 3));
     }
 
     @Test
     public void inlineHeading() {
-        assertInlineSpans("# foo", Text.class, SourceSpan.of(0, 2, 3));
-        assertInlineSpans(" # foo", Text.class, SourceSpan.of(0, 3, 3));
-        assertInlineSpans("> # foo", Text.class, SourceSpan.of(0, 4, 3));
+        assertInlineSpans("# foo", Text.class, SourceSpan.of(0, 2, 2, 3));
+        assertInlineSpans(" # foo", Text.class, SourceSpan.of(0, 3, 3, 3));
+        assertInlineSpans("> # foo", Text.class, SourceSpan.of(0, 4, 4, 3));
     }
 
     @Test
     public void inlineAutolink() {
-        assertInlineSpans("see <https://example.org>", Link.class, SourceSpan.of(0, 4, 21));
+        assertInlineSpans("see <https://example.org>", Link.class, SourceSpan.of(0, 4, 4, 21));
     }
 
     @Test
     public void inlineBackslash() {
-        assertInlineSpans("\\!", Text.class, SourceSpan.of(0, 0, 2));
+        assertInlineSpans("\\!", Text.class, SourceSpan.of(0, 0, 0, 2));
     }
 
     @Test
     public void inlineBackticks() {
-        assertInlineSpans("see `code`", Code.class, SourceSpan.of(0, 4, 6));
+        assertInlineSpans("see `code`", Code.class, SourceSpan.of(0, 4, 4, 6));
         assertInlineSpans("`multi\nline`", Code.class,
-                SourceSpan.of(0, 0, 6),
-                SourceSpan.of(1, 0, 5));
-        assertInlineSpans("text ```", Text.class, SourceSpan.of(0, 0, 8));
+                SourceSpan.of(0, 0, 0, 6),
+                SourceSpan.of(1, 0, 7, 5));
+        assertInlineSpans("text ```", Text.class, SourceSpan.of(0, 0, 0, 8));
     }
 
     @Test
     public void inlineEntity() {
-        assertInlineSpans("&amp;", Text.class, SourceSpan.of(0, 0, 5));
+        assertInlineSpans("&amp;", Text.class, SourceSpan.of(0, 0, 0, 5));
     }
 
     @Test
     public void inlineHtml() {
-        assertInlineSpans("hi <strong>there</strong>", HtmlInline.class, SourceSpan.of(0, 3, 8));
+        assertInlineSpans("hi <strong>there</strong>", HtmlInline.class, SourceSpan.of(0, 3, 3, 8));
     }
 
     @Test
     public void links() {
-        assertInlineSpans("[text](/url)", Link.class, SourceSpan.of(0, 0, 12));
-        assertInlineSpans("[text](/url)", Text.class, SourceSpan.of(0, 1, 4));
+        assertInlineSpans("\n[text](/url)", Link.class, SourceSpan.of(1, 0, 1, 12));
+        assertInlineSpans("\n[text](/url)", Text.class, SourceSpan.of(1, 1, 2, 4));
 
-        assertInlineSpans("[text]\n\n[text]: /url", Link.class, SourceSpan.of(0, 0, 6));
-        assertInlineSpans("[text]\n\n[text]: /url", Text.class, SourceSpan.of(0, 1, 4));
-        assertInlineSpans("[text][]\n\n[text]: /url", Link.class, SourceSpan.of(0, 0, 8));
-        assertInlineSpans("[text][]\n\n[text]: /url", Text.class, SourceSpan.of(0, 1, 4));
-        assertInlineSpans("[text][ref]\n\n[ref]: /url", Link.class, SourceSpan.of(0, 0, 11));
-        assertInlineSpans("[text][ref]\n\n[ref]: /url", Text.class, SourceSpan.of(0, 1, 4));
-        assertInlineSpans("[notalink]", Text.class, SourceSpan.of(0, 0, 10));
+        assertInlineSpans("\n[text]\n\n[text]: /url", Link.class, SourceSpan.of(1, 0, 1, 6));
+        assertInlineSpans("\n[text]\n\n[text]: /url", Text.class, SourceSpan.of(1, 1, 2, 4));
+        assertInlineSpans("\n[text][]\n\n[text]: /url", Link.class, SourceSpan.of(1, 0, 1, 8));
+        assertInlineSpans("\n[text][]\n\n[text]: /url", Text.class, SourceSpan.of(1, 1, 2, 4));
+        assertInlineSpans("\n[text][ref]\n\n[ref]: /url", Link.class, SourceSpan.of(1, 0, 1, 11));
+        assertInlineSpans("\n[text][ref]\n\n[ref]: /url", Text.class, SourceSpan.of(1, 1, 2, 4));
+        assertInlineSpans("\n[notalink]", Text.class, SourceSpan.of(1, 0, 1, 10));
     }
 
     @Test
     public void inlineEmphasis() {
-        assertInlineSpans("*hey*", Emphasis.class, SourceSpan.of(0, 0, 5));
-        assertInlineSpans("*hey*", Text.class, SourceSpan.of(0, 1, 3));
-        assertInlineSpans("**hey**", StrongEmphasis.class, SourceSpan.of(0, 0, 7));
-        assertInlineSpans("**hey**", Text.class, SourceSpan.of(0, 2, 3));
+        assertInlineSpans("\n*hey*", Emphasis.class, SourceSpan.of(1, 0, 1, 5));
+        assertInlineSpans("\n*hey*", Text.class, SourceSpan.of(1, 1, 2, 3));
+        assertInlineSpans("\n**hey**", StrongEmphasis.class, SourceSpan.of(1, 0, 1, 7));
+        assertInlineSpans("\n**hey**", Text.class, SourceSpan.of(1, 2, 3, 3));
 
         // This is an interesting one. It renders like this:
         // <p>*<em>hey</em></p>
         // The delimiter processor only uses one of the asterisks.
         // So the first Text node should be the `*` at the beginning with the correct span.
-        assertInlineSpans("**hey*", Text.class, SourceSpan.of(0, 0, 1));
-        assertInlineSpans("**hey*", Emphasis.class, SourceSpan.of(0, 1, 5));
+        assertInlineSpans("\n**hey*", Text.class, SourceSpan.of(1, 0, 1, 1));
+        assertInlineSpans("\n**hey*", Emphasis.class, SourceSpan.of(1, 1, 2, 5));
 
-        assertInlineSpans("***hey**", Text.class, SourceSpan.of(0, 0, 1));
-        assertInlineSpans("***hey**", StrongEmphasis.class, SourceSpan.of(0, 1, 7));
+        assertInlineSpans("\n***hey**", Text.class, SourceSpan.of(1, 0, 1, 1));
+        assertInlineSpans("\n***hey**", StrongEmphasis.class, SourceSpan.of(1, 1, 2, 7));
 
         Node document = INLINES_PARSER.parse("*hey**");
         Node lastText = document.getFirstChild().getLastChild();
-        assertEquals(List.of(SourceSpan.of(0, 5, 1)), lastText.getSourceSpans());
+        assertEquals(List.of(SourceSpan.of(0, 5, 5, 1)), lastText.getSourceSpans());
     }
 
     @Test
     public void tabExpansion() {
-        assertInlineSpans(">\tfoo", BlockQuote.class, SourceSpan.of(0, 0, 5));
-        assertInlineSpans(">\tfoo", Text.class, SourceSpan.of(0, 2, 3));
+        assertInlineSpans(">\tfoo", BlockQuote.class, SourceSpan.of(0, 0, 0, 5));
+        assertInlineSpans(">\tfoo", Text.class, SourceSpan.of(0, 2, 2, 3));
 
-        assertInlineSpans("a\tb", Text.class, SourceSpan.of(0, 0, 3));
+        assertInlineSpans("a\tb", Text.class, SourceSpan.of(0, 0, 0, 3));
     }
 
-    private String visualizeSourceSpans(String source) {
-        Node document = PARSER.parse(source);
-        return SourceSpanRenderer.render(document, source);
+    @Test
+    public void differentLineTerminators() {
+        var input = "foo\nbar\rbaz\r\nqux\r\n\r\n> *hi*";
+        assertSpans(input, Paragraph.class,
+                SourceSpan.of(0, 0, 0, 3),
+                SourceSpan.of(1, 0, 4, 3),
+                SourceSpan.of(2, 0, 8, 3),
+                SourceSpan.of(3, 0, 13, 3));
+        assertSpans(input, BlockQuote.class,
+                SourceSpan.of(5, 0, 20, 6));
+
+        assertInlineSpans(input, Emphasis.class, SourceSpan.of(5, 2, 22, 4));
+    }
+
+    private void assertVisualize(String source, String expected) {
+        var doc = PARSER.parse(source);
+        assertEquals(expected, SourceSpanRenderer.renderWithLineColumn(doc, source));
+        assertEquals(expected, SourceSpanRenderer.renderWithInputIndex(doc, source));
     }
 
     private static void assertSpans(String input, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
         assertSpans(PARSER.parse(input), nodeClass, expectedSourceSpans);
+        try {
+            assertSpans(PARSER.parseReader(new StringReader(input)), nodeClass, expectedSourceSpans);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static void assertInlineSpans(String input, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
         assertSpans(INLINES_PARSER.parse(input), nodeClass, expectedSourceSpans);
+        try {
+            assertSpans(INLINES_PARSER.parseReader(new StringReader(input)), nodeClass, expectedSourceSpans);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static void assertSpans(Node rootNode, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {


### PR DESCRIPTION
The existing line/column indexes in `SourceSpan` are useful for some cases, e.g. editors that are line based. But for other cases, it's useful to be able to get the index within the original input string.

An example: If the input string is `"foo\n\nbar"`, the `"bar"` paragraph has the following `SourceSpan`:
- line 2 (third line), column 0, length 3.

With this change, now it also includes the input index: 5 ("b" is the character at index 5 in the string).
That means it's possible to use e.g. `substring` instead of having to split the input text into lines first.