### PR TITLE
Add license to core pom, use SPDX identifier

### DIFF
--- a/commonmark/pom.xml
+++ b/commonmark/pom.xml
@@ -54,4 +54,12 @@
         </profile>
     </profiles>
 
+    <licenses>
+        <license>
+            <name>BSD-2-Clause</name>
+            <url>https://opensource.org/licenses/BSD-2-Clause</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
 
     <licenses>
         <license>
-            <name>BSD 2-Clause License</name>
+            <name>BSD-2-Clause</name>
             <url>https://opensource.org/licenses/BSD-2-Clause</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
Tools that calculate effective poms correctly don't need it, but let's copy the license down to at least the core pom. Fixes #347.

Also use the SPDX identifier as recommended by [Maven](https://maven.apache.org/pom.html#licenses):

> Using an [SPDX identifier](https://spdx.org/licenses/) as the license name is recommended.