### PR TITLE
fix: Add 'requires transitive' to fix compiler warning

### DIFF
--- a/commonmark-ext-autolink/src/main/java/module-info.java
+++ b/commonmark-ext-autolink/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 module org.commonmark.ext.autolink {
     exports org.commonmark.ext.autolink;
 
-    requires org.commonmark;
+    requires transitive org.commonmark;
     requires org.nibor.autolink;
 }

--- a/commonmark-ext-footnotes/src/main/java/module-info.java
+++ b/commonmark-ext-footnotes/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module org.commonmark.ext.footnotes {
     exports org.commonmark.ext.footnotes;
 
-    requires org.commonmark;
+    requires transitive org.commonmark;
 }

--- a/commonmark-ext-gfm-strikethrough/src/main/java/module-info.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module org.commonmark.ext.gfm.strikethrough {
     exports org.commonmark.ext.gfm.strikethrough;
 
-    requires org.commonmark;
+    requires transitive org.commonmark;
 }

--- a/commonmark-ext-gfm-tables/src/main/java/module-info.java
+++ b/commonmark-ext-gfm-tables/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module org.commonmark.ext.gfm.tables {
     exports org.commonmark.ext.gfm.tables;
 
-    requires org.commonmark;
+    requires transitive org.commonmark;
 }

--- a/commonmark-ext-heading-anchor/src/main/java/module-info.java
+++ b/commonmark-ext-heading-anchor/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module org.commonmark.ext.heading.anchor {
     exports org.commonmark.ext.heading.anchor;
 
-    requires org.commonmark;
+    requires transitive org.commonmark;
 }

--- a/commonmark-ext-image-attributes/src/main/java/module-info.java
+++ b/commonmark-ext-image-attributes/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module org.commonmark.ext.image.attributes {
     exports org.commonmark.ext.image.attributes;
 
-    requires org.commonmark;
+    requires transitive org.commonmark;
 }

--- a/commonmark-ext-ins/src/main/java/module-info.java
+++ b/commonmark-ext-ins/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module org.commonmark.ext.ins {
     exports org.commonmark.ext.ins;
 
-    requires org.commonmark;
+    requires transitive org.commonmark;
 }

--- a/commonmark-ext-task-list-items/src/main/java/module-info.java
+++ b/commonmark-ext-task-list-items/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module org.commonmark.ext.task.list.items {
     exports org.commonmark.ext.task.list.items;
 
-    requires org.commonmark;
+    requires transitive org.commonmark;
 }

--- a/commonmark-ext-yaml-front-matter/src/main/java/module-info.java
+++ b/commonmark-ext-yaml-front-matter/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module org.commonmark.ext.front.matter {
     exports org.commonmark.ext.front.matter;
 
-    requires org.commonmark;
+    requires transitive org.commonmark;
 }


### PR DESCRIPTION
This fixes the compiler warning "The type Extension from module org.commonmark may not be accessible to clients due to missing 'requires transitive'"