### PR TITLE
add osgi headers via maven-bundle-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ Some users of this library (feel free to raise a PR if you want to be added):
 * [Gerrit](https://www.gerritcodereview.com/) code review/Gitiles ([link](https://gerrit-review.googlesource.com/c/gitiles/+/353794))
 * [Clerk](https://clerk.vision/) moldable live programming for Clojure
 * [Znai](https://github.com/testingisdocumenting/znai)
+* [Lucee](https://github.com/lucee/lucee)
 
 See also
 --------

--- a/commonmark-ext-autolink/pom.xml
+++ b/commonmark-ext-autolink/pom.xml
@@ -33,4 +33,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/commonmark-ext-footnotes/pom.xml
+++ b/commonmark-ext-footnotes/pom.xml
@@ -24,4 +24,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/commonmark-ext-gfm-strikethrough/pom.xml
+++ b/commonmark-ext-gfm-strikethrough/pom.xml
@@ -24,4 +24,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/commonmark-ext-gfm-tables/pom.xml
+++ b/commonmark-ext-gfm-tables/pom.xml
@@ -23,5 +23,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+ 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/commonmark-ext-heading-anchor/pom.xml
+++ b/commonmark-ext-heading-anchor/pom.xml
@@ -23,5 +23,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+ 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/commonmark-ext-image-attributes/pom.xml
+++ b/commonmark-ext-image-attributes/pom.xml
@@ -24,4 +24,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/commonmark-ext-ins/pom.xml
+++ b/commonmark-ext-ins/pom.xml
@@ -24,4 +24,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/commonmark-ext-task-list-items/pom.xml
+++ b/commonmark-ext-task-list-items/pom.xml
@@ -24,4 +24,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/commonmark-ext-yaml-front-matter/pom.xml
+++ b/commonmark-ext-yaml-front-matter/pom.xml
@@ -24,4 +24,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/commonmark/pom.xml
+++ b/commonmark/pom.xml
@@ -54,6 +54,15 @@
         </profile>
     </profiles>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
     <licenses>
         <license>
             <name>BSD-2-Clause</name>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,42 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.2.5</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>6.0.0</version>
+                    <configuration>
+                        <supportedProjectTypes>
+                            <supportedProjectType>jar</supportedProjectType>
+                            <supportedProjectType>bundle</supportedProjectType>
+                        </supportedProjectTypes>
+                        <instructions>
+                            <Import-Package>
+                                org.commonmark.*;-split-package:=merge-first
+                            </Import-Package>
+                            <Export-Package>
+                                {local-packages}
+                            </Export-Package>
+                        </instructions>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>manifest</id>
+                            <goals>
+                                <goal>manifest</goal>
+                            </goals>
+                            <configuration>
+                                <supportIncrementalBuild>true</supportIncrementalBuild>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>bundle</id>
+                            <goals>
+                                <goal>bundle</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>6.0.0</version>
+                    <version>5.1.9</version>
                     <configuration>
                         <supportedProjectTypes>
                             <supportedProjectType>jar</supportedProjectType>


### PR DESCRIPTION
following up on https://github.com/commonmark/commonmark-java/issues/128

this PR adds the maven-bundle-plugin and config

I am doing this, as we use Commonmark in Lucee, for the initial version, we wrapped the jar ourselves with OSGI metadata, but now I'd like to add some extensions and I'd rather just use commonmark jars

https://github.com/lucee/Lucee/pull/2473

I have tested this locally and the OSGI Export-Package / Import-Package headers look good

But there are some warnings be thrown for each extension

```
[INFO] --- bundle:6.0.0:bundle (bundle) @ commonmark-ext-autolink ---
[WARNING] Bundle org.commonmark:commonmark-ext-autolink:jar:0.24.1-SNAPSHOT : Split package, multiple jars provide the same package:
Use Import/Export Package directive -split-package:=(merge-first|merge-last|error|first) to get rid of this warning
Package found in   [Jar:., Jar:commonmark, Jar:autolink]
Class path         [Jar:., Jar:commonmark, Jar:autolink]
[INFO] Building bundle: D:\work\java\commonmark-java\commonmark-ext-autolink\target\commonmark-ext-autolink-0.24.1-SNAPSHOT.jar
[INFO] Writing manifest: D:\work\java\commonmark-java\commonmark-ext-autolink\target\classes\META-INF\MANIFEST.MF
```

In addition, the autolink dependancy also needs OSGI metadata

