### PR TITLE
Enable adding own markdown renderers in builder

### DIFF
--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
@@ -136,9 +136,9 @@ public class MarkdownRenderer implements Renderer {
             }
             additionalTextEscapes = Collections.unmodifiableSet(escapes);
 
-            // The first node renderer for a node type "wins".
-            for (int i = nodeRendererFactories.size() - 1; i >= 0; i--) {
-                MarkdownNodeRendererFactory nodeRendererFactory = nodeRendererFactories.get(i);
+            // The first node renderer for a node type "wins". The NodeRendererMap
+            // disallows overwriting.
+            for (MarkdownNodeRendererFactory nodeRendererFactory : nodeRendererFactories) {
                 // Pass in this as context here, which uses the fields set above
                 NodeRenderer nodeRenderer = nodeRendererFactory.create(this);
                 nodeRendererMap.add(nodeRenderer);

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/NodeRendererFactoriesTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/NodeRendererFactoriesTest.java
@@ -1,0 +1,73 @@
+package org.commonmark.renderer.markdown;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.commonmark.node.Heading;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.NodeRenderer;
+import org.junit.Test;
+
+public class NodeRendererFactoriesTest {
+
+    @Test
+    public void testAddedNodeRendererFactoryOverrides() {
+        String input = "# Header";
+        TestCoreMarkdownNodeRenderer.called = false;
+        parseAndRender(input, new TestNodeRendererFactory());
+        assertTrue(TestCoreMarkdownNodeRenderer.called);
+    }
+
+    private void assertRoundTrip(String input, MarkdownNodeRendererFactory factory) {
+        String rendered = parseAndRender(input, factory);
+        assertEquals(input, rendered);
+    }
+
+    private String parseAndRender(String source, MarkdownNodeRendererFactory factory) {
+        Node parsed = parse(source);
+        return render(parsed, factory);
+    }
+
+    private Node parse(String source) {
+        return Parser.builder().build().parse(source);
+    }
+
+    private String render(Node node, MarkdownNodeRendererFactory factory) {
+        return MarkdownRenderer.builder().nodeRendererFactory(factory).build().render(node);
+    }
+
+    private static class TestNodeRendererFactory implements MarkdownNodeRendererFactory {
+        @Override
+        public NodeRenderer create(MarkdownNodeRendererContext context) {
+            return new TestCoreMarkdownNodeRenderer(context);
+        }
+
+        @Override
+        public Set<Character> getSpecialCharacters() {
+            return Set.of();
+        }
+    }
+
+    private static class TestCoreMarkdownNodeRenderer extends CoreMarkdownNodeRenderer {
+        static boolean called = false;
+
+        public TestCoreMarkdownNodeRenderer(MarkdownNodeRendererContext context) {
+            super(context);
+        }
+
+        @Override
+        public Set<Class<? extends Node>> getNodeTypes() {
+            return super.getNodeTypes();
+        }
+
+        @Override
+        public void visit(Heading heading) {
+            called = true;
+            super.visit(heading);
+        }
+    }
+
+}


### PR DESCRIPTION
The NodeRendererMap refuses to write over the existing entries.

Looking a bit into it, it was because MarkdownRenderer.RendererContext iterates over the nodeRenderFactories in reverse order. This means that the last (i.e. the default) one is added first, making it impossible to override.

There were a few ways to fix this, but looking at the corresponding code in TextContentReader.RenderContext and HtmlRenderer.RenderContext, they iterate over the list of factories in the natural order.

@robinst @sebthom if you agree with the fix, it would be great if it could be included in a release soon :-)