### PR TITLE
generic Renderer for render targets richer than String

### DIFF
--- a/commonmark/src/main/java/org/commonmark/renderer/Renderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/Renderer.java
@@ -2,7 +2,7 @@ package org.commonmark.renderer;
 
 import org.commonmark.node.Node;
 
-public interface Renderer {
+public interface Renderer<T> {
 
     /**
      * Render the tree of nodes to output.
@@ -16,7 +16,7 @@ public interface Renderer {
      * Render the tree of nodes to string.
      *
      * @param node the root node
-     * @return the rendered string
+     * @return the rendered result
      */
-    String render(Node node);
+    T render(Node node);
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
@@ -18,7 +18,7 @@ import java.util.*;
  * renderer.render(node);
  * </code></pre>
  */
-public class HtmlRenderer implements Renderer {
+public class HtmlRenderer implements Renderer<String> {
 
     private final String softbreak;
     private final boolean escapeHtml;

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
@@ -22,7 +22,7 @@ import java.util.*;
  * However, it should produce Markdown that is semantically equivalent to the input, i.e. if the Markdown was parsed
  * again and compared against the original AST, it should be the same (minus bugs).
  */
-public class MarkdownRenderer implements Renderer {
+public class MarkdownRenderer implements Renderer<String> {
 
     private final List<MarkdownNodeRendererFactory> nodeRendererFactories;
 

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Renders nodes to plain text content with minimal markup-like additions.
  */
-public class TextContentRenderer implements Renderer {
+public class TextContentRenderer implements Renderer<String> {
 
     private final LineBreakRendering lineBreakRendering;
 


### PR DESCRIPTION
Changed `org.commonmark.node.Node.Renderer` to `Renderer<T>` and updated all three type descendants to concretize as `Render<String>`.

This change was motivated by my project's need to render markdown to targets not easily represented as a single `String`.  
