### PR TITLE
Change ordering of `node.getNext()` and `context.render(node)` in CoreHtmlRenderer.java

### DIFF
--- a/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
@@ -252,9 +252,8 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
     protected void visitChildren(Node parent) {
         Node node = parent.getFirstChild();
         while (node != null) {
-            Node next = node.getNext();
             context.render(node);
-            node = next;
+            node = node.getNext();
         }
     }
 


### PR DESCRIPTION
Getting the next node before rendering the current one prevents a renderer from contextually unlinking the next node.