### PR TITLE
Migrate from OSSRH to Central Publisher Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,12 @@ jobs:
       - name: Set up Maven Central repository
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 24
           distribution: 'zulu'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME # env variable to use for username in release
-          server-password: MAVEN_PASSWORD # env variable to use for password in release
+          # See https://central.sonatype.org/publish/publish-portal-maven/
+          server-id: central
+          server-username: CENTRAL_USERNAME # env variable to use for username in release
+          server-password: CENTRAL_PASSWORD # env variable to use for password in release
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable to use for passphrase in release
 
@@ -37,6 +38,6 @@ jobs:
           mvn -B -Dusername=${{ secrets.GH_USERNAME }} -Dpassword=${{ secrets.GH_ACCESS_TOKEN }} release:prepare
           mvn -B release:perform
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -85,22 +85,22 @@
         </pluginManagement>
 
         <plugins>
+            <!-- https://central.sonatype.org/publish/publish-portal-maven/ -->
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>
@@ -306,16 +306,5 @@
         <url>https://github.com/commonmark/commonmark-java</url>
         <tag>HEAD</tag>
     </scm>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
 </project>


### PR DESCRIPTION
See announcement: https://central.sonatype.org/news/20250326_ossrh_sunset/

Followed the guide here, we'll see if it works: https://central.sonatype.org/publish/publish-portal-maven/