### PR TITLE
Format with google-java-format (via spotless)

### DIFF
--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoogleJavaFormatSettings">
+    <option name="enabled" value="true" />
+    <option name="style" value="AOSP" />
+  </component>
+</project>

--- a/commonmark-ext-autolink/src/main/java/org/commonmark/ext/autolink/AutolinkExtension.java
+++ b/commonmark-ext-autolink/src/main/java/org/commonmark/ext/autolink/AutolinkExtension.java
@@ -2,7 +2,6 @@ package org.commonmark.ext.autolink;
 
 import java.util.EnumSet;
 import java.util.Set;
-
 import org.commonmark.Extension;
 import org.commonmark.ext.autolink.internal.AutolinkPostProcessor;
 import org.commonmark.parser.Parser;
@@ -10,14 +9,12 @@ import org.commonmark.renderer.html.HtmlRenderer;
 
 /**
  * Extension for automatically turning plain URLs and email addresses into links.
- * <p>
- * Create it with {@link #create()} and then configure it on the builders
- * ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)},
- * {@link HtmlRenderer.Builder#extensions(Iterable)}).
- * </p>
- * <p>
- * The parsed links are turned into normal {@link org.commonmark.node.Link} nodes.
- * </p>
+ *
+ * <p>Create it with {@link #create()} and then configure it on the builders ({@link
+ * org.commonmark.parser.Parser.Builder#extensions(Iterable)}, {@link
+ * HtmlRenderer.Builder#extensions(Iterable)}).
+ *
+ * <p>The parsed links are turned into normal {@link org.commonmark.node.Link} nodes.
  */
 public class AutolinkExtension implements Parser.ParserExtension {
 
@@ -51,8 +48,8 @@ public class AutolinkExtension implements Parser.ParserExtension {
         private Set<AutolinkType> linkTypes = EnumSet.allOf(AutolinkType.class);
 
         /**
-         * @param linkTypes the link types that should be converted. By default,
-         *                  all {@link AutolinkType}s are converted.
+         * @param linkTypes the link types that should be converted. By default, all {@link
+         *     AutolinkType}s are converted.
          * @return {@code this}
          */
         public Builder linkTypes(AutolinkType... linkTypes) {
@@ -64,8 +61,8 @@ public class AutolinkExtension implements Parser.ParserExtension {
         }
 
         /**
-         * @param linkTypes the link types that should be converted. By default,
-         *                  all {@link AutolinkType}s are converted.
+         * @param linkTypes the link types that should be converted. By default, all {@link
+         *     AutolinkType}s are converted.
          * @return {@code this}
          */
         public Builder linkTypes(Set<AutolinkType> linkTypes) {

--- a/commonmark-ext-autolink/src/main/java/org/commonmark/ext/autolink/AutolinkType.java
+++ b/commonmark-ext-autolink/src/main/java/org/commonmark/ext/autolink/AutolinkType.java
@@ -1,19 +1,11 @@
 package org.commonmark.ext.autolink;
 
-/**
- * The types of strings that can be automatically turned into links.
- */
+/** The types of strings that can be automatically turned into links. */
 public enum AutolinkType {
-    /**
-     * URL such as {@code http://example.com}
-     */
+    /** URL such as {@code http://example.com} */
     URL,
-    /**
-     * Email address such as {@code foo@example.com}
-     */
+    /** Email address such as {@code foo@example.com} */
     EMAIL,
-    /**
-     * URL such as {@code www.example.com}
-     */
+    /** URL such as {@code www.example.com} */
     WWW
 }

--- a/commonmark-ext-autolink/src/main/java/org/commonmark/ext/autolink/internal/AutolinkPostProcessor.java
+++ b/commonmark-ext-autolink/src/main/java/org/commonmark/ext/autolink/internal/AutolinkPostProcessor.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.autolink.internal;
 
+import java.util.*;
 import org.commonmark.ext.autolink.AutolinkType;
 import org.commonmark.node.*;
 import org.commonmark.parser.PostProcessor;
@@ -7,8 +8,6 @@ import org.nibor.autolink.LinkExtractor;
 import org.nibor.autolink.LinkSpan;
 import org.nibor.autolink.LinkType;
 import org.nibor.autolink.Span;
-
-import java.util.*;
 
 public class AutolinkPostProcessor implements PostProcessor {
 
@@ -38,9 +37,7 @@ public class AutolinkPostProcessor implements PostProcessor {
             }
         }
 
-        this.linkExtractor = LinkExtractor.builder()
-                .linkTypes(types)
-                .build();
+        this.linkExtractor = LinkExtractor.builder().linkTypes(types).build();
     }
 
     @Override

--- a/commonmark-ext-autolink/src/test/java/org/commonmark/ext/autolink/AutolinkTest.java
+++ b/commonmark-ext-autolink/src/test/java/org/commonmark/ext/autolink/AutolinkTest.java
@@ -1,5 +1,9 @@
 package org.commonmark.ext.autolink;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.*;
 import org.commonmark.parser.IncludeSourceSpans;
@@ -8,64 +12,69 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class AutolinkTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(AutolinkExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
-    private static final Set<Extension> NO_WWW_EXTENSIONS = Set.of(AutolinkExtension.builder()
-        .linkTypes(AutolinkType.URL, AutolinkType.EMAIL)
-        .build());
-    private static final Parser NO_WWW_PARSER = Parser.builder().extensions(NO_WWW_EXTENSIONS).build();
-    private static final HtmlRenderer NO_WWW_RENDERER = HtmlRenderer.builder().extensions(NO_WWW_EXTENSIONS).build();
+    private static final Set<Extension> NO_WWW_EXTENSIONS =
+            Set.of(
+                    AutolinkExtension.builder()
+                            .linkTypes(AutolinkType.URL, AutolinkType.EMAIL)
+                            .build());
+    private static final Parser NO_WWW_PARSER =
+            Parser.builder().extensions(NO_WWW_EXTENSIONS).build();
+    private static final HtmlRenderer NO_WWW_RENDERER =
+            HtmlRenderer.builder().extensions(NO_WWW_EXTENSIONS).build();
 
     @Test
     public void oneTextNode() {
-        assertRendering("foo http://one.org/ bar http://two.org/",
+        assertRendering(
+                "foo http://one.org/ bar http://two.org/",
                 "<p>foo <a href=\"http://one.org/\">http://one.org/</a> bar <a href=\"http://two.org/\">http://two.org/</a></p>\n");
     }
 
     @Test
     public void textNodeAndOthers() {
-        assertRendering("foo http://one.org/ bar `code` baz http://two.org/",
+        assertRendering(
+                "foo http://one.org/ bar `code` baz http://two.org/",
                 "<p>foo <a href=\"http://one.org/\">http://one.org/</a> bar <code>code</code> baz <a href=\"http://two.org/\">http://two.org/</a></p>\n");
     }
 
     @Test
     public void tricky() {
-        assertRendering("http://example.com/one. Example 2 (see http://example.com/two). Example 3: http://example.com/foo_(bar)",
-                "<p><a href=\"http://example.com/one\">http://example.com/one</a>. " +
-                        "Example 2 (see <a href=\"http://example.com/two\">http://example.com/two</a>). " +
-                        "Example 3: <a href=\"http://example.com/foo_(bar)\">http://example.com/foo_(bar)</a></p>\n");
+        assertRendering(
+                "http://example.com/one. Example 2 (see http://example.com/two). Example 3: http://example.com/foo_(bar)",
+                "<p><a href=\"http://example.com/one\">http://example.com/one</a>. "
+                        + "Example 2 (see <a href=\"http://example.com/two\">http://example.com/two</a>). "
+                        + "Example 3: <a href=\"http://example.com/foo_(bar)\">http://example.com/foo_(bar)</a></p>\n");
     }
 
     @Test
     public void emailUsesMailto() {
-        assertRendering("foo@example.com",
+        assertRendering(
+                "foo@example.com",
                 "<p><a href=\"mailto:foo@example.com\">foo@example.com</a></p>\n");
     }
 
     @Test
     public void emailWithTldNotLinked() {
-        assertRendering("foo@com",
-                "<p>foo@com</p>\n");
+        assertRendering("foo@com", "<p>foo@com</p>\n");
     }
 
     @Test
     public void dontLinkTextWithinLinks() {
-        assertRendering("<http://example.com>",
+        assertRendering(
+                "<http://example.com>",
                 "<p><a href=\"http://example.com\">http://example.com</a></p>\n");
     }
 
     @Test
     public void wwwLinks() {
-        assertRendering("www.example.com",
+        assertRendering(
+                "www.example.com",
                 "<p><a href=\"http://www.example.com\">www.example.com</a></p>\n");
     }
 
@@ -77,14 +86,17 @@ public class AutolinkTest extends RenderingTestCase {
 
     @Test
     public void sourceSpans() {
-        Parser parser = Parser.builder()
-                .extensions(EXTENSIONS)
-                .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
-                .build();
-        Node document = parser.parse("abc\n" +
-                "http://example.com/one\n" +
-                "def http://example.com/two\n" +
-                "ghi http://example.com/three jkl");
+        Parser parser =
+                Parser.builder()
+                        .extensions(EXTENSIONS)
+                        .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                        .build();
+        Node document =
+                parser.parse(
+                        "abc\n"
+                                + "http://example.com/one\n"
+                                + "def http://example.com/two\n"
+                                + "ghi http://example.com/three jkl");
 
         Paragraph paragraph = (Paragraph) document.getFirstChild();
         Text abc = (Text) paragraph.getFirstChild();

--- a/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/FootnoteDefinition.java
+++ b/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/FootnoteDefinition.java
@@ -4,13 +4,16 @@ import org.commonmark.node.CustomBlock;
 
 /**
  * A footnote definition, e.g.:
+ *
  * <pre><code>
  * [^foo]: This is the footnote text
  * </code></pre>
- * The {@link #getLabel() label} is the text in brackets after {@code ^}, so {@code foo} in the example. The contents
- * of the footnote are child nodes of the definition, a {@link org.commonmark.node.Paragraph} in the example.
- * <p>
- * Footnote definitions are parsed even if there's no corresponding {@link FootnoteReference}.
+ *
+ * The {@link #getLabel() label} is the text in brackets after {@code ^}, so {@code foo} in the
+ * example. The contents of the footnote are child nodes of the definition, a {@link
+ * org.commonmark.node.Paragraph} in the example.
+ *
+ * <p>Footnote definitions are parsed even if there's no corresponding {@link FootnoteReference}.
  */
 public class FootnoteDefinition extends CustomBlock {
 
@@ -24,4 +27,3 @@ public class FootnoteDefinition extends CustomBlock {
         return label;
     }
 }
-

--- a/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/FootnoteReference.java
+++ b/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/FootnoteReference.java
@@ -4,9 +4,10 @@ import org.commonmark.node.CustomNode;
 
 /**
  * A footnote reference, e.g. <code>[^foo]</code> in <code>Some text with a footnote[^foo]</code>
- * <p>
- * The {@link #getLabel() label} is the text within brackets after {@code ^}, so {@code foo} in the example. It needs to
- * match the label of a corresponding {@link FootnoteDefinition} for the footnote to be parsed.
+ *
+ * <p>The {@link #getLabel() label} is the text within brackets after {@code ^}, so {@code foo} in
+ * the example. It needs to match the label of a corresponding {@link FootnoteDefinition} for the
+ * footnote to be parsed.
  */
 public class FootnoteReference extends CustomNode {
     private String label;

--- a/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/FootnotesExtension.java
+++ b/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/FootnotesExtension.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.footnotes;
 
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.ext.footnotes.internal.*;
 import org.commonmark.parser.Parser;
@@ -9,32 +10,37 @@ import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
 import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 
-import java.util.Set;
-
 /**
  * Extension for footnotes with syntax like GitHub Flavored Markdown:
+ *
  * <pre><code>
  * Some text with a footnote[^1].
  *
  * [^1]: The text of the footnote.
  * </code></pre>
- * The <code>[^1]</code> is a {@link FootnoteReference}, with "1" being the label.
- * <p>
- * The line with <code>[^1]: ...</code> is a {@link FootnoteDefinition}, with the contents as child nodes (can be a
- * paragraph like in the example, or other blocks like lists).
- * <p>
- * All the footnotes (definitions) will be rendered in a list at the end of a document, no matter where they appear in
- * the source. The footnotes will be numbered starting from 1, then 2, etc, depending on the order in which they appear
- * in the text (and not dependent on the label). The footnote reference is a link to the footnote, and from the footnote
- * there is a link back to the reference (or multiple).
- * <p>
- * There is also optional support for inline footnotes, use {@link #builder()} and then set {@link Builder#inlineFootnotes}.
  *
- * @see <a href="https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#footnotes">GitHub docs for footnotes</a>
+ * The <code>[^1]</code> is a {@link FootnoteReference}, with "1" being the label.
+ *
+ * <p>The line with <code>[^1]: ...</code> is a {@link FootnoteDefinition}, with the contents as
+ * child nodes (can be a paragraph like in the example, or other blocks like lists).
+ *
+ * <p>All the footnotes (definitions) will be rendered in a list at the end of a document, no matter
+ * where they appear in the source. The footnotes will be numbered starting from 1, then 2, etc,
+ * depending on the order in which they appear in the text (and not dependent on the label). The
+ * footnote reference is a link to the footnote, and from the footnote there is a link back to the
+ * reference (or multiple).
+ *
+ * <p>There is also optional support for inline footnotes, use {@link #builder()} and then set
+ * {@link Builder#inlineFootnotes}.
+ *
+ * @see <a
+ *     href="https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#footnotes">GitHub
+ *     docs for footnotes</a>
  */
-public class FootnotesExtension implements Parser.ParserExtension,
-        HtmlRenderer.HtmlRendererExtension,
-        MarkdownRenderer.MarkdownRendererExtension {
+public class FootnotesExtension
+        implements Parser.ParserExtension,
+                HtmlRenderer.HtmlRendererExtension,
+                MarkdownRenderer.MarkdownRendererExtension {
 
     private final boolean inlineFootnotes;
 
@@ -42,9 +48,7 @@ public class FootnotesExtension implements Parser.ParserExtension,
         this.inlineFootnotes = inlineFootnotes;
     }
 
-    /**
-     * The extension with the default configuration (no support for inline footnotes).
-     */
+    /** The extension with the default configuration (no support for inline footnotes). */
     public static Extension create() {
         return builder().build();
     }
@@ -70,17 +74,18 @@ public class FootnotesExtension implements Parser.ParserExtension,
 
     @Override
     public void extend(MarkdownRenderer.Builder rendererBuilder) {
-        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(MarkdownNodeRendererContext context) {
-                return new FootnoteMarkdownNodeRenderer(context);
-            }
+        rendererBuilder.nodeRendererFactory(
+                new MarkdownNodeRendererFactory() {
+                    @Override
+                    public NodeRenderer create(MarkdownNodeRendererContext context) {
+                        return new FootnoteMarkdownNodeRenderer(context);
+                    }
 
-            @Override
-            public Set<Character> getSpecialCharacters() {
-                return Set.of();
-            }
-        });
+                    @Override
+                    public Set<Character> getSpecialCharacters() {
+                        return Set.of();
+                    }
+                });
     }
 
     public static class Builder {
@@ -89,6 +94,7 @@ public class FootnotesExtension implements Parser.ParserExtension,
 
         /**
          * Enable support for inline footnotes without definitions, e.g.:
+         *
          * <pre>
          * Some text^[this is an inline footnote]
          * </pre>

--- a/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/InlineFootnote.java
+++ b/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/InlineFootnote.java
@@ -2,5 +2,4 @@ package org.commonmark.ext.footnotes;
 
 import org.commonmark.node.CustomNode;
 
-public class InlineFootnote extends CustomNode {
-}
+public class InlineFootnote extends CustomNode {}

--- a/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/internal/FootnoteBlockParser.java
+++ b/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/internal/FootnoteBlockParser.java
@@ -1,16 +1,13 @@
 package org.commonmark.ext.footnotes.internal;
 
+import java.util.List;
 import org.commonmark.ext.footnotes.FootnoteDefinition;
 import org.commonmark.node.Block;
 import org.commonmark.node.DefinitionMap;
 import org.commonmark.parser.block.*;
 import org.commonmark.text.Characters;
 
-import java.util.List;
-
-/**
- * Parser for a single {@link FootnoteDefinition} block.
- */
+/** Parser for a single {@link FootnoteDefinition} block. */
 public class FootnoteBlockParser extends AbstractBlockParser {
 
     private final FootnoteDefinition block;
@@ -37,16 +34,18 @@ public class FootnoteBlockParser extends AbstractBlockParser {
     @Override
     public BlockContinue tryContinue(ParserState parserState) {
         if (parserState.getIndent() >= 4) {
-            // It looks like content needs to be indented by 4 so that it's part of a footnote (instead of starting a new block).
+            // It looks like content needs to be indented by 4 so that it's part of a footnote
+            // (instead of starting a new block).
             return BlockContinue.atColumn(4);
         } else if (parserState.isBlank()) {
-            // A blank line doesn't finish a footnote yet. If there's another line with indent >= 4 after it,
-            // that should result in another paragraph in this footnote definition.
+            // A blank line doesn't finish a footnote yet. If there's another line with indent >= 4
+            // after it, that should result in another paragraph in this footnote definition.
             return BlockContinue.atIndex(parserState.getIndex());
         } else {
-            // We're not continuing to give other block parsers a chance to interrupt this definition.
-            // But if no other block parser applied (including another FootnotesBlockParser), we will
-            // accept the line via lazy continuation (same as a block quote).
+            // We're not continuing to give other block parsers a chance to interrupt this
+            // definition. But if no other block parser applied (including another
+            // FootnotesBlockParser), we will accept the line via lazy continuation (same as a block
+            // quote).
             return BlockContinue.none();
         }
     }
@@ -82,11 +81,16 @@ public class FootnoteBlockParser extends AbstractBlockParser {
                 var c = content.charAt(index);
                 switch (c) {
                     case ']':
-                        if (index > labelStart && index + 1 < content.length() && content.charAt(index + 1) == ':') {
+                        if (index > labelStart
+                                && index + 1 < content.length()
+                                && content.charAt(index + 1) == ':') {
                             var label = content.subSequence(labelStart, index).toString();
-                            // After the colon, any number of spaces is skipped (not part of the content)
-                            var afterSpaces = Characters.skipSpaceTab(content, index + 2, content.length());
-                            return BlockStart.of(new FootnoteBlockParser(label)).atIndex(afterSpaces);
+                            // After the colon, any number of spaces is skipped (not part of the
+                            // content)
+                            var afterSpaces =
+                                    Characters.skipSpaceTab(content, index + 2, content.length());
+                            return BlockStart.of(new FootnoteBlockParser(label))
+                                    .atIndex(afterSpaces);
                         } else {
                             return BlockStart.none();
                         }

--- a/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/internal/FootnoteHtmlNodeRenderer.java
+++ b/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/internal/FootnoteHtmlNodeRenderer.java
@@ -1,5 +1,7 @@
 package org.commonmark.ext.footnotes.internal;
 
+import java.util.*;
+import java.util.function.Consumer;
 import org.commonmark.ext.footnotes.FootnoteDefinition;
 import org.commonmark.ext.footnotes.FootnoteReference;
 import org.commonmark.ext.footnotes.InlineFootnote;
@@ -8,64 +10,68 @@ import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlWriter;
 
-import java.util.*;
-import java.util.function.Consumer;
-
 /**
  * HTML rendering for footnotes.
- * <p>
- * Aims to match the rendering of cmark-gfm (which is slightly different from GitHub's when it comes to class
- * attributes, not sure why).
- * <p>
- * Some notes on how rendering works:
+ *
+ * <p>Aims to match the rendering of cmark-gfm (which is slightly different from GitHub's when it
+ * comes to class attributes, not sure why).
+ *
+ * <p>Some notes on how rendering works:
+ *
  * <ul>
- * <li>Footnotes are numbered according to the order of references, starting at 1</li>
- * <li>Definitions are rendered at the end of the document, regardless of where the definition was in the source</li>
- * <li>Definitions are ordered by number</li>
- * <li>Definitions have links back to their references (one or more)</li>
+ *   <li>Footnotes are numbered according to the order of references, starting at 1
+ *   <li>Definitions are rendered at the end of the document, regardless of where the definition was
+ *       in the source
+ *   <li>Definitions are ordered by number
+ *   <li>Definitions have links back to their references (one or more)
  * </ul>
  *
  * <h4>Nested footnotes</h4>
- * Text in footnote definitions can reference other footnotes, even ones that aren't referenced in the main text.
- * This makes them tricky because it's not enough to just go through the main text for references.
- * And before we can render a definition, we need to know all references (because we add links back to references).
- * <p>
- * In other words, footnotes form a directed graph. Footnotes can reference each other so cycles are possible too.
- * <p>
- * One way to implement it, which is what cmark-gfm does, is to go through the whole document (including definitions)
- * and find all references in order. That guarantees that all definitions are found, but it has strange results for
- * ordering or when the reference is in an unreferenced definition, see tests. In graph terms, it renders all
- * definitions that have an incoming edge, no matter whether they are connected to the main text or not.
- * <p>
- * The way we implement it:
+ *
+ * Text in footnote definitions can reference other footnotes, even ones that aren't referenced in
+ * the main text. This makes them tricky because it's not enough to just go through the main text
+ * for references. And before we can render a definition, we need to know all references (because we
+ * add links back to references).
+ *
+ * <p>In other words, footnotes form a directed graph. Footnotes can reference each other so cycles
+ * are possible too.
+ *
+ * <p>One way to implement it, which is what cmark-gfm does, is to go through the whole document
+ * (including definitions) and find all references in order. That guarantees that all definitions
+ * are found, but it has strange results for ordering or when the reference is in an unreferenced
+ * definition, see tests. In graph terms, it renders all definitions that have an incoming edge, no
+ * matter whether they are connected to the main text or not.
+ *
+ * <p>The way we implement it:
+ *
  * <ol>
- * <li>Start with the references in the main text; we can render them as we go</li>
- * <li>After the main text is rendered, we have the referenced definitions, but there might be more from definition text</li>
- * <li>To find the remaining definitions, we visit the definitions from before to look at references</li>
- * <li>Repeat (breadth-first search) until we've found all definitions (note that we can't render before that's done because of backrefs)</li>
- * <li>Now render the definitions (and any references inside)</li>
+ *   <li>Start with the references in the main text; we can render them as we go
+ *   <li>After the main text is rendered, we have the referenced definitions, but there might be
+ *       more from definition text
+ *   <li>To find the remaining definitions, we visit the definitions from before to look at
+ *       references
+ *   <li>Repeat (breadth-first search) until we've found all definitions (note that we can't render
+ *       before that's done because of backrefs)
+ *   <li>Now render the definitions (and any references inside)
  * </ol>
- * This means we only render definitions whose references are actually rendered, and in a meaningful order (all main
- * text footnotes first, then any nested ones).
+ *
+ * This means we only render definitions whose references are actually rendered, and in a meaningful
+ * order (all main text footnotes first, then any nested ones).
  */
 public class FootnoteHtmlNodeRenderer implements NodeRenderer {
 
     private final HtmlWriter html;
     private final HtmlNodeRendererContext context;
 
-    /**
-     * All definitions (even potentially unused ones), for looking up references
-     */
+    /** All definitions (even potentially unused ones), for looking up references */
     private DefinitionMap<FootnoteDefinition> definitionMap;
 
-    /**
-     * Definitions that were referenced, in order in which they should be rendered.
-     */
+    /** Definitions that were referenced, in order in which they should be rendered. */
     private final Map<Node, ReferencedDefinition> referencedDefinitions = new LinkedHashMap<>();
 
     /**
-     * Information about references that should be rendered as footnotes. This doesn't contain all references, just the
-     * ones from inside definitions.
+     * Information about references that should be rendered as footnotes. This doesn't contain all
+     * references, just the ones from inside definitions.
      */
     private final Map<Node, ReferenceInfo> references = new HashMap<>();
 
@@ -81,7 +87,8 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
 
     @Override
     public void beforeRoot(Node rootNode) {
-        // Collect all definitions first, so we can look them up when encountering a reference later.
+        // Collect all definitions first, so we can look them up when encountering a reference
+        // later.
         var visitor = new DefinitionVisitor();
         rootNode.accept(visitor);
         definitionMap = visitor.definitions;
@@ -90,11 +97,12 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
     @Override
     public void render(Node node) {
         if (node instanceof FootnoteReference) {
-            // This is called for all references, even ones inside definitions that we render at the end.
-            // Inside definitions, we have registered the reference already.
+            // This is called for all references, even ones inside definitions that we render at the
+            // end. Inside definitions, we have registered the reference already.
             var ref = (FootnoteReference) node;
             // Use containsKey because if value is null, we don't need to try registering again.
-            var info = references.containsKey(ref) ? references.get(ref) : tryRegisterReference(ref);
+            var info =
+                    references.containsKey(ref) ? references.get(ref) : tryRegisterReference(ref);
             if (info != null) {
                 renderReference(ref, info);
             } else {
@@ -126,26 +134,30 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
         html.tag("ol");
         html.line();
 
-        // Check whether there are any footnotes inside the definitions that we're about to render. For those, we might
-        // need to render more definitions. So do a breadth-first search to find all relevant definitions.
+        // Check whether there are any footnotes inside the definitions that we're about to render.
+        // For those, we might need to render more definitions. So do a breadth-first search to find
+        // all relevant definitions.
         var check = new LinkedList<>(referencedDefinitions.keySet());
         while (!check.isEmpty()) {
             var def = check.removeFirst();
-            def.accept(new ShallowReferenceVisitor(def, node -> {
-                if (node instanceof FootnoteReference) {
-                    var ref = (FootnoteReference) node;
-                    var d = definitionMap.get(ref.getLabel());
-                    if (d != null) {
-                        if (!referencedDefinitions.containsKey(d)) {
-                            check.addLast(d);
-                        }
-                        references.put(ref, registerReference(d, d.getLabel()));
-                    }
-                } else if (node instanceof InlineFootnote) {
-                    check.addLast(node);
-                    references.put(node, registerReference(node, null));
-                }
-            }));
+            def.accept(
+                    new ShallowReferenceVisitor(
+                            def,
+                            node -> {
+                                if (node instanceof FootnoteReference) {
+                                    var ref = (FootnoteReference) node;
+                                    var d = definitionMap.get(ref.getLabel());
+                                    if (d != null) {
+                                        if (!referencedDefinitions.containsKey(d)) {
+                                            check.addLast(d);
+                                        }
+                                        references.put(ref, registerReference(d, d.getLabel()));
+                                    }
+                                } else if (node instanceof InlineFootnote) {
+                                    check.addLast(node);
+                                    references.put(node, registerReference(node, null));
+                                }
+                            }));
         }
 
         for (var entry : referencedDefinitions.entrySet()) {
@@ -169,15 +181,19 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
 
     private ReferenceInfo registerReference(Node node, String label) {
         // The first referenced definition gets number 1, second one 2, etc.
-        var referencedDef = referencedDefinitions.computeIfAbsent(node, k -> {
-            var num = referencedDefinitions.size() + 1;
-            var key = definitionKey(label, num);
-            return new ReferencedDefinition(num, key);
-        });
+        var referencedDef =
+                referencedDefinitions.computeIfAbsent(
+                        node,
+                        k -> {
+                            var num = referencedDefinitions.size() + 1;
+                            var key = definitionKey(label, num);
+                            return new ReferencedDefinition(num, key);
+                        });
         var definitionNumber = referencedDef.definitionNumber;
-        // The reference number for that particular definition. E.g. if there's two references for the same definition,
-        // the first one is 1, the second one 2, etc. This is needed to give each reference a unique ID so that each
-        // reference can get its own backlink from the definition.
+        // The reference number for that particular definition. E.g. if there's two references for
+        // the same definition, the first one is 1, the second one 2, etc. This is needed to give
+        // each reference a unique ID so that each reference can get its own backlink from the
+        // definition.
         var refNumber = referencedDef.references.size() + 1;
         var definitionKey = referencedDef.definitionKey;
         var id = referenceId(definitionKey, refNumber);
@@ -212,8 +228,9 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
             var node = def.getFirstChild();
             while (node != lastParagraph) {
                 if (node instanceof Paragraph) {
-                    // Because we're manually rendering the <p> for the last paragraph, do the same for all other
-                    // paragraphs for consistency (Paragraph rendering might be overwritten by a custom renderer).
+                    // Because we're manually rendering the <p> for the last paragraph, do the same
+                    // for all other paragraphs for consistency (Paragraph rendering might be
+                    // overwritten by a custom renderer).
                     html.tag("p", context.extendAttributes(node, "p", Map.of()));
                     renderChildren(node);
                     html.tag("/p");
@@ -252,7 +269,9 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
         for (int i = 0; i < refs.size(); i++) {
             var ref = refs.get(i);
             var refNumber = i + 1;
-            var idx = referencedDefinition.definitionNumber + (refNumber > 1 ? ("-" + refNumber) : "");
+            var idx =
+                    referencedDefinition.definitionNumber
+                            + (refNumber > 1 ? ("-" + refNumber) : "");
 
             var attrs = new LinkedHashMap<String, String>();
             attrs.put("href", "#" + ref);
@@ -262,7 +281,9 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
             attrs.put("aria-label", "Back to reference " + idx);
             html.tag("a", context.extendAttributes(def, "a", attrs));
             if (refNumber > 1) {
-                html.tag("sup", context.extendAttributes(def, "sup", Map.of("class", "footnote-ref")));
+                html.tag(
+                        "sup",
+                        context.extendAttributes(def, "sup", Map.of("class", "footnote-ref")));
                 html.raw(String.valueOf(refNumber));
                 html.tag("/sup");
             }
@@ -280,8 +301,9 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
     }
 
     private String definitionKey(String label, int number) {
-        // Named definitions use the pattern "fn-{name}" and inline definitions use "fn{number}" so as not to conflict.
-        // "fn{number}" is also what pandoc uses (for all types), starting with number 1.
+        // Named definitions use the pattern "fn-{name}" and inline definitions use "fn{number}" so
+        // as not to conflict. "fn{number}" is also what pandoc uses (for all types), starting with
+        // number 1.
         if (label != null) {
             return "-" + label;
         } else {
@@ -304,7 +326,8 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
 
     private static class DefinitionVisitor extends AbstractVisitor {
 
-        private final DefinitionMap<FootnoteDefinition> definitions = new DefinitionMap<>(FootnoteDefinition.class);
+        private final DefinitionMap<FootnoteDefinition> definitions =
+                new DefinitionMap<>(FootnoteDefinition.class);
 
         @Override
         public void visit(CustomBlock customBlock) {
@@ -318,8 +341,8 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
     }
 
     /**
-     * Visit footnote references/inline footnotes inside the parent (but not the parent itself). We want a shallow visit
-     * because the caller wants to control when to descend.
+     * Visit footnote references/inline footnotes inside the parent (but not the parent itself). We
+     * want a shallow visit because the caller wants to control when to descend.
      */
     private static class ShallowReferenceVisitor extends AbstractVisitor {
         private final Node parent;
@@ -349,17 +372,16 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
     }
 
     private static class ReferencedDefinition {
-        /**
-         * The definition number, starting from 1, and in order in which they're referenced.
-         */
+        /** The definition number, starting from 1, and in order in which they're referenced. */
         final int definitionNumber;
+
         /**
-         * The unique key of the definition. Together with a static prefix it forms the ID used in the HTML.
+         * The unique key of the definition. Together with a static prefix it forms the ID used in
+         * the HTML.
          */
         final String definitionKey;
-        /**
-         * The IDs of references for this definition, for backrefs.
-         */
+
+        /** The IDs of references for this definition, for backrefs. */
         final List<String> references = new ArrayList<>();
 
         ReferencedDefinition(int definitionNumber, String definitionKey) {
@@ -370,16 +392,15 @@ public class FootnoteHtmlNodeRenderer implements NodeRenderer {
 
     private static class ReferenceInfo {
         /**
-         * The ID of the reference; in the corresponding definition, a link back to this reference will be rendered.
+         * The ID of the reference; in the corresponding definition, a link back to this reference
+         * will be rendered.
          */
         private final String id;
-        /**
-         * The ID of the definition, for linking to the definition.
-         */
+
+        /** The ID of the definition, for linking to the definition. */
         private final String definitionId;
-        /**
-         * The definition number, rendered in superscript.
-         */
+
+        /** The definition number, rendered in superscript. */
         private final int definitionNumber;
 
         private ReferenceInfo(String id, String definitionId, int definitionNumber) {

--- a/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/internal/FootnoteLinkProcessor.java
+++ b/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/internal/FootnoteLinkProcessor.java
@@ -11,17 +11,18 @@ import org.commonmark.parser.beta.LinkResult;
 import org.commonmark.parser.beta.Scanner;
 
 /**
- * For turning e.g. <code>[^foo]</code> into a {@link FootnoteReference},
- * and <code>^[foo]</code> into an {@link InlineFootnote}.
+ * For turning e.g. <code>[^foo]</code> into a {@link FootnoteReference}, and <code>^[foo]</code>
+ * into an {@link InlineFootnote}.
  */
 public class FootnoteLinkProcessor implements LinkProcessor {
     @Override
     public LinkResult process(LinkInfo linkInfo, Scanner scanner, InlineParserContext context) {
 
         if (linkInfo.marker() != null && linkInfo.marker().getLiteral().equals("^")) {
-            // An inline footnote like ^[footnote text]. Note that we only get the marker here if the option is enabled
-            // on the extension.
-            return LinkResult.wrapTextIn(new InlineFootnote(), linkInfo.afterTextBracket()).includeMarker();
+            // An inline footnote like ^[footnote text]. Note that we only get the marker here if
+            // the option is enabled on the extension.
+            return LinkResult.wrapTextIn(new InlineFootnote(), linkInfo.afterTextBracket())
+                    .includeMarker();
         }
 
         if (linkInfo.destination() != null) {
@@ -35,21 +36,25 @@ public class FootnoteLinkProcessor implements LinkProcessor {
             return LinkResult.none();
         }
 
-        if (linkInfo.label() != null && context.getDefinition(LinkReferenceDefinition.class, linkInfo.label()) != null) {
-            // If there's a label after the text and the label has a definition -> it's a link, and it should take
-            // preference, e.g. in `[^foo][bar]` if `[bar]` has a definition, `[^foo]` won't be a footnote reference.
+        if (linkInfo.label() != null
+                && context.getDefinition(LinkReferenceDefinition.class, linkInfo.label()) != null) {
+            // If there's a label after the text and the label has a definition -> it's a link, and
+            // it should take preference, e.g. in `[^foo][bar]` if `[bar]` has a definition,
+            // `[^foo]` won't be a footnote reference.
             return LinkResult.none();
         }
 
         var label = text.substring(1);
-        // Check if we have a definition, otherwise ignore (same behavior as for link reference definitions).
-        // Note that the definition parser already checked the syntax of the label, we don't need to check again.
+        // Check if we have a definition, otherwise ignore (same behavior as for link reference
+        // definitions). Note that the definition parser already checked the syntax of the label, we
+        // don't need to check again.
         var def = context.getDefinition(FootnoteDefinition.class, label);
         if (def == null) {
             return LinkResult.none();
         }
 
-        // For footnotes, we only ever consume the text part of the link, not the label part (if any)
+        // For footnotes, we only ever consume the text part of the link, not the label part (if
+        // any)
         var position = linkInfo.afterTextBracket();
         // If the marker is `![`, we don't want to include the `!`, so start from bracket
         return LinkResult.replaceWith(new FootnoteReference(label), position);

--- a/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/internal/FootnoteMarkdownNodeRenderer.java
+++ b/commonmark-ext-footnotes/src/main/java/org/commonmark/ext/footnotes/internal/FootnoteMarkdownNodeRenderer.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.footnotes.internal;
 
+import java.util.Set;
 import org.commonmark.ext.footnotes.FootnoteDefinition;
 import org.commonmark.ext.footnotes.FootnoteReference;
 import org.commonmark.ext.footnotes.InlineFootnote;
@@ -7,8 +8,6 @@ import org.commonmark.node.*;
 import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
 import org.commonmark.renderer.markdown.MarkdownWriter;
-
-import java.util.Set;
 
 public class FootnoteMarkdownNodeRenderer implements NodeRenderer {
 

--- a/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnoteHtmlRendererTest.java
+++ b/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnoteHtmlRendererTest.java
@@ -1,5 +1,7 @@
 package org.commonmark.ext.footnotes;
 
+import java.util.List;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.Document;
 import org.commonmark.node.Paragraph;
@@ -10,40 +12,40 @@ import org.commonmark.testutil.Asserts;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Set;
-
 public class FootnoteHtmlRendererTest extends RenderingTestCase {
     private static final Set<Extension> EXTENSIONS = Set.of(FootnotesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void testOne() {
-        assertRendering("Test [^foo]\n\n[^foo]: note\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn-foo\">\n" +
-                        "<p>note <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        assertRendering(
+                "Test [^foo]\n\n[^foo]: note\n",
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-foo\">\n"
+                        + "<p>note <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testLabelNormalization() {
-        // Labels match via their normalized form. For the href and IDs to match, rendering needs to use the
-        // label from the definition consistently.
-        assertRendering("Test [^bar]\n\n[^BAR]: note\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-BAR\" id=\"fnref-BAR\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn-BAR\">\n" +
-                        "<p>note <a href=\"#fnref-BAR\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        // Labels match via their normalized form. For the href and IDs to match, rendering needs to
+        // use the label from the definition consistently.
+        assertRendering(
+                "Test [^bar]\n\n[^BAR]: note\n",
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-BAR\" id=\"fnref-BAR\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-BAR\">\n"
+                        + "<p>note <a href=\"#fnref-BAR\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
@@ -52,253 +54,250 @@ public class FootnoteHtmlRendererTest extends RenderingTestCase {
         // - Numbering is based on the reference order, not the definition order
         // - The same number is used when a definition is referenced multiple times
         // - Multiple backrefs are rendered
-        assertRendering("First [^foo]\n\nThen [^bar]\n\nThen [^foo] again\n\n[^bar]: b\n[^foo]: f\n",
-                "<p>First <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<p>Then <sup class=\"footnote-ref\"><a href=\"#fn-bar\" id=\"fnref-bar\" data-footnote-ref>2</a></sup></p>\n" +
-                        "<p>Then <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo-2\" data-footnote-ref>1</a></sup> again</p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn-foo\">\n" +
-                        "<p>f <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a> <a href=\"#fnref-foo-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-2\" aria-label=\"Back to reference 1-2\"><sup class=\"footnote-ref\">2</sup>↩</a></p>\n" +
-                        "</li>\n" +
-                        "<li id=\"fn-bar\">\n" +
-                        "<p>b <a href=\"#fnref-bar\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        assertRendering(
+                "First [^foo]\n\nThen [^bar]\n\nThen [^foo] again\n\n[^bar]: b\n[^foo]: f\n",
+                "<p>First <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<p>Then <sup class=\"footnote-ref\"><a href=\"#fn-bar\" id=\"fnref-bar\" data-footnote-ref>2</a></sup></p>\n"
+                        + "<p>Then <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo-2\" data-footnote-ref>1</a></sup> again</p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-foo\">\n"
+                        + "<p>f <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a> <a href=\"#fnref-foo-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-2\" aria-label=\"Back to reference 1-2\"><sup class=\"footnote-ref\">2</sup>↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn-bar\">\n"
+                        + "<p>b <a href=\"#fnref-bar\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testDefinitionWithTwoParagraphs() {
         // With two paragraphs, the backref <a> should be added to the second one
-        assertRendering("Test [^foo]\n\n[^foo]: one\n    \n    two\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn-foo\">\n" +
-                        "<p>one</p>\n" +
-                        "<p>two <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        assertRendering(
+                "Test [^foo]\n\n[^foo]: one\n    \n    two\n",
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-foo\">\n"
+                        + "<p>one</p>\n"
+                        + "<p>two <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testDefinitionWithList() {
-        assertRendering("Test [^foo]\n\n[^foo]:\n    - one\n    - two\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn-foo\">\n" +
-                        "<ul>\n" +
-                        "<li>one</li>\n" +
-                        "<li>two</li>\n" +
-                        "</ul>\n" +
-                        "<a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        assertRendering(
+                "Test [^foo]\n\n[^foo]:\n    - one\n    - two\n",
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-foo\">\n"
+                        + "<ul>\n"
+                        + "<li>one</li>\n"
+                        + "<li>two</li>\n"
+                        + "</ul>\n"
+                        + "<a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     // See docs on FootnoteHtmlNodeRenderer about nested footnotes.
 
     @Test
     public void testNestedFootnotesSimple() {
-        assertRendering("[^foo1]\n" +
-                "\n" +
-                "[^foo1]: one [^foo2]\n" +
-                "[^foo2]: two\n", "<p><sup class=\"footnote-ref\"><a href=\"#fn-foo1\" id=\"fnref-foo1\" data-footnote-ref>1</a></sup></p>\n" +
-                "<section class=\"footnotes\" data-footnotes>\n" +
-                "<ol>\n" +
-                "<li id=\"fn-foo1\">\n" +
-                "<p>one <sup class=\"footnote-ref\"><a href=\"#fn-foo2\" id=\"fnref-foo2\" data-footnote-ref>2</a></sup> <a href=\"#fnref-foo1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                "</li>\n" +
-                "<li id=\"fn-foo2\">\n" +
-                "<p>two <a href=\"#fnref-foo2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" +
-                "</li>\n" +
-                "</ol>\n" +
-                "</section>\n");
+        assertRendering(
+                "[^foo1]\n" + "\n" + "[^foo1]: one [^foo2]\n" + "[^foo2]: two\n",
+                "<p><sup class=\"footnote-ref\"><a href=\"#fn-foo1\" id=\"fnref-foo1\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-foo1\">\n"
+                        + "<p>one <sup class=\"footnote-ref\"><a href=\"#fn-foo2\" id=\"fnref-foo2\" data-footnote-ref>2</a></sup> <a href=\"#fnref-foo1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn-foo2\">\n"
+                        + "<p>two <a href=\"#fnref-foo2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testNestedFootnotesOrder() {
         // GitHub has a strange result here, the definitions are in order: 1. bar, 2. foo.
-        // The reason is that the number is done based on all references in document order, including references in
-        // definitions. So [^bar] from the first line is first.
-        assertRendering("[^foo]: foo [^bar]\n" +
-                "\n" +
-                "[^foo]\n" +
-                "\n" +
-                "[^bar]: bar\n", "<p><sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n" +
-                "<section class=\"footnotes\" data-footnotes>\n" +
-                "<ol>\n" +
-                "<li id=\"fn-foo\">\n" +
-                "<p>foo <sup class=\"footnote-ref\"><a href=\"#fn-bar\" id=\"fnref-bar\" data-footnote-ref>2</a></sup> <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                "</li>\n" +
-                "<li id=\"fn-bar\">\n" +
-                "<p>bar <a href=\"#fnref-bar\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" +
-                "</li>\n" +
-                "</ol>\n" +
-                "</section>\n");
+        // The reason is that the number is done based on all references in document order,
+        // including references in definitions. So [^bar] from the first line is first.
+        assertRendering(
+                "[^foo]: foo [^bar]\n" + "\n" + "[^foo]\n" + "\n" + "[^bar]: bar\n",
+                "<p><sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-foo\">\n"
+                        + "<p>foo <sup class=\"footnote-ref\"><a href=\"#fn-bar\" id=\"fnref-bar\" data-footnote-ref>2</a></sup> <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn-bar\">\n"
+                        + "<p>bar <a href=\"#fnref-bar\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testNestedFootnotesOrder2() {
-        assertRendering("[^1]\n" +
-                "\n" +
-                "[^4]: four\n" +
-                "[^3]: three [^4]\n" +
-                "[^2]: two [^4]\n" +
-                "[^1]: one [^2][^3]\n", "<p><sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n" +
-                "<section class=\"footnotes\" data-footnotes>\n" +
-                "<ol>\n" +
-                "<li id=\"fn-1\">\n" +
-                "<p>one <sup class=\"footnote-ref\"><a href=\"#fn-2\" id=\"fnref-2\" data-footnote-ref>2</a></sup><sup class=\"footnote-ref\"><a href=\"#fn-3\" id=\"fnref-3\" data-footnote-ref>3</a></sup> <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                "</li>\n" +
-                "<li id=\"fn-2\">\n" +
-                "<p>two <sup class=\"footnote-ref\"><a href=\"#fn-4\" id=\"fnref-4\" data-footnote-ref>4</a></sup> <a href=\"#fnref-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" +
-                "</li>\n" +
-                "<li id=\"fn-3\">\n" +
-                "<p>three <sup class=\"footnote-ref\"><a href=\"#fn-4\" id=\"fnref-4-2\" data-footnote-ref>4</a></sup> <a href=\"#fnref-3\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"3\" aria-label=\"Back to reference 3\">↩</a></p>\n" +
-                "</li>\n" +
-                "<li id=\"fn-4\">\n" +
-                "<p>four <a href=\"#fnref-4\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"4\" aria-label=\"Back to reference 4\">↩</a> <a href=\"#fnref-4-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"4-2\" aria-label=\"Back to reference 4-2\"><sup class=\"footnote-ref\">2</sup>↩</a></p>\n" +
-                "</li>\n" +
-                "</ol>\n" +
-                "</section>\n");
+        assertRendering(
+                "[^1]\n"
+                        + "\n"
+                        + "[^4]: four\n"
+                        + "[^3]: three [^4]\n"
+                        + "[^2]: two [^4]\n"
+                        + "[^1]: one [^2][^3]\n",
+                "<p><sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-1\">\n"
+                        + "<p>one <sup class=\"footnote-ref\"><a href=\"#fn-2\" id=\"fnref-2\" data-footnote-ref>2</a></sup><sup class=\"footnote-ref\"><a href=\"#fn-3\" id=\"fnref-3\" data-footnote-ref>3</a></sup> <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn-2\">\n"
+                        + "<p>two <sup class=\"footnote-ref\"><a href=\"#fn-4\" id=\"fnref-4\" data-footnote-ref>4</a></sup> <a href=\"#fnref-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn-3\">\n"
+                        + "<p>three <sup class=\"footnote-ref\"><a href=\"#fn-4\" id=\"fnref-4-2\" data-footnote-ref>4</a></sup> <a href=\"#fnref-3\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"3\" aria-label=\"Back to reference 3\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn-4\">\n"
+                        + "<p>four <a href=\"#fnref-4\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"4\" aria-label=\"Back to reference 4\">↩</a> <a href=\"#fnref-4-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"4-2\" aria-label=\"Back to reference 4-2\"><sup class=\"footnote-ref\">2</sup>↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testNestedFootnotesCycle() {
         // Footnotes can contain cycles, lol.
-        assertRendering("[^foo1]\n" +
-                "\n" +
-                "[^foo1]: one [^foo2]\n" +
-                "[^foo2]: two [^foo1]\n", "<p><sup class=\"footnote-ref\"><a href=\"#fn-foo1\" id=\"fnref-foo1\" data-footnote-ref>1</a></sup></p>\n" +
-                "<section class=\"footnotes\" data-footnotes>\n" +
-                "<ol>\n" +
-                "<li id=\"fn-foo1\">\n" +
-                "<p>one <sup class=\"footnote-ref\"><a href=\"#fn-foo2\" id=\"fnref-foo2\" data-footnote-ref>2</a></sup> <a href=\"#fnref-foo1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a> <a href=\"#fnref-foo1-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-2\" aria-label=\"Back to reference 1-2\"><sup class=\"footnote-ref\">2</sup>↩</a></p>\n" +
-                "</li>\n" +
-                "<li id=\"fn-foo2\">\n" +
-                "<p>two <sup class=\"footnote-ref\"><a href=\"#fn-foo1\" id=\"fnref-foo1-2\" data-footnote-ref>1</a></sup> <a href=\"#fnref-foo2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" +
-                "</li>\n" +
-                "</ol>\n" +
-                "</section>\n");
+        assertRendering(
+                "[^foo1]\n" + "\n" + "[^foo1]: one [^foo2]\n" + "[^foo2]: two [^foo1]\n",
+                "<p><sup class=\"footnote-ref\"><a href=\"#fn-foo1\" id=\"fnref-foo1\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-foo1\">\n"
+                        + "<p>one <sup class=\"footnote-ref\"><a href=\"#fn-foo2\" id=\"fnref-foo2\" data-footnote-ref>2</a></sup> <a href=\"#fnref-foo1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a> <a href=\"#fnref-foo1-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-2\" aria-label=\"Back to reference 1-2\"><sup class=\"footnote-ref\">2</sup>↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn-foo2\">\n"
+                        + "<p>two <sup class=\"footnote-ref\"><a href=\"#fn-foo1\" id=\"fnref-foo1-2\" data-footnote-ref>1</a></sup> <a href=\"#fnref-foo2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testNestedFootnotesUnreferenced() {
         // This should not result in any footnotes, as baz itself isn't referenced.
         // But GitHub renders bar only, with a broken backref, because bar is referenced from foo.
-        assertRendering("[^foo]: foo[^bar]\n" +
-                "[^bar]: bar\n", "");
+        assertRendering("[^foo]: foo[^bar]\n" + "[^bar]: bar\n", "");
 
         // And here only 1 is rendered.
-        assertRendering("[^1]\n" +
-                "\n" +
-                "[^1]: one\n" +
-                "[^foo]: foo[^bar]\n" +
-                "[^bar]: bar\n", "<p><sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n" +
-                "<section class=\"footnotes\" data-footnotes>\n" +
-                "<ol>\n" +
-                "<li id=\"fn-1\">\n" +
-                "<p>one <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                "</li>\n" +
-                "</ol>\n" +
-                "</section>\n");
+        assertRendering(
+                "[^1]\n" + "\n" + "[^1]: one\n" + "[^foo]: foo[^bar]\n" + "[^bar]: bar\n",
+                "<p><sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-1\">\n"
+                        + "<p>one <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testInlineFootnotes() {
-        assertRenderingInline("Test ^[inline *footnote*]",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn1\">\n" +
-                        "<p>inline <em>footnote</em> <a href=\"#fnref1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        assertRenderingInline(
+                "Test ^[inline *footnote*]",
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn1\">\n"
+                        + "<p>inline <em>footnote</em> <a href=\"#fnref1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testInlineFootnotesNested() {
-        assertRenderingInline("Test ^[inline ^[nested]]",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn1\">\n" +
-                        "<p>inline <sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\" data-footnote-ref>2</a></sup> <a href=\"#fnref1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "<li id=\"fn2\">\n" +
-                        "<p>nested <a href=\"#fnref2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        assertRenderingInline(
+                "Test ^[inline ^[nested]]",
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn1\">\n"
+                        + "<p>inline <sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\" data-footnote-ref>2</a></sup> <a href=\"#fnref1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn2\">\n"
+                        + "<p>nested <a href=\"#fnref2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testInlineFootnoteWithReference() {
         // This is a bit tricky because the IDs need to be unique.
-        assertRenderingInline("Test ^[inline [^1]]\n" +
-                        "\n" +
-                        "[^1]: normal",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn1\">\n" +
-                        "<p>inline <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>2</a></sup> <a href=\"#fnref1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "<li id=\"fn-1\">\n" +
-                        "<p>normal <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        assertRenderingInline(
+                "Test ^[inline [^1]]\n" + "\n" + "[^1]: normal",
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn1\">\n"
+                        + "<p>inline <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>2</a></sup> <a href=\"#fnref1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn-1\">\n"
+                        + "<p>normal <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testInlineFootnoteInsideDefinition() {
-        assertRenderingInline("Test [^1]\n" +
-                        "\n" +
-                        "[^1]: Definition ^[inline]\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn-1\">\n" +
-                        "<p>Definition <sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\" data-footnote-ref>2</a></sup> <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "<li id=\"fn2\">\n" +
-                        "<p>inline <a href=\"#fnref2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        assertRenderingInline(
+                "Test [^1]\n" + "\n" + "[^1]: Definition ^[inline]\n",
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-1\">\n"
+                        + "<p>Definition <sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\" data-footnote-ref>2</a></sup> <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn2\">\n"
+                        + "<p>inline <a href=\"#fnref2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
 
     @Test
     public void testInlineFootnoteInsideDefinition2() {
-        // Tricky because of the nested inline footnote which we want to visit after foo (breadth-first).
-        assertRenderingInline("Test [^1]\n" +
-                        "\n" +
-                        "[^1]: Definition ^[inline ^[nested]] ^[foo]\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n" +
-                        "<section class=\"footnotes\" data-footnotes>\n" +
-                        "<ol>\n" +
-                        "<li id=\"fn-1\">\n" +
-                        "<p>Definition <sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\" data-footnote-ref>2</a></sup> <sup class=\"footnote-ref\"><a href=\"#fn3\" id=\"fnref3\" data-footnote-ref>3</a></sup> <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "<li id=\"fn2\">\n" +
-                        "<p>inline <sup class=\"footnote-ref\"><a href=\"#fn4\" id=\"fnref4\" data-footnote-ref>4</a></sup> <a href=\"#fnref2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "<li id=\"fn3\">\n" +
-                        "<p>foo <a href=\"#fnref3\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"3\" aria-label=\"Back to reference 3\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "<li id=\"fn4\">\n" +
-                        "<p>nested <a href=\"#fnref4\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"4\" aria-label=\"Back to reference 4\">↩</a></p>\n" +
-                        "</li>\n" +
-                        "</ol>\n" +
-                        "</section>\n");
+        // Tricky because of the nested inline footnote which we want to visit after foo
+        // (breadth-first).
+        assertRenderingInline(
+                "Test [^1]\n" + "\n" + "[^1]: Definition ^[inline ^[nested]] ^[foo]\n",
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-1\">\n"
+                        + "<p>Definition <sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\" data-footnote-ref>2</a></sup> <sup class=\"footnote-ref\"><a href=\"#fn3\" id=\"fnref3\" data-footnote-ref>3</a></sup> <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn2\">\n"
+                        + "<p>inline <sup class=\"footnote-ref\"><a href=\"#fn4\" id=\"fnref4\" data-footnote-ref>4</a></sup> <a href=\"#fnref2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn3\">\n"
+                        + "<p>foo <a href=\"#fnref3\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"3\" aria-label=\"Back to reference 3\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "<li id=\"fn4\">\n"
+                        + "<p>nested <a href=\"#fnref4\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"4\" aria-label=\"Back to reference 4\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n");
     }
-
 
     @Test
     public void testRenderNodesDirectly() {
@@ -314,14 +313,15 @@ public class FootnoteHtmlRendererTest extends RenderingTestCase {
         doc.appendChild(p);
         doc.appendChild(def);
 
-        var expected = "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n" +
-                "<section class=\"footnotes\" data-footnotes>\n" +
-                "<ol>\n" +
-                "<li id=\"fn-foo\">\n" +
-                "<p>note! <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n" +
-                "</li>\n" +
-                "</ol>\n" +
-                "</section>\n";
+        var expected =
+                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
+                        + "<section class=\"footnotes\" data-footnotes>\n"
+                        + "<ol>\n"
+                        + "<li id=\"fn-foo\">\n"
+                        + "<p>note! <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
+                        + "</li>\n"
+                        + "</ol>\n"
+                        + "</section>\n";
         Asserts.assertRendering("", expected, RENDERER.render(doc));
     }
 

--- a/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnoteMarkdownRendererTest.java
+++ b/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnoteMarkdownRendererTest.java
@@ -1,19 +1,20 @@
 package org.commonmark.ext.footnotes;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class FootnoteMarkdownRendererTest {
-    private static final Set<Extension> EXTENSIONS = Set.of(FootnotesExtension.builder().inlineFootnotes(true).build());
+    private static final Set<Extension> EXTENSIONS =
+            Set.of(FootnotesExtension.builder().inlineFootnotes(true).build());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER =
+            MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void testSimple() {
@@ -22,7 +23,8 @@ public class FootnoteMarkdownRendererTest {
 
     @Test
     public void testUnreferenced() {
-        // Whether a reference has a corresponding definition or vice versa shouldn't matter for Markdown rendering.
+        // Whether a reference has a corresponding definition or vice versa shouldn't matter for
+        // Markdown rendering.
         assertRoundTrip("Test [^foo]\n\n[^foo]: one\n\n[^bar]: two\n");
     }
 
@@ -43,8 +45,8 @@ public class FootnoteMarkdownRendererTest {
 
     @Test
     public void testMultipleParagraphs() {
-        // Note that the line between p1 and p2 could be blank too (instead of 4 spaces), but we currently don't
-        // preserve that information.
+        // Note that the line between p1 and p2 could be blank too (instead of 4 spaces), but we
+        // currently don't preserve that information.
         assertRoundTrip("Test [^1]\n\n[^1]: footnote p1\n    \n    footnote p2\n");
     }
 

--- a/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnotesTest.java
+++ b/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnotesTest.java
@@ -1,17 +1,16 @@
 package org.commonmark.ext.footnotes;
 
-import org.commonmark.Extension;
-import org.commonmark.node.*;
-import org.commonmark.parser.IncludeSourceSpans;
-import org.commonmark.parser.Parser;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.commonmark.Extension;
+import org.commonmark.node.*;
+import org.commonmark.parser.IncludeSourceSpans;
+import org.commonmark.parser.Parser;
+import org.junit.jupiter.api.Test;
 
 public class FootnotesTest {
 
@@ -35,7 +34,8 @@ public class FootnotesTest {
 
     @Test
     public void testDefBlockStartInterrupts() {
-        // This is different from a link reference definition, which can only be at the start of paragraphs.
+        // This is different from a link reference definition, which can only be at the start of
+        // paragraphs.
         var doc = PARSER.parse("test\n[^1]: footnote\n");
         var paragraph = find(doc, Paragraph.class);
         var def = find(doc, FootnoteDefinition.class);
@@ -172,7 +172,8 @@ public class FootnotesTest {
 
     @Test
     public void testRefWithEmphasisAround() {
-        // Emphasis around footnote reference, the * inside needs to be removed from emphasis processing
+        // Emphasis around footnote reference, the * inside needs to be removed from emphasis
+        // processing
         var doc = PARSER.parse("Test *abc [^foo*] def*\n\n[^foo*]: def\n");
         var ref = find(doc, FootnoteReference.class);
         assertThat(ref.getLabel()).isEqualTo("foo*");
@@ -193,8 +194,9 @@ public class FootnotesTest {
 
     @Test
     public void testRefAsLabelOnly() {
-        // [^bar] is a footnote but [foo] is just text, because full reference links (text `foo`, label `^bar`) don't
-        // resolve as footnotes. If `[foo][^bar]` fails to parse as a bracket, `[^bar]` by itself needs to be tried.
+        // [^bar] is a footnote but [foo] is just text, because full reference links (text `foo`,
+        // label `^bar`) don't resolve as footnotes. If `[foo][^bar]` fails to parse as a bracket,
+        // `[^bar]` by itself needs to be tried.
         var doc = PARSER.parse("Test [foo][^bar]\n\n[^bar]: footnote\n");
         var ref = find(doc, FootnoteReference.class);
         assertThat(ref.getLabel()).isEqualTo("bar");
@@ -204,7 +206,8 @@ public class FootnotesTest {
 
     @Test
     public void testRefWithEmptyLabel() {
-        // [^bar] is a footnote but [] is just text, because collapsed reference links don't resolve as footnotes
+        // [^bar] is a footnote but [] is just text, because collapsed reference links don't resolve
+        // as footnotes
         var doc = PARSER.parse("Test [^bar][]\n\n[^bar]: footnote\n");
         var ref = find(doc, FootnoteReference.class);
         assertThat(ref.getLabel()).isEqualTo("bar");
@@ -237,8 +240,8 @@ public class FootnotesTest {
 
     @Test
     public void testPreferReferenceLink() {
-        // This is tricky because `[^*foo*][foo]` is a valid link already. If `[foo]` was not defined, the first bracket
-        // would be a footnote.
+        // This is tricky because `[^*foo*][foo]` is a valid link already. If `[foo]` was not
+        // defined, the first bracket would be a footnote.
         var doc = PARSER.parse("Test [^*foo*][foo]\n\n[^*foo*]: /url\n\n[foo]: /url");
         assertNone(doc, FootnoteReference.class);
     }
@@ -256,10 +259,13 @@ public class FootnotesTest {
 
     @Test
     public void testFootnoteInLink() {
-        // Expected to behave the same way as a link within a link, see https://spec.commonmark.org/0.31.2/#example-518
-        // i.e. the first (inner) link is parsed, which means the outer one becomes plain text, as nesting links is not
-        // allowed.
-        var doc = PARSER.parse("[link with footnote ref [^1]](https://example.com)\n\n[^1]: footnote\n");
+        // Expected to behave the same way as a link within a link, see
+        // https://spec.commonmark.org/0.31.2/#example-518
+        // i.e. the first (inner) link is parsed, which means the outer one becomes plain text, as
+        // nesting links is not allowed.
+        var doc =
+                PARSER.parse(
+                        "[link with footnote ref [^1]](https://example.com)\n\n[^1]: footnote\n");
         var ref = find(doc, FootnoteReference.class);
         assertThat(ref.getLabel()).isEqualTo("1");
         var paragraph = doc.getFirstChild();
@@ -269,7 +275,9 @@ public class FootnotesTest {
 
     @Test
     public void testFootnoteWithMarkerInLink() {
-        var doc = PARSER.parse("[link with footnote ref ![^1]](https://example.com)\n\n[^1]: footnote\n");
+        var doc =
+                PARSER.parse(
+                        "[link with footnote ref ![^1]](https://example.com)\n\n[^1]: footnote\n");
         var ref = find(doc, FootnoteReference.class);
         assertThat(ref.getLabel()).isEqualTo("1");
         var paragraph = doc.getFirstChild();
@@ -325,7 +333,11 @@ public class FootnotesTest {
 
     @Test
     public void testSourcePositions() {
-        var parser = Parser.builder().extensions(EXTENSIONS).includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES).build();
+        var parser =
+                Parser.builder()
+                        .extensions(EXTENSIONS)
+                        .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                        .build();
 
         var doc = parser.parse("Test [^foo]\n\n[^foo]: /url\n");
         var ref = find(doc, FootnoteReference.class);
@@ -336,11 +348,15 @@ public class FootnotesTest {
     }
 
     private static void assertNone(Node parent, Class<?> nodeClass) {
-        assertThat(tryFind(parent, nodeClass)).as(() -> "Node " + parent + " containing " + nodeClass).isNull();
+        assertThat(tryFind(parent, nodeClass))
+                .as(() -> "Node " + parent + " containing " + nodeClass)
+                .isNull();
     }
 
     private static <T> T find(Node parent, Class<T> nodeClass) {
-        return Objects.requireNonNull(tryFind(parent, nodeClass), "Could not find a " + nodeClass.getSimpleName() + " node in " + parent);
+        return Objects.requireNonNull(
+                tryFind(parent, nodeClass),
+                "Could not find a " + nodeClass.getSimpleName() + " node in " + parent);
     }
 
     private static <T> T tryFind(Node parent, Class<T> nodeClass) {

--- a/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/Alert.java
+++ b/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/Alert.java
@@ -21,31 +21,32 @@ public class Alert extends CustomBlock {
 
     /**
      * @return Whether this alert has any body content (not including the title).
-     * <p>
+     *     <p>- Examples where this would be {@code true}:
+     *     <pre>{@code
+     * > [!NOTE]
+     * > Body text
      *
-     * - Examples where this would be {@code true}:
-     *   <pre>{@code
-     *   > [!NOTE]
-     *   > Body text
-     *   }</pre>
-     *   <pre>{@code
-     *   > [!NOTE] Custom title
-     *   > Body text
-     *   }</pre>
+     * }</pre>
+     *     <pre>{@code
+     * > [!NOTE] Custom title
+     * > Body text
      *
-     * - Examples where this would be {@code false}:
+     * }</pre>
+     *     - Examples where this would be {@code false}:
+     *     <pre>{@code
+     * > [!NOTE]
      *
-     *   <pre>{@code
-     *   > [!NOTE]
-     *   }</pre>
-     *   <pre>{@code
-     *   > [!NOTE]
-     *   >
-     *   >
-     *   }</pre>
-     *   <pre>{@code
-     *   > [!NOTE] Custom title
-     *   }</pre>
+     * }</pre>
+     *     <pre>{@code
+     * > [!NOTE]
+     * >
+     * >
+     *
+     * }</pre>
+     *     <pre>{@code
+     * > [!NOTE] Custom title
+     *
+     * }</pre>
      */
     public boolean hasBody() {
         var first = this.getFirstChild();

--- a/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/AlertTitle.java
+++ b/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/AlertTitle.java
@@ -5,20 +5,18 @@ import org.commonmark.node.CustomNode;
 /**
  * Inline content container for the optional custom title of an {@link Alert}.
  *
- * <p>
- * When present, an {@code AlertTitle} is always the first child of an {@link Alert}.
- * Its own children are the parsed inline nodes of the title (i.e., the text after
- * the {@code [!TYPE]} marker on the same line). For example, in
+ * <p>When present, an {@code AlertTitle} is always the first child of an {@link Alert}. Its own
+ * children are the parsed inline nodes of the title (i.e., the text after the {@code [!TYPE]}
+ * marker on the same line). For example, in
  *
  * <pre>{@code
  * > [!NOTE] Custom _title_
  * > Body text
  * }</pre>
  *
- * the {@code AlertTitle} contains a {@code Text} node ({@code "Custom "}) followed
- * by an {@code Emphasis} node wrapping {@code "title"}.
+ * the {@code AlertTitle} contains a {@code Text} node ({@code "Custom "}) followed by an {@code
+ * Emphasis} node wrapping {@code "title"}.
  *
  * @see AlertsExtension.Builder#allowCustomTitles(boolean)
  */
-public class AlertTitle extends CustomNode {
-}
+public class AlertTitle extends CustomNode {}

--- a/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/AlertsExtension.java
+++ b/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/AlertsExtension.java
@@ -1,5 +1,11 @@
 package org.commonmark.ext.gfm.alerts;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.alerts.internal.AlertBlockParser;
 import org.commonmark.ext.gfm.alerts.internal.AlertHtmlNodeRenderer;
@@ -13,61 +19,60 @@ import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.commonmark.renderer.text.TextContentRenderer;
 
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-
 /**
  * Extension for GFM alerts using {@code [!TYPE]} syntax (GitHub Flavored Markdown).
- * <p>
- * Create with {@link #create()} or {@link #builder()} and configure on builders
- * ({@link Parser.Builder#extensions(Iterable)}, {@link HtmlRenderer.Builder#extensions(Iterable)}).
- * Parsed alerts become {@link Alert} blocks. If custom alert titles are allowed
- * via {@link Builder#allowCustomTitles(boolean)}, the inline formatting of those
- * titles will be parsed into {@link AlertTitle} nodes.
  *
- * The {@link #create() default configuration} of this extension will match GFM
- * exactly, with the following exceptions:
+ * <p>Create with {@link #create()} or {@link #builder()} and configure on builders ({@link
+ * Parser.Builder#extensions(Iterable)}, {@link HtmlRenderer.Builder#extensions(Iterable)}). Parsed
+ * alerts become {@link Alert} blocks. If custom alert titles are allowed via {@link
+ * Builder#allowCustomTitles(boolean)}, the inline formatting of those titles will be parsed into
+ * {@link AlertTitle} nodes.
  *
- * - Alert markers take precedence over <a href="https://spec.commonmark.org/current/#shortcut-reference-link">shortcut reference links</a>.
+ * <p>The {@link #create() default configuration} of this extension will match GFM exactly, with the
+ * following exceptions:
+ *
+ * <p>- Alert markers take precedence over <a
+ * href="https://spec.commonmark.org/current/#shortcut-reference-link">shortcut reference links</a>.
  * - Alerts with no content are allowed. Example:
  *
- *   <pre>{@code
- *   <!-- Valid -->
- *   > [!NOTE]
+ * <pre>{@code
+ * <!-- Valid -->
+ * > [!NOTE]
  *
- *   <!-- Also valid if custom titles are allowed -->
- *   > [!NOTE] Custom title
- *   }</pre>
+ * <!-- Also valid if custom titles are allowed -->
+ * > [!NOTE] Custom title
+ *
+ * }</pre>
+ *
  * - Lazy continuation is not allowed between the marker and the body text. Example:
  *
- *   <pre>{@code
- *   > [!NOTE]
- *   Lazy body text will be parsed as a new paragraph
- *   }</pre>
+ * <pre>{@code
+ * > [!NOTE]
+ * Lazy body text will be parsed as a new paragraph
+ *
+ * }</pre>
  */
-public class AlertsExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension,
-        TextContentRenderer.TextContentRendererExtension, MarkdownRenderer.MarkdownRendererExtension {
+public class AlertsExtension
+        implements Parser.ParserExtension,
+                HtmlRenderer.HtmlRendererExtension,
+                TextContentRenderer.TextContentRendererExtension,
+                MarkdownRenderer.MarkdownRendererExtension {
 
     /**
-     * The standard GitHub Flavored Markdown (GFM) types that the extension
-     * enables by default. These can be overwritten with {@link Builder#setAllowedTypes(Map)}.
+     * The standard GitHub Flavored Markdown (GFM) types that the extension enables by default.
+     * These can be overwritten with {@link Builder#setAllowedTypes(Map)}.
      */
-    public static final Map<String, String> STANDARD_TYPES = Map.ofEntries(
-        Map.entry("NOTE", "Note"),
-        Map.entry("TIP", "Tip"),
-        Map.entry("IMPORTANT", "Important"),
-        Map.entry("WARNING", "Warning"),
-        Map.entry("CAUTION", "Caution")
-    );
+    public static final Map<String, String> STANDARD_TYPES =
+            Map.ofEntries(
+                    Map.entry("NOTE", "Note"),
+                    Map.entry("TIP", "Tip"),
+                    Map.entry("IMPORTANT", "Important"),
+                    Map.entry("WARNING", "Warning"),
+                    Map.entry("CAUTION", "Caution"));
 
-    /**
-     * A map of alert marker ({@code [!TYPE]}) to the default title for that marker.
-     */
+    /** A map of alert marker ({@code [!TYPE]}) to the default title for that marker. */
     private final Map<String, String> allowedTypes;
+
     private final boolean customTitlesAllowed;
     private final boolean nestedAlertsAllowed;
 
@@ -89,37 +94,39 @@ public class AlertsExtension implements Parser.ParserExtension, HtmlRenderer.Htm
     public void extend(Parser.Builder parserBuilder) {
         var allowedTypesSet = new HashSet<>(allowedTypes.keySet());
         parserBuilder.customBlockParserFactory(
-            new AlertBlockParser.Factory(allowedTypesSet, customTitlesAllowed, nestedAlertsAllowed));
+                new AlertBlockParser.Factory(
+                        allowedTypesSet, customTitlesAllowed, nestedAlertsAllowed));
     }
 
     @Override
     public void extend(HtmlRenderer.Builder rendererBuilder) {
-        rendererBuilder.nodeRendererFactory(context -> new AlertHtmlNodeRenderer(context, allowedTypes));
+        rendererBuilder.nodeRendererFactory(
+                context -> new AlertHtmlNodeRenderer(context, allowedTypes));
     }
 
     @Override
     public void extend(TextContentRenderer.Builder rendererBuilder) {
-        rendererBuilder.nodeRendererFactory(context -> new AlertTextContentNodeRenderer(context, allowedTypes));
+        rendererBuilder.nodeRendererFactory(
+                context -> new AlertTextContentNodeRenderer(context, allowedTypes));
     }
 
     @Override
     public void extend(MarkdownRenderer.Builder rendererBuilder) {
-        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(MarkdownNodeRendererContext context) {
-                return new AlertMarkdownNodeRenderer(context);
-            }
+        rendererBuilder.nodeRendererFactory(
+                new MarkdownNodeRendererFactory() {
+                    @Override
+                    public NodeRenderer create(MarkdownNodeRendererContext context) {
+                        return new AlertMarkdownNodeRenderer(context);
+                    }
 
-            @Override
-            public Set<Character> getSpecialCharacters() {
-                return Set.of();
-            }
-        });
+                    @Override
+                    public Set<Character> getSpecialCharacters() {
+                        return Set.of();
+                    }
+                });
     }
 
-    /**
-     * Builder for configuring the alerts extension.
-     */
+    /** Builder for configuring the alerts extension. */
     public static class Builder {
         private Map<String, String> allowedTypes = new HashMap<>(STANDARD_TYPES);
         private boolean customTitlesAllowed = false;
@@ -128,12 +135,12 @@ public class AlertsExtension implements Parser.ParserExtension, HtmlRenderer.Htm
         /**
          * Sets which alert types will be recognized and parsed into {@link Alert} blocks,
          * completely overwriting any previous configuration.
-         * <p>
-         * By default, {@link AlertsExtension#STANDARD_TYPES} are used.
          *
-         * @param allowedTypes A map of alert type to the default title for that type.
-         *                     Must not be null/empty or contain any null/empty keys or
-         *                     values. Additionally, all alert types must be uppercase.
+         * <p>By default, {@link AlertsExtension#STANDARD_TYPES} are used.
+         *
+         * @param allowedTypes A map of alert type to the default title for that type. Must not be
+         *     null/empty or contain any null/empty keys or values. Additionally, all alert types
+         *     must be uppercase.
          * @return {@code this}
          * @see Builder#addCustomType(String, String)
          */
@@ -153,9 +160,9 @@ public class AlertsExtension implements Parser.ParserExtension, HtmlRenderer.Htm
 
         /**
          * Adds a custom alert type with a default title.
-         * <p>
-         * This can also be used to override the default title of standard GFM types
-         * (e.g., for localization).
+         *
+         * <p>This can also be used to override the default title of standard GFM types (e.g., for
+         * localization).
          *
          * @param type the alert type (must be uppercase)
          * @param title the default title for this alert type
@@ -169,8 +176,8 @@ public class AlertsExtension implements Parser.ParserExtension, HtmlRenderer.Htm
         }
 
         /**
-         * Allows or disallows custom titles on alerts. Inline formatting is supported
-         * within these titles.
+         * Allows or disallows custom titles on alerts. Inline formatting is supported within these
+         * titles.
          *
          * @param allow Whether to allow or disallow custom titles on alerts.
          * @return {@code this}
@@ -183,11 +190,11 @@ public class AlertsExtension implements Parser.ParserExtension, HtmlRenderer.Htm
 
         /**
          * Allows or disallows parsing alerts within non-root blocks ({@code Document}).
-         * <p>
-         * When disallowed, if an alert appears within another block, it will be parsed as
-         * a regular {@code BlockQuote}.
-         * <p>
-         * Note that even when this is allowed, {@link Parser.Builder#maxOpenBlockParsers(int)}
+         *
+         * <p>When disallowed, if an alert appears within another block, it will be parsed as a
+         * regular {@code BlockQuote}.
+         *
+         * <p>Note that even when this is allowed, {@link Parser.Builder#maxOpenBlockParsers(int)}
          * will be respected.
          *
          * @param allow Whether to allow or disallow parsing alerts within non-root blocks.
@@ -208,10 +215,7 @@ public class AlertsExtension implements Parser.ParserExtension, HtmlRenderer.Htm
         /**
          * Checks whether an alert type and default title are valid.
          *
-         * @param type The type to validate:
-         *             <p>
-         *             - Must not be null or empty
-         *             - Must be uppercase
+         * @param type The type to validate. Must be uppercase.
          * @param title The default title to validate. Must not be null or empty.
          */
         private void validateTypeAndTitle(String type, String title) {

--- a/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/internal/AlertBlockParser.java
+++ b/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/internal/AlertBlockParser.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
-
 import org.commonmark.ext.gfm.alerts.Alert;
 import org.commonmark.ext.gfm.alerts.AlertTitle;
 import org.commonmark.node.Block;
@@ -23,8 +22,10 @@ import org.commonmark.text.Characters;
 
 public class AlertBlockParser extends AbstractBlockParser {
 
-    private static final Pattern ALERT_PATTERN_NO_CUSTOM_TITLE = Pattern.compile("^\\[!([a-zA-Z]+)]\\s*$");
-    private static final Pattern ALERT_PATTERN_CUSTOM_TITLE = Pattern.compile("^\\[!([a-zA-Z]+)](.*)$");
+    private static final Pattern ALERT_PATTERN_NO_CUSTOM_TITLE =
+            Pattern.compile("^\\[!([a-zA-Z]+)]\\s*$");
+    private static final Pattern ALERT_PATTERN_CUSTOM_TITLE =
+            Pattern.compile("^\\[!([a-zA-Z]+)](.*)$");
 
     private final Alert block;
     private final SourceLine titleLine;
@@ -103,7 +104,10 @@ public class AlertBlockParser extends AbstractBlockParser {
         private final boolean customTitlesAllowed;
         private final boolean nestedAlertsAllowed;
 
-        public Factory(Set<String> allowedTypes, boolean customTitlesAllowed, boolean nestedAlertsAllowed) {
+        public Factory(
+                Set<String> allowedTypes,
+                boolean customTitlesAllowed,
+                boolean nestedAlertsAllowed) {
             this.allowedTypes = allowedTypes;
             this.customTitlesAllowed = customTitlesAllowed;
             this.nestedAlertsAllowed = nestedAlertsAllowed;
@@ -116,7 +120,8 @@ public class AlertBlockParser extends AbstractBlockParser {
                 return BlockStart.none();
             }
 
-            if (!nestedAlertsAllowed && !isAtRoot(matchedBlockParser.getMatchedBlockParser().getBlock())) {
+            if (!nestedAlertsAllowed
+                    && !isAtRoot(matchedBlockParser.getMatchedBlockParser().getBlock())) {
                 return BlockStart.none();
             }
 
@@ -176,7 +181,10 @@ public class AlertBlockParser extends AbstractBlockParser {
                 afterGt = state.getIndex();
             }
 
-            var pattern = customTitlesAllowed ? ALERT_PATTERN_CUSTOM_TITLE : ALERT_PATTERN_NO_CUSTOM_TITLE;
+            var pattern =
+                    customTitlesAllowed
+                            ? ALERT_PATTERN_CUSTOM_TITLE
+                            : ALERT_PATTERN_NO_CUSTOM_TITLE;
             var matcher = pattern.matcher(line.subSequence(afterGt, line.length()));
 
             if (!matcher.matches()) {
@@ -215,7 +223,8 @@ public class AlertBlockParser extends AbstractBlockParser {
 
             // If we got here via the promotion path, replace the empty BlockQuote.
             var matched = state.getActiveBlockParser().getBlock();
-            if (matched instanceof BlockQuote && matched.getFirstChild() == null
+            if (matched instanceof BlockQuote
+                    && matched.getFirstChild() == null
                     && (nextNonSpace >= line.length() || line.charAt(nextNonSpace) != '>')) {
                 start = start.replaceActiveBlockParser();
             }

--- a/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/internal/AlertHtmlNodeRenderer.java
+++ b/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/internal/AlertHtmlNodeRenderer.java
@@ -1,13 +1,12 @@
 package org.commonmark.ext.gfm.alerts.internal;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.commonmark.ext.gfm.alerts.Alert;
 import org.commonmark.ext.gfm.alerts.AlertTitle;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlWriter;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 public class AlertHtmlNodeRenderer extends AlertNodeRenderer {
 
@@ -15,7 +14,8 @@ public class AlertHtmlNodeRenderer extends AlertNodeRenderer {
     private final HtmlNodeRendererContext context;
     private final Map<String, String> allowedTypes;
 
-    public AlertHtmlNodeRenderer(HtmlNodeRendererContext context, Map<String, String> allowedTypes) {
+    public AlertHtmlNodeRenderer(
+            HtmlNodeRendererContext context, Map<String, String> allowedTypes) {
         this.htmlWriter = context.getWriter();
         this.context = context;
         this.allowedTypes = allowedTypes;
@@ -39,7 +39,8 @@ public class AlertHtmlNodeRenderer extends AlertNodeRenderer {
         htmlWriter.line();
 
         // Render alert title
-        htmlWriter.tag("p", context.extendAttributes(alert, "p", Map.of("class", "markdown-alert-title")));
+        htmlWriter.tag(
+                "p", context.extendAttributes(alert, "p", Map.of("class", "markdown-alert-title")));
         var first = alert.getFirstChild();
         if (first instanceof AlertTitle) {
             renderChildren(first);

--- a/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/internal/AlertNodeRenderer.java
+++ b/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/internal/AlertNodeRenderer.java
@@ -1,11 +1,10 @@
 package org.commonmark.ext.gfm.alerts.internal;
 
+import java.util.Set;
 import org.commonmark.ext.gfm.alerts.Alert;
 import org.commonmark.ext.gfm.alerts.AlertTitle;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.NodeRenderer;
-
-import java.util.Set;
 
 public abstract class AlertNodeRenderer implements NodeRenderer {
 
@@ -23,8 +22,8 @@ public abstract class AlertNodeRenderer implements NodeRenderer {
     protected abstract void renderAlert(Alert alert);
 
     /**
-     * Renders the children of a parent node, excluding {@link AlertTitle} nodes.
-     * {@link AlertTitle} is rendered separately from other content.
+     * Renders the children of a parent node, excluding {@link AlertTitle} nodes. {@link AlertTitle}
+     * is rendered separately from other content.
      *
      * @param parent the parent node whose children should be rendered
      */
@@ -42,8 +41,8 @@ public abstract class AlertNodeRenderer implements NodeRenderer {
     }
 
     /**
-     * Renders a single node. Subclasses must implement this to delegate
-     * to their context's render method.
+     * Renders a single node. Subclasses must implement this to delegate to their context's render
+     * method.
      *
      * @param node the node to render
      */

--- a/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/internal/AlertTextContentNodeRenderer.java
+++ b/commonmark-ext-gfm-alerts/src/main/java/org/commonmark/ext/gfm/alerts/internal/AlertTextContentNodeRenderer.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.gfm.alerts.internal;
 
+import java.util.Map;
 import org.commonmark.ext.gfm.alerts.Alert;
 import org.commonmark.ext.gfm.alerts.AlertTitle;
 import org.commonmark.node.Node;
@@ -7,15 +8,14 @@ import org.commonmark.renderer.text.LineBreakRendering;
 import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentWriter;
 
-import java.util.Map;
-
 public class AlertTextContentNodeRenderer extends AlertNodeRenderer {
 
     private final TextContentNodeRendererContext context;
     private final TextContentWriter textContent;
     private final Map<String, String> allowedTypes;
 
-    public AlertTextContentNodeRenderer(TextContentNodeRendererContext context, Map<String, String> allowedTypes) {
+    public AlertTextContentNodeRenderer(
+            TextContentNodeRendererContext context, Map<String, String> allowedTypes) {
         this.context = context;
         this.textContent = context.getWriter();
         this.allowedTypes = allowedTypes;

--- a/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsMarkdownRendererTest.java
+++ b/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsMarkdownRendererTest.java
@@ -1,27 +1,26 @@
 package org.commonmark.ext.gfm.alerts;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class AlertsMarkdownRendererTest {
 
     private static final Set<Extension> EXTENSIONS = Set.of(AlertsExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER =
+            MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 
-    private static final Set<Extension> EXTENSIONS_CUSTOM_TITLES = Set.of(AlertsExtension.builder().allowCustomTitles(true).build());
-    private static final Parser PARSER_CUSTOM_TITLES = Parser.builder()
-                                                             .extensions(EXTENSIONS_CUSTOM_TITLES)
-                                                             .build();
-    private static final MarkdownRenderer RENDERER_CUSTOM_TITLES = MarkdownRenderer.builder()
-                                                                                   .extensions(EXTENSIONS_CUSTOM_TITLES)
-                                                                                   .build();
+    private static final Set<Extension> EXTENSIONS_CUSTOM_TITLES =
+            Set.of(AlertsExtension.builder().allowCustomTitles(true).build());
+    private static final Parser PARSER_CUSTOM_TITLES =
+            Parser.builder().extensions(EXTENSIONS_CUSTOM_TITLES).build();
+    private static final MarkdownRenderer RENDERER_CUSTOM_TITLES =
+            MarkdownRenderer.builder().extensions(EXTENSIONS_CUSTOM_TITLES).build();
 
     @Test
     public void alertRoundTrip() {
@@ -61,9 +60,7 @@ public class AlertsMarkdownRendererTest {
 
     @Test
     public void customTypeRoundTrip() {
-        var extension = AlertsExtension.builder()
-                .addCustomType("INFO", "Information")
-                .build();
+        var extension = AlertsExtension.builder().addCustomType("INFO", "Information").build();
 
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = MarkdownRenderer.builder().extensions(Set.of(extension)).build();
@@ -99,14 +96,17 @@ public class AlertsMarkdownRendererTest {
 
     @Test
     public void customTitleWithFormattingRoundTrip() {
-        assertRoundTripCustomTitles("> [!WARNING] Custom _title **with `formatting`**_\n> Be careful\n");
+        assertRoundTripCustomTitles(
+                "> [!WARNING] Custom _title **with `formatting`**_\n> Be careful\n");
     }
 
     @Test
     public void customTitleWithMultipleBlocks() {
-        var input = "> [!NOTE]Title\n> First paragraph\n>\n> Second paragraph\n>\n> - > Nested blocks\n";
+        var input =
+                "> [!NOTE]Title\n> First paragraph\n>\n> Second paragraph\n>\n> - > Nested blocks\n";
         // MarkdownWriter always writes the prefix including trailing space
-        var expected = "> [!NOTE] Title\n> First paragraph\n> \n> Second paragraph\n> \n> - > Nested blocks\n";
+        var expected =
+                "> [!NOTE] Title\n> First paragraph\n> \n> Second paragraph\n> \n> - > Nested blocks\n";
         var rendered = RENDERER_CUSTOM_TITLES.render(PARSER_CUSTOM_TITLES.parse(input));
         assertThat(rendered).isEqualTo(expected);
     }

--- a/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsSpecTest.java
+++ b/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsSpecTest.java
@@ -1,5 +1,8 @@
 package org.commonmark.ext.gfm.alerts;
 
+import java.net.URL;
+import java.util.List;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -11,16 +14,12 @@ import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.net.URL;
-import java.util.List;
-import java.util.Set;
-
 /**
- * Tests the default configuration of {@link AlertsExtension} against how
- * GitHub Flavored Markdown (GFM) parses and renders {@link Alert}s.
- * <p>
- * This test should only be used for the default configuration of
- * {@link AlertsExtension}. Other configurations cause deviation from GFM.
+ * Tests the default configuration of {@link AlertsExtension} against how GitHub Flavored Markdown
+ * (GFM) parses and renders {@link Alert}s.
+ *
+ * <p>This test should only be used for the default configuration of {@link AlertsExtension}. Other
+ * configurations cause deviation from GFM.
  */
 @ParameterizedClass
 @MethodSource("data")
@@ -28,11 +27,12 @@ public class AlertsSpecTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(AlertsExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    // Use softbreak("<br>") to match GitHub's rendering for easier comparison with GitHub API output.
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).softbreak("<br>\n").build();
+    // Use softbreak("<br>") to match GitHub's rendering for easier comparison with GitHub API
+    // output.
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).softbreak("<br>\n").build();
 
-    @Parameter
-    Example example;
+    @Parameter Example example;
 
     static List<Example> data() {
         URL spec = AlertsSpecTest.class.getResource("/alerts-spec.txt");

--- a/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsTest.java
+++ b/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsTest.java
@@ -1,5 +1,11 @@
 package org.commonmark.ext.gfm.alerts;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.Emphasis;
 import org.commonmark.node.SourceSpan;
@@ -11,27 +17,26 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 public class AlertsTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(AlertsExtension.create());
-    private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES).build();
-    private static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final Parser PARSER =
+            Parser.builder()
+                    .extensions(EXTENSIONS)
+                    .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                    .build();
+    private static final HtmlRenderer HTML_RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
-    private static final Set<Extension> EXTENSIONS_CUSTOM_TITLES = Set.of(AlertsExtension.builder().allowCustomTitles(true).build());
-    private static final Parser PARSER_CUSTOM_TITLES = Parser.builder()
-                                                             .extensions(EXTENSIONS_CUSTOM_TITLES)
-                                                             .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
-                                                             .build();
-    private static final HtmlRenderer HTML_RENDERER_CUSTOM_TITLES = HtmlRenderer.builder()
-                                                                                .extensions(EXTENSIONS_CUSTOM_TITLES)
-                                                                                .build();
+    private static final Set<Extension> EXTENSIONS_CUSTOM_TITLES =
+            Set.of(AlertsExtension.builder().allowCustomTitles(true).build());
+    private static final Parser PARSER_CUSTOM_TITLES =
+            Parser.builder()
+                    .extensions(EXTENSIONS_CUSTOM_TITLES)
+                    .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                    .build();
+    private static final HtmlRenderer HTML_RENDERER_CUSTOM_TITLES =
+            HtmlRenderer.builder().extensions(EXTENSIONS_CUSTOM_TITLES).build();
 
     @Override
     protected String render(String source) {
@@ -39,103 +44,109 @@ public class AlertsTest extends RenderingTestCase {
     }
 
     private void assertRenderingCustomTitles(String source, String expectedResult) {
-        assertThat(HTML_RENDERER_CUSTOM_TITLES.render(PARSER_CUSTOM_TITLES.parse(source))).isEqualTo(expectedResult);
+        assertThat(HTML_RENDERER_CUSTOM_TITLES.render(PARSER_CUSTOM_TITLES.parse(source)))
+                .isEqualTo(expectedResult);
     }
 
     // Custom types
 
     @Test
     public void customType() {
-        var extension = AlertsExtension.builder()
-                .addCustomType("INFO", "Information")
-                .build();
+        var extension = AlertsExtension.builder().addCustomType("INFO", "Information").build();
 
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        assertThat(renderer.render(parser.parse("> [!INFO]\n> Custom alert"))).isEqualTo(
-                "<div class=\"markdown-alert markdown-alert-info\" data-alert-type=\"info\">\n" +
-                "<p class=\"markdown-alert-title\">Information</p>\n" +
-                "<p>Custom alert</p>\n" +
-                "</div>\n");
+        assertThat(renderer.render(parser.parse("> [!INFO]\n> Custom alert")))
+                .isEqualTo(
+                        "<div class=\"markdown-alert markdown-alert-info\" data-alert-type=\"info\">\n"
+                                + "<p class=\"markdown-alert-title\">Information</p>\n"
+                                + "<p>Custom alert</p>\n"
+                                + "</div>\n");
     }
 
     @Test
     public void multipleCustomTypes() {
-        var extension = AlertsExtension.builder()
-                .addCustomType("INFO", "Information")
-                .addCustomType("SUCCESS", "Success!")
-                .addCustomType("DANGER", "Danger!")
-                .build();
+        var extension =
+                AlertsExtension.builder()
+                        .addCustomType("INFO", "Information")
+                        .addCustomType("SUCCESS", "Success!")
+                        .addCustomType("DANGER", "Danger!")
+                        .build();
 
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        assertThat(renderer.render(parser.parse("> [!INFO]\n> Info content\n\n> [!SUCCESS]\n> Success content\n\n> [!DANGER]\n> Danger content"))).isEqualTo(
-                "<div class=\"markdown-alert markdown-alert-info\" data-alert-type=\"info\">\n" +
-                "<p class=\"markdown-alert-title\">Information</p>\n" +
-                "<p>Info content</p>\n" +
-                "</div>\n" +
-                "<div class=\"markdown-alert markdown-alert-success\" data-alert-type=\"success\">\n" +
-                "<p class=\"markdown-alert-title\">Success!</p>\n" +
-                "<p>Success content</p>\n" +
-                "</div>\n" +
-                "<div class=\"markdown-alert markdown-alert-danger\" data-alert-type=\"danger\">\n" +
-                "<p class=\"markdown-alert-title\">Danger!</p>\n" +
-                "<p>Danger content</p>\n" +
-                "</div>\n");
+        assertThat(
+                        renderer.render(
+                                parser.parse(
+                                        "> [!INFO]\n> Info content\n\n> [!SUCCESS]\n> Success content\n\n> [!DANGER]\n> Danger content")))
+                .isEqualTo(
+                        "<div class=\"markdown-alert markdown-alert-info\" data-alert-type=\"info\">\n"
+                                + "<p class=\"markdown-alert-title\">Information</p>\n"
+                                + "<p>Info content</p>\n"
+                                + "</div>\n"
+                                + "<div class=\"markdown-alert markdown-alert-success\" data-alert-type=\"success\">\n"
+                                + "<p class=\"markdown-alert-title\">Success!</p>\n"
+                                + "<p>Success content</p>\n"
+                                + "</div>\n"
+                                + "<div class=\"markdown-alert markdown-alert-danger\" data-alert-type=\"danger\">\n"
+                                + "<p class=\"markdown-alert-title\">Danger!</p>\n"
+                                + "<p>Danger content</p>\n"
+                                + "</div>\n");
     }
 
     @Test
     public void standardTypesWithCustomConfigured() {
-        var extension = AlertsExtension.builder()
-                .addCustomType("INFO", "Information")
-                .build();
+        var extension = AlertsExtension.builder().addCustomType("INFO", "Information").build();
 
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        assertThat(renderer.render(parser.parse("> [!NOTE]\n> Standard type"))).isEqualTo(
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Note</p>\n" +
-                "<p>Standard type</p>\n" +
-                "</div>\n");
+        assertThat(renderer.render(parser.parse("> [!NOTE]\n> Standard type")))
+                .isEqualTo(
+                        "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                                + "<p class=\"markdown-alert-title\">Note</p>\n"
+                                + "<p>Standard type</p>\n"
+                                + "</div>\n");
     }
 
     @Test
     public void overrideStandardTypeTitle() {
-        var extension = AlertsExtension.builder()
-                .addCustomType("NOTE", "Nota")
-                .build();
+        var extension = AlertsExtension.builder().addCustomType("NOTE", "Nota").build();
 
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        assertThat(renderer.render(parser.parse("> [!NOTE]\n> Localized title"))).isEqualTo(
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Nota</p>\n" +
-                "<p>Localized title</p>\n" +
-                "</div>\n");
+        assertThat(renderer.render(parser.parse("> [!NOTE]\n> Localized title")))
+                .isEqualTo(
+                        "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                                + "<p class=\"markdown-alert-title\">Nota</p>\n"
+                                + "<p>Localized title</p>\n"
+                                + "</div>\n");
     }
 
     // Custom type validation
 
     @Test
     public void customTypeMustBeUppercase() {
-        assertThrows(IllegalArgumentException.class, () ->
-                AlertsExtension.builder().addCustomType("info", "Information").build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> AlertsExtension.builder().addCustomType("info", "Information").build());
     }
 
     @Test
     public void customTypeMustNotBeEmpty() {
-        assertThrows(IllegalArgumentException.class, () ->
-                AlertsExtension.builder().addCustomType("", "Title").build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> AlertsExtension.builder().addCustomType("", "Title").build());
     }
 
     @Test
     public void customTypeTitleMustNotBeEmpty() {
-        assertThrows(IllegalArgumentException.class, () ->
-                AlertsExtension.builder().addCustomType("INFO", "").build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> AlertsExtension.builder().addCustomType("INFO", "").build());
     }
 
     // Overwriting types
@@ -143,36 +154,41 @@ public class AlertsTest extends RenderingTestCase {
     @Test
     public void overwriteStandardTypes() {
         var allowedTypes = Map.ofEntries(Map.entry("IMPORTANT", "Important"));
-        var extension = AlertsExtension.builder()
-                .setAllowedTypes(allowedTypes)
-                .addCustomType("BUG", "Known Bug")
-                .build();
+        var extension =
+                AlertsExtension.builder()
+                        .setAllowedTypes(allowedTypes)
+                        .addCustomType("BUG", "Known Bug")
+                        .build();
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        assertThat(renderer.render(parser.parse("> [!NOTE]\n> Regular block quote"))).isEqualTo(
-                "<blockquote>\n" +
-                "<p>[!NOTE]\n" +
-                "Regular block quote</p>\n" +
-                "</blockquote>\n");
+        assertThat(renderer.render(parser.parse("> [!NOTE]\n> Regular block quote")))
+                .isEqualTo(
+                        "<blockquote>\n"
+                                + "<p>[!NOTE]\n"
+                                + "Regular block quote</p>\n"
+                                + "</blockquote>\n");
 
-        assertThat(renderer.render(parser.parse("> [!TIP]\n> Regular block quote"))).isEqualTo(
-                "<blockquote>\n" +
-                "<p>[!TIP]\n" +
-                "Regular block quote</p>\n" +
-                "</blockquote>\n");
+        assertThat(renderer.render(parser.parse("> [!TIP]\n> Regular block quote")))
+                .isEqualTo(
+                        "<blockquote>\n"
+                                + "<p>[!TIP]\n"
+                                + "Regular block quote</p>\n"
+                                + "</blockquote>\n");
 
-        assertThat(renderer.render(parser.parse("> [!IMPORTANT]\n> Alert"))).isEqualTo(
-                "<div class=\"markdown-alert markdown-alert-important\" data-alert-type=\"important\">\n" +
-                "<p class=\"markdown-alert-title\">Important</p>\n" +
-                "<p>Alert</p>\n" +
-                "</div>\n");
+        assertThat(renderer.render(parser.parse("> [!IMPORTANT]\n> Alert")))
+                .isEqualTo(
+                        "<div class=\"markdown-alert markdown-alert-important\" data-alert-type=\"important\">\n"
+                                + "<p class=\"markdown-alert-title\">Important</p>\n"
+                                + "<p>Alert</p>\n"
+                                + "</div>\n");
 
-        assertThat(renderer.render(parser.parse("> [!BUG]\n> Alert"))).isEqualTo(
-                "<div class=\"markdown-alert markdown-alert-bug\" data-alert-type=\"bug\">\n" +
-                "<p class=\"markdown-alert-title\">Known Bug</p>\n" +
-                "<p>Alert</p>\n" +
-                "</div>\n");
+        assertThat(renderer.render(parser.parse("> [!BUG]\n> Alert")))
+                .isEqualTo(
+                        "<div class=\"markdown-alert markdown-alert-bug\" data-alert-type=\"bug\">\n"
+                                + "<p class=\"markdown-alert-title\">Known Bug</p>\n"
+                                + "<p>Alert</p>\n"
+                                + "</div>\n");
     }
 
     // Overwriting types validation
@@ -180,226 +196,249 @@ public class AlertsTest extends RenderingTestCase {
     @Test
     public void overwriteTypesMustBeUppercase() {
         var allowedTypes = Map.ofEntries(Map.entry("info", "Info"));
-        assertThrows(IllegalArgumentException.class, () ->
-                AlertsExtension.builder().setAllowedTypes(allowedTypes).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> AlertsExtension.builder().setAllowedTypes(allowedTypes).build());
     }
 
     @Test
     public void overwriteTypesMustNotBeEmpty() {
         var allowedTypes = Map.ofEntries(Map.entry("", "Info"));
-        assertThrows(IllegalArgumentException.class, () ->
-                AlertsExtension.builder().setAllowedTypes(allowedTypes).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> AlertsExtension.builder().setAllowedTypes(allowedTypes).build());
     }
 
     @Test
     public void overwriteTypesTitleMustNotBeEmpty() {
         var allowedTypes = Map.ofEntries(Map.entry("INFO", ""));
-        assertThrows(IllegalArgumentException.class, () ->
-                AlertsExtension.builder().setAllowedTypes(allowedTypes).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> AlertsExtension.builder().setAllowedTypes(allowedTypes).build());
     }
 
     // Custom titles
 
     @Test
     public void customTitle() {
-        assertRenderingCustomTitles("> [!NOTE] Custom title\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom title</p>\n" +
-                "<p>Note with a custom title</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE] Custom title\n> Note with a custom title",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom title</p>\n"
+                        + "<p>Note with a custom title</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleNoSpace() {
-        assertRenderingCustomTitles("> [!NOTE]Custom title\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom title</p>\n" +
-                "<p>Note with a custom title</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE]Custom title\n> Note with a custom title",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom title</p>\n"
+                        + "<p>Note with a custom title</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleExtraSpace() {
-        assertRenderingCustomTitles("> [!NOTE]            Custom title  \n>    Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom title</p>\n" +
-                "<p>Note with a custom title</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE]            Custom title  \n>    Note with a custom title",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom title</p>\n"
+                        + "<p>Note with a custom title</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleNoHardLineBreak() {
-        assertRenderingCustomTitles("> [!NOTE] Custom title\\\n>    Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom title\\</p>\n" +
-                "<p>Note with a custom title</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE] Custom title\\\n>    Note with a custom title",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom title\\</p>\n"
+                        + "<p>Note with a custom title</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleWithComment() {
-        assertRenderingCustomTitles("> [!NOTE] Custom title <!-- Comment -->  \n>    Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom title <!-- Comment --></p>\n" +
-                "<p>Note with a custom title</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE] Custom title <!-- Comment -->  \n>    Note with a custom title",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom title <!-- Comment --></p>\n"
+                        + "<p>Note with a custom title</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleWithInlineFormatting() {
-        assertRenderingCustomTitles("> [!NOTE] Custom _title <ins>with **formatting**</ins>_\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom <em>title <ins>with <strong>formatting</strong></ins></em></p>\n" +
-                "<p>Note with a custom title</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE] Custom _title <ins>with **formatting**</ins>_\n> Note with a custom title",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom <em>title <ins>with <strong>formatting</strong></ins></em></p>\n"
+                        + "<p>Note with a custom title</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleWithLinkAndCode() {
-        assertRenderingCustomTitles("> [!IMPORTANT] See [docs](https://example.com) or `run()`\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-important\" data-alert-type=\"important\">\n" +
-                "<p class=\"markdown-alert-title\">See <a href=\"https://example.com\">docs</a> or <code>run()</code></p>\n" +
-                "<p>Note with a custom title</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!IMPORTANT] See [docs](https://example.com) or `run()`\n> Note with a custom title",
+                "<div class=\"markdown-alert markdown-alert-important\" data-alert-type=\"important\">\n"
+                        + "<p class=\"markdown-alert-title\">See <a href=\"https://example.com\">docs</a> or <code>run()</code></p>\n"
+                        + "<p>Note with a custom title</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleLeadingEmptyLines() {
-        assertRenderingCustomTitles(">\n>  \n> [!NOTE] Custom **title**\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom <strong>title</strong></p>\n" +
-                "<p>Note with a custom title</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                ">\n>  \n> [!NOTE] Custom **title**\n> Note with a custom title",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom <strong>title</strong></p>\n"
+                        + "<p>Note with a custom title</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleNoOverlappingInlines() {
-        assertRenderingCustomTitles("> [!NOTE] Custom _title with **opening `delimiters\n> Note` with** closing delimiters_",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom _title with **opening `delimiters</p>\n" +
-                "<p>Note` with** closing delimiters_</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE] Custom _title with **opening `delimiters\n> Note` with** closing delimiters_",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom _title with **opening `delimiters</p>\n"
+                        + "<p>Note` with** closing delimiters_</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleIgnoresBlockContent() {
-        assertRenderingCustomTitles("> [!NOTE] ## Custom title looks like an ATX heading\n>But it's not",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">## Custom title looks like an ATX heading</p>\n" +
-                "<p>But it's not</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE] ## Custom title looks like an ATX heading\n>But it's not",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">## Custom title looks like an ATX heading</p>\n"
+                        + "<p>But it's not</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleNoBody() {
         // Alerts with no body are allowed.
-        assertRenderingCustomTitles("> [!NOTE] Custom _title_\n>  \n>\n>",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom <em>title</em></p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE] Custom _title_\n>  \n>\n>",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom <em>title</em></p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void customTitleNoBodyNoSpace() {
-        assertRenderingCustomTitles("> [!NOTE] Custom _title_",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom <em>title</em></p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE] Custom _title_",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom <em>title</em></p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void onlyTrailingWhitespaceIsNotCustomTitle() {
-        assertRenderingCustomTitles("> [!NOTE]   \n> Body text",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Note</p>\n" +
-                "<p>Body text</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE]   \n> Body text",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Note</p>\n"
+                        + "<p>Body text</p>\n"
+                        + "</div>\n");
     }
 
     // Lazy continuation
 
     @Test
     public void noLazyContinuationAfterMarker() {
-        assertRendering("> [!NOTE]\nBody text",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Note</p>\n" +
-                "</div>\n" +
-                "<p>Body text</p>\n");
+        assertRendering(
+                "> [!NOTE]\nBody text",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Note</p>\n"
+                        + "</div>\n"
+                        + "<p>Body text</p>\n");
     }
 
     @Test
     public void noLazyContinuationAfterTitle() {
-        assertRenderingCustomTitles("> [!NOTE] Custom title\nBody text",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Custom title</p>\n" +
-                "</div>\n" +
-                "<p>Body text</p>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE] Custom title\nBody text",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Custom title</p>\n"
+                        + "</div>\n"
+                        + "<p>Body text</p>\n");
     }
 
     // Alert markers take precedence over link reference definitions
 
     @Test
     public void alertTakesPrecedence() {
-        assertRenderingCustomTitles("> [!NOTE]: https://example.com\n> Body text\n\n[!NOTE]",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">: https://example.com</p>\n" +
-                "<p>Body text</p>\n" +
-                "</div>\n" +
-                "<p>[!NOTE]</p>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE]: https://example.com\n> Body text\n\n[!NOTE]",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">: https://example.com</p>\n"
+                        + "<p>Body text</p>\n"
+                        + "</div>\n"
+                        + "<p>[!NOTE]</p>\n");
     }
 
     @Test
     public void alertTakesPrecedenceBefore() {
-        assertRenderingCustomTitles("> [!NOTE]\n> Body text\n\n[!NOTE]: https://example.com",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Note</p>\n" +
-                "<p>Body text</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "> [!NOTE]\n> Body text\n\n[!NOTE]: https://example.com",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Note</p>\n"
+                        + "<p>Body text</p>\n"
+                        + "</div>\n");
     }
 
     @Test
     public void alertTakesPrecedenceAfter() {
-        assertRenderingCustomTitles("[!NOTE]: https://example.com\n\n> [!NOTE]\n> Body text",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n" +
-                "<p class=\"markdown-alert-title\">Note</p>\n" +
-                "<p>Body text</p>\n" +
-                "</div>\n");
+        assertRenderingCustomTitles(
+                "[!NOTE]: https://example.com\n\n> [!NOTE]\n> Body text",
+                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
+                        + "<p class=\"markdown-alert-title\">Note</p>\n"
+                        + "<p>Body text</p>\n"
+                        + "</div>\n");
     }
 
     // Nested alerts
 
     @Test
     public void noNestedAlertsByDefault() {
-        assertRendering("> [!TIP]\n> Body\n\n- > [!TIP]\n   > Nested body",
-                "<div class=\"markdown-alert markdown-alert-tip\" data-alert-type=\"tip\">\n" +
-                "<p class=\"markdown-alert-title\">Tip</p>\n" +
-                "<p>Body</p>\n" +
-                "</div>\n" +
-                "<ul>\n" +
-                "<li>\n" +
-                "<blockquote>\n" +
-                "<p>[!TIP]\n" +
-                "Nested body</p>\n" +
-                "</blockquote>\n" +
-                "</li>\n" +
-                "</ul>\n");
+        assertRendering(
+                "> [!TIP]\n> Body\n\n- > [!TIP]\n   > Nested body",
+                "<div class=\"markdown-alert markdown-alert-tip\" data-alert-type=\"tip\">\n"
+                        + "<p class=\"markdown-alert-title\">Tip</p>\n"
+                        + "<p>Body</p>\n"
+                        + "</div>\n"
+                        + "<ul>\n"
+                        + "<li>\n"
+                        + "<blockquote>\n"
+                        + "<p>[!TIP]\n"
+                        + "Nested body</p>\n"
+                        + "</blockquote>\n"
+                        + "</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void noNestedAlertsByDefaultLeadingEmptyLines() {
-        assertRendering(">\n>   \n> [!TIP]\n> Body\n\n- > [!TIP]\n   > Nested body",
-                "<div class=\"markdown-alert markdown-alert-tip\" data-alert-type=\"tip\">\n" +
-                "<p class=\"markdown-alert-title\">Tip</p>\n" +
-                "<p>Body</p>\n" +
-                "</div>\n" +
-                "<ul>\n" +
-                "<li>\n" +
-                "<blockquote>\n" +
-                "<p>[!TIP]\n" +
-                "Nested body</p>\n" +
-                "</blockquote>\n" +
-                "</li>\n" +
-                "</ul>\n");
+        assertRendering(
+                ">\n>   \n> [!TIP]\n> Body\n\n- > [!TIP]\n   > Nested body",
+                "<div class=\"markdown-alert markdown-alert-tip\" data-alert-type=\"tip\">\n"
+                        + "<p class=\"markdown-alert-title\">Tip</p>\n"
+                        + "<p>Body</p>\n"
+                        + "</div>\n"
+                        + "<ul>\n"
+                        + "<li>\n"
+                        + "<blockquote>\n"
+                        + "<p>[!TIP]\n"
+                        + "Nested body</p>\n"
+                        + "</blockquote>\n"
+                        + "</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
@@ -408,46 +447,50 @@ public class AlertsTest extends RenderingTestCase {
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        var source = String.join("\n",
-                "> [!TIP]",
-                "> Tip body",
-                "> > [!IMPORTANT]",
-                "> > Important body",
-                "",
-                "- > [!NOTE]",
-                "  > Nested body",
-                "  >",
-                "  > 1. Ordered list body",
-                "  >",
-                "  >    > [!CAUTION]",
-                "  >    >",
-                "  >    > Deeply nested body");
-        var expected = String.join("\n",
-                "<div class=\"markdown-alert markdown-alert-tip\" data-alert-type=\"tip\">",
-                "<p class=\"markdown-alert-title\">Tip</p>",
-                "<p>Tip body</p>",
-                "<div class=\"markdown-alert markdown-alert-important\" data-alert-type=\"important\">",
-                "<p class=\"markdown-alert-title\">Important</p>",
-                "<p>Important body</p>",
-                "</div>",
-                "</div>",
-                "<ul>",
-                "<li>",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">",
-                "<p class=\"markdown-alert-title\">Note</p>",
-                "<p>Nested body</p>",
-                "<ol>",
-                "<li>",
-                "<p>Ordered list body</p>",
-                "<div class=\"markdown-alert markdown-alert-caution\" data-alert-type=\"caution\">",
-                "<p class=\"markdown-alert-title\">Caution</p>",
-                "<p>Deeply nested body</p>",
-                "</div>",
-                "</li>",
-                "</ol>",
-                "</div>",
-                "</li>",
-                "</ul>\n");
+        var source =
+                String.join(
+                        "\n",
+                        "> [!TIP]",
+                        "> Tip body",
+                        "> > [!IMPORTANT]",
+                        "> > Important body",
+                        "",
+                        "- > [!NOTE]",
+                        "  > Nested body",
+                        "  >",
+                        "  > 1. Ordered list body",
+                        "  >",
+                        "  >    > [!CAUTION]",
+                        "  >    >",
+                        "  >    > Deeply nested body");
+        var expected =
+                String.join(
+                        "\n",
+                        "<div class=\"markdown-alert markdown-alert-tip\" data-alert-type=\"tip\">",
+                        "<p class=\"markdown-alert-title\">Tip</p>",
+                        "<p>Tip body</p>",
+                        "<div class=\"markdown-alert markdown-alert-important\" data-alert-type=\"important\">",
+                        "<p class=\"markdown-alert-title\">Important</p>",
+                        "<p>Important body</p>",
+                        "</div>",
+                        "</div>",
+                        "<ul>",
+                        "<li>",
+                        "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">",
+                        "<p class=\"markdown-alert-title\">Note</p>",
+                        "<p>Nested body</p>",
+                        "<ol>",
+                        "<li>",
+                        "<p>Ordered list body</p>",
+                        "<div class=\"markdown-alert markdown-alert-caution\" data-alert-type=\"caution\">",
+                        "<p class=\"markdown-alert-title\">Caution</p>",
+                        "<p>Deeply nested body</p>",
+                        "</div>",
+                        "</li>",
+                        "</ol>",
+                        "</div>",
+                        "</li>",
+                        "</ul>\n");
 
         assertThat(renderer.render(parser.parse(source))).isEqualTo(expected);
     }
@@ -465,9 +508,7 @@ public class AlertsTest extends RenderingTestCase {
 
     @Test
     public void customTypeParsedAsAlertNode() {
-        var extension = AlertsExtension.builder()
-                .addCustomType("INFO", "Information")
-                .build();
+        var extension = AlertsExtension.builder().addCustomType("INFO", "Information").build();
 
         var parser = Parser.builder().extensions(Set.of(extension)).build();
 
@@ -578,5 +619,4 @@ public class AlertsTest extends RenderingTestCase {
         assertThat(((Text) italicText).getLiteral()).isEqualTo("and italic");
         assertThat(italicText.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 28, 28, 10)));
     }
-
 }

--- a/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsTextContentRendererTest.java
+++ b/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsTextContentRendererTest.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.gfm.alerts;
 
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.text.LineBreakRendering;
@@ -7,33 +8,45 @@ import org.commonmark.renderer.text.TextContentRenderer;
 import org.commonmark.testutil.Asserts;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
 public class AlertsTextContentRendererTest {
 
     private static final Set<Extension> EXTENSIONS = Set.of(AlertsExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
 
-    private static final TextContentRenderer COMPACT_RENDERER = TextContentRenderer.builder()
-            .extensions(EXTENSIONS).build();
-    private static final TextContentRenderer SEPARATE_RENDERER = TextContentRenderer.builder()
-            .extensions(EXTENSIONS).lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS).build();
-    private static final TextContentRenderer STRIPPED_RENDERER = TextContentRenderer.builder()
-            .extensions(EXTENSIONS).lineBreakRendering(LineBreakRendering.STRIP).build();
+    private static final TextContentRenderer COMPACT_RENDERER =
+            TextContentRenderer.builder().extensions(EXTENSIONS).build();
+    private static final TextContentRenderer SEPARATE_RENDERER =
+            TextContentRenderer.builder()
+                    .extensions(EXTENSIONS)
+                    .lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS)
+                    .build();
+    private static final TextContentRenderer STRIPPED_RENDERER =
+            TextContentRenderer.builder()
+                    .extensions(EXTENSIONS)
+                    .lineBreakRendering(LineBreakRendering.STRIP)
+                    .build();
 
-    private static final Set<Extension> EXTENSIONS_CUSTOM_TITLES = Set.of(
-            AlertsExtension.builder().allowCustomTitles(true).allowNestedAlerts(true).build());
-    private static final Parser PARSER_CUSTOM_TITLES = Parser.builder()
-            .extensions(EXTENSIONS_CUSTOM_TITLES).build();
+    private static final Set<Extension> EXTENSIONS_CUSTOM_TITLES =
+            Set.of(
+                    AlertsExtension.builder()
+                            .allowCustomTitles(true)
+                            .allowNestedAlerts(true)
+                            .build());
+    private static final Parser PARSER_CUSTOM_TITLES =
+            Parser.builder().extensions(EXTENSIONS_CUSTOM_TITLES).build();
 
-    private static final TextContentRenderer COMPACT_RENDERER_CUSTOM = TextContentRenderer.builder()
-            .extensions(EXTENSIONS_CUSTOM_TITLES).build();
-    private static final TextContentRenderer SEPARATE_RENDERER_CUSTOM = TextContentRenderer.builder()
-            .extensions(EXTENSIONS_CUSTOM_TITLES)
-            .lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS).build();
-    private static final TextContentRenderer STRIPPED_RENDERER_CUSTOM = TextContentRenderer.builder()
-            .extensions(EXTENSIONS_CUSTOM_TITLES)
-            .lineBreakRendering(LineBreakRendering.STRIP).build();
+    private static final TextContentRenderer COMPACT_RENDERER_CUSTOM =
+            TextContentRenderer.builder().extensions(EXTENSIONS_CUSTOM_TITLES).build();
+    private static final TextContentRenderer SEPARATE_RENDERER_CUSTOM =
+            TextContentRenderer.builder()
+                    .extensions(EXTENSIONS_CUSTOM_TITLES)
+                    .lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS)
+                    .build();
+    private static final TextContentRenderer STRIPPED_RENDERER_CUSTOM =
+            TextContentRenderer.builder()
+                    .extensions(EXTENSIONS_CUSTOM_TITLES)
+                    .lineBreakRendering(LineBreakRendering.STRIP)
+                    .build();
 
     @Test
     public void alertNoBody() {
@@ -123,7 +136,8 @@ public class AlertsTextContentRendererTest {
     public void alertWithinAlert() {
         var source = "> [!NOTE] Custom title\n> Body text\n> > [!WARNING]\n> > Nested body text";
         assertCompactCustomTitles(source, "Custom title\nBody text\nWarning\nNested body text");
-        assertSeparateCustomTitles(source, "Custom title\n\nBody text\n\nWarning\n\nNested body text");
+        assertSeparateCustomTitles(
+                source, "Custom title\n\nBody text\n\nWarning\n\nNested body text");
         assertStrippedCustomTitles(source, "Custom title: Body text Warning: Nested body text");
     }
 

--- a/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/examples/AlertsExample.java
+++ b/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/examples/AlertsExample.java
@@ -1,14 +1,11 @@
 package org.commonmark.ext.gfm.alerts.examples;
 
+import java.util.List;
 import org.commonmark.ext.gfm.alerts.AlertsExtension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 
-import java.util.List;
-
-/**
- * Example demonstrating the use of the GFM Alerts extension.
- */
+/** Example demonstrating the use of the GFM Alerts extension. */
 public class AlertsExample {
 
     public static void main(String[] args) {
@@ -23,25 +20,22 @@ public class AlertsExample {
 
         var extension = AlertsExtension.create();
 
-        var parser = Parser.builder()
-                .extensions(List.of(extension))
-                .build();
+        var parser = Parser.builder().extensions(List.of(extension)).build();
 
-        var renderer = HtmlRenderer.builder()
-                .extensions(List.of(extension))
-                .build();
+        var renderer = HtmlRenderer.builder().extensions(List.of(extension)).build();
 
-        var markdown = "# GFM Alerts Demo\n\n" +
-                "> [!NOTE]\n" +
-                "> Highlights information that users should take into account.\n\n" +
-                "> [!TIP]\n" +
-                "> Helpful advice for doing things better.\n\n" +
-                "> [!IMPORTANT]\n" +
-                "> Key information users need to know.\n\n" +
-                "> [!WARNING]\n" +
-                "> Urgent info that needs immediate attention.\n\n" +
-                "> [!CAUTION]\n" +
-                "> Advises about risks or negative outcomes.\n";
+        var markdown =
+                "# GFM Alerts Demo\n\n"
+                        + "> [!NOTE]\n"
+                        + "> Highlights information that users should take into account.\n\n"
+                        + "> [!TIP]\n"
+                        + "> Helpful advice for doing things better.\n\n"
+                        + "> [!IMPORTANT]\n"
+                        + "> Key information users need to know.\n\n"
+                        + "> [!WARNING]\n"
+                        + "> Urgent info that needs immediate attention.\n\n"
+                        + "> [!CAUTION]\n"
+                        + "> Advises about risks or negative outcomes.\n";
 
         var html = renderer.render(parser.parse(markdown));
 
@@ -55,25 +49,20 @@ public class AlertsExample {
         System.out.println("CUSTOM ALERT TYPES");
         System.out.println("=".repeat(60));
 
-        var extension = AlertsExtension.builder()
-                .addCustomType("BUG", "Known Bug")
-                .build();
+        var extension = AlertsExtension.builder().addCustomType("BUG", "Known Bug").build();
 
-        var parser = Parser.builder()
-                .extensions(List.of(extension))
-                .build();
+        var parser = Parser.builder().extensions(List.of(extension)).build();
 
-        var renderer = HtmlRenderer.builder()
-                .extensions(List.of(extension))
-                .build();
+        var renderer = HtmlRenderer.builder().extensions(List.of(extension)).build();
 
-        var markdown = "# Custom Alert Types\n\n" +
-                "> [!NOTE]\n" +
-                "> Useful information that users should know.\n\n" +
-                "> [!TIP]\n" +
-                "> Helpful advice for doing things better.\n\n" +
-                "> [!BUG]\n" +
-                "> This feature has a known issue with large files (see #42).\n";
+        var markdown =
+                "# Custom Alert Types\n\n"
+                        + "> [!NOTE]\n"
+                        + "> Useful information that users should know.\n\n"
+                        + "> [!TIP]\n"
+                        + "> Helpful advice for doing things better.\n\n"
+                        + "> [!BUG]\n"
+                        + "> This feature has a known issue with large files (see #42).\n";
 
         var html = renderer.render(parser.parse(markdown));
 

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/Strikethrough.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/Strikethrough.java
@@ -3,9 +3,7 @@ package org.commonmark.ext.gfm.strikethrough;
 import org.commonmark.node.CustomNode;
 import org.commonmark.node.Delimited;
 
-/**
- * A strikethrough node containing text and other inline nodes as children.
- */
+/** A strikethrough node containing text and other inline nodes as children. */
 public class Strikethrough extends CustomNode implements Delimited {
 
     private String delimiter;

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/StrikethroughExtension.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.gfm.strikethrough;
 
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.strikethrough.internal.StrikethroughDelimiterProcessor;
 import org.commonmark.ext.gfm.strikethrough.internal.StrikethroughHtmlNodeRenderer;
@@ -13,38 +14,40 @@ import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.commonmark.renderer.text.TextContentRenderer;
 
-import java.util.Set;
-
 /**
  * Extension for GFM strikethrough using {@code ~} or {@code ~~} (GitHub Flavored Markdown).
- * <p>Example input:</p>
+ *
+ * <p>Example input:
+ *
  * <pre>{@code ~foo~ or ~~bar~~}</pre>
- * <p>Example output (HTML):</p>
+ *
+ * <p>Example output (HTML):
+ *
  * <pre>{@code <del>foo</del> or <del>bar</del>}</pre>
- * <p>
- * Create the extension with {@link #create()} and then add it to the parser and renderer builders
- * ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)},
- * {@link HtmlRenderer.Builder#extensions(Iterable)}).
- * </p>
- * <p>
- * The parsed strikethrough text regions are turned into {@link Strikethrough} nodes.
- * </p>
- * <p>
- * If you have another extension that only uses a single tilde ({@code ~}) syntax, you will have to configure this
- * {@link StrikethroughExtension} to only accept the double tilde syntax, like this:
- * </p>
- * <pre>
- *     {@code
- *     StrikethroughExtension.builder().requireTwoTildes(true).build();
- *     }
- * </pre>
- * <p>
- * If you don't do that, there's a conflict between the two extensions and you will get an
- * {@link IllegalArgumentException} when constructing the parser.
- * </p>
+ *
+ * <p>Create the extension with {@link #create()} and then add it to the parser and renderer
+ * builders ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)}, {@link
+ * HtmlRenderer.Builder#extensions(Iterable)}).
+ *
+ * <p>The parsed strikethrough text regions are turned into {@link Strikethrough} nodes.
+ *
+ * <p>If you have another extension that only uses a single tilde ({@code ~}) syntax, you will have
+ * to configure this {@link StrikethroughExtension} to only accept the double tilde syntax, like
+ * this:
+ *
+ * <pre>{@code
+ * StrikethroughExtension.builder().requireTwoTildes(true).build();
+ *
+ * }</pre>
+ *
+ * <p>If you don't do that, there's a conflict between the two extensions and you will get an {@link
+ * IllegalArgumentException} when constructing the parser.
  */
-public class StrikethroughExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension,
-        TextContentRenderer.TextContentRendererExtension, MarkdownRenderer.MarkdownRendererExtension {
+public class StrikethroughExtension
+        implements Parser.ParserExtension,
+                HtmlRenderer.HtmlRendererExtension,
+                TextContentRenderer.TextContentRendererExtension,
+                MarkdownRenderer.MarkdownRendererExtension {
 
     private final boolean requireTwoTildes;
 
@@ -68,7 +71,8 @@ public class StrikethroughExtension implements Parser.ParserExtension, HtmlRende
 
     @Override
     public void extend(Parser.Builder parserBuilder) {
-        parserBuilder.customDelimiterProcessor(new StrikethroughDelimiterProcessor(requireTwoTildes));
+        parserBuilder.customDelimiterProcessor(
+                new StrikethroughDelimiterProcessor(requireTwoTildes));
     }
 
     @Override
@@ -83,17 +87,18 @@ public class StrikethroughExtension implements Parser.ParserExtension, HtmlRende
 
     @Override
     public void extend(MarkdownRenderer.Builder rendererBuilder) {
-        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(MarkdownNodeRendererContext context) {
-                return new StrikethroughMarkdownNodeRenderer(context);
-            }
+        rendererBuilder.nodeRendererFactory(
+                new MarkdownNodeRendererFactory() {
+                    @Override
+                    public NodeRenderer create(MarkdownNodeRendererContext context) {
+                        return new StrikethroughMarkdownNodeRenderer(context);
+                    }
 
-            @Override
-            public Set<Character> getSpecialCharacters() {
-                return Set.of('~');
-            }
-        });
+                    @Override
+                    public Set<Character> getSpecialCharacters() {
+                        return Set.of('~');
+                    }
+                });
     }
 
     public static class Builder {
@@ -101,8 +106,9 @@ public class StrikethroughExtension implements Parser.ParserExtension, HtmlRende
         private boolean requireTwoTildes = false;
 
         /**
-         * @param requireTwoTildes Whether two tilde characters ({@code ~~}) are required for strikethrough or whether
-         *                         one is also enough. Default is {@code false}; both a single tilde and two tildes can be used for strikethrough.
+         * @param requireTwoTildes Whether two tilde characters ({@code ~~}) are required for
+         *     strikethrough or whether one is also enough. Default is {@code false}; both a single
+         *     tilde and two tildes can be used for strikethrough.
          * @return {@code this}
          */
         public Builder requireTwoTildes(boolean requireTwoTildes) {

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
@@ -43,7 +43,10 @@ public class StrikethroughDelimiterProcessor implements DelimiterProcessor {
             Text opener = openingRun.getOpener();
 
             // Wrap nodes between delimiters in strikethrough.
-            String delimiter = openingRun.length() == 1 ? opener.getLiteral() : opener.getLiteral() + opener.getLiteral();
+            String delimiter =
+                    openingRun.length() == 1
+                            ? opener.getLiteral()
+                            : opener.getLiteral() + opener.getLiteral();
             Node strikethrough = new Strikethrough(delimiter);
 
             SourceSpans sourceSpans = new SourceSpans();

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughHtmlNodeRenderer.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughHtmlNodeRenderer.java
@@ -1,10 +1,9 @@
 package org.commonmark.ext.gfm.strikethrough.internal;
 
+import java.util.Map;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlWriter;
-
-import java.util.Map;
 
 public class StrikethroughHtmlNodeRenderer extends StrikethroughNodeRenderer {
 

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughNodeRenderer.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughNodeRenderer.java
@@ -1,10 +1,9 @@
 package org.commonmark.ext.gfm.strikethrough.internal;
 
+import java.util.Set;
 import org.commonmark.ext.gfm.strikethrough.Strikethrough;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.NodeRenderer;
-
-import java.util.Set;
 
 abstract class StrikethroughNodeRenderer implements NodeRenderer {
 

--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughTextContentNodeRenderer.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughTextContentNodeRenderer.java
@@ -1,8 +1,8 @@
 package org.commonmark.ext.gfm.strikethrough.internal;
 
-import org.commonmark.renderer.text.TextContentWriter;
-import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.node.Node;
+import org.commonmark.renderer.text.TextContentNodeRendererContext;
+import org.commonmark.renderer.text.TextContentWriter;
 
 public class StrikethroughTextContentNodeRenderer extends StrikethroughNodeRenderer {
 

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughMarkdownRendererTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughMarkdownRendererTest.java
@@ -1,19 +1,19 @@
 package org.commonmark.ext.gfm.strikethrough;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class StrikethroughMarkdownRendererTest {
 
     private static final Set<Extension> EXTENSIONS = Set.of(StrikethroughExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER =
+            MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void testStrikethrough() {

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughSpecTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughSpecTest.java
@@ -1,5 +1,7 @@
 package org.commonmark.ext.gfm.strikethrough;
 
+import java.util.List;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -12,19 +14,16 @@ import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
-import java.util.Set;
-
 @ParameterizedClass
 @MethodSource("data")
 public class StrikethroughSpecTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(StrikethroughExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
-    @Parameter
-    Example example;
+    @Parameter Example example;
 
     static List<Example> data() {
         return ExampleReader.readExamples(TestResources.getGfmSpec(), "strikethrough");

--- a/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughTest.java
+++ b/commonmark-ext-gfm-strikethrough/src/test/java/org/commonmark/ext/gfm/strikethrough/StrikethroughTest.java
@@ -1,5 +1,9 @@
 package org.commonmark.ext.gfm.strikethrough;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.Node;
 import org.commonmark.node.Paragraph;
@@ -14,18 +18,14 @@ import org.commonmark.renderer.text.TextContentRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class StrikethroughTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(StrikethroughExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
-    private static final TextContentRenderer CONTENT_RENDERER = TextContentRenderer.builder()
-            .extensions(EXTENSIONS).build();
+    private static final HtmlRenderer HTML_RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final TextContentRenderer CONTENT_RENDERER =
+            TextContentRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void oneTildeIsEnough() {
@@ -70,13 +70,15 @@ public class StrikethroughTest extends RenderingTestCase {
 
     @Test
     public void strikethroughWholeParagraphWithOtherDelimiters() {
-        assertRendering("~~Paragraph with *emphasis* and __strong emphasis__~~",
+        assertRendering(
+                "~~Paragraph with *emphasis* and __strong emphasis__~~",
                 "<p><del>Paragraph with <em>emphasis</em> and <strong>strong emphasis</strong></del></p>\n");
     }
 
     @Test
     public void insideBlockQuote() {
-        assertRendering("> strike ~~that~~",
+        assertRendering(
+                "> strike ~~that~~",
                 "<blockquote>\n<p>strike <del>that</del></p>\n</blockquote>\n");
     }
 
@@ -96,12 +98,15 @@ public class StrikethroughTest extends RenderingTestCase {
 
     @Test
     public void requireTwoTildesOption() {
-        Parser parser = Parser.builder()
-                .extensions(Set.of(StrikethroughExtension.builder()
-                        .requireTwoTildes(true)
-                        .build()))
-                .customDelimiterProcessor(new SubscriptDelimiterProcessor())
-                .build();
+        Parser parser =
+                Parser.builder()
+                        .extensions(
+                                Set.of(
+                                        StrikethroughExtension.builder()
+                                                .requireTwoTildes(true)
+                                                .build()))
+                        .customDelimiterProcessor(new SubscriptDelimiterProcessor())
+                        .build();
 
         Node document = parser.parse("~foo~ ~~bar~~");
         assertThat(CONTENT_RENDERER.render(document)).isEqualTo("(sub)foo(/sub) /bar/");
@@ -109,10 +114,11 @@ public class StrikethroughTest extends RenderingTestCase {
 
     @Test
     public void sourceSpans() {
-        Parser parser = Parser.builder()
-                .extensions(EXTENSIONS)
-                .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
-                .build();
+        Parser parser =
+                Parser.builder()
+                        .extensions(EXTENSIONS)
+                        .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                        .build();
 
         Node document = parser.parse("hey ~~there~~\n");
         Paragraph block = (Paragraph) document.getFirstChild();

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableBlock.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableBlock.java
@@ -2,8 +2,5 @@ package org.commonmark.ext.gfm.tables;
 
 import org.commonmark.node.CustomBlock;
 
-/**
- * Table block containing a {@link TableHead} and optionally a {@link TableBody}.
- */
-public class TableBlock extends CustomBlock {
-}
+/** Table block containing a {@link TableHead} and optionally a {@link TableBody}. */
+public class TableBlock extends CustomBlock {}

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableBody.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableBody.java
@@ -2,8 +2,5 @@ package org.commonmark.ext.gfm.tables;
 
 import org.commonmark.node.CustomNode;
 
-/**
- * Body part of a {@link TableBlock} containing {@link TableRow TableRows}.
- */
-public class TableBody extends CustomNode {
-}
+/** Body part of a {@link TableBlock} containing {@link TableRow TableRows}. */
+public class TableBody extends CustomNode {}

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableCell.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableCell.java
@@ -2,9 +2,7 @@ package org.commonmark.ext.gfm.tables;
 
 import org.commonmark.node.CustomNode;
 
-/**
- * Table cell of a {@link TableRow} containing inline nodes.
- */
+/** Table cell of a {@link TableRow} containing inline nodes. */
 public class TableCell extends CustomNode {
 
     private boolean header;
@@ -34,7 +32,8 @@ public class TableCell extends CustomNode {
     }
 
     /**
-     * @return the cell width (the number of dash and colon characters in the delimiter row of the table for this column)
+     * @return the cell width (the number of dash and colon characters in the delimiter row of the
+     *     table for this column)
      */
     public int getWidth() {
         return width;
@@ -44,11 +43,10 @@ public class TableCell extends CustomNode {
         this.width = width;
     }
 
-    /**
-     * How the cell is aligned horizontally.
-     */
+    /** How the cell is aligned horizontally. */
     public enum Alignment {
-        LEFT, CENTER, RIGHT
+        LEFT,
+        CENTER,
+        RIGHT
     }
-
 }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableHead.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableHead.java
@@ -2,8 +2,5 @@ package org.commonmark.ext.gfm.tables;
 
 import org.commonmark.node.CustomNode;
 
-/**
- * Head part of a {@link TableBlock} containing {@link TableRow TableRows}.
- */
-public class TableHead extends CustomNode {
-}
+/** Head part of a {@link TableBlock} containing {@link TableRow TableRows}. */
+public class TableHead extends CustomNode {}

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableRow.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TableRow.java
@@ -5,5 +5,4 @@ import org.commonmark.node.CustomNode;
 /**
  * Table row of a {@link TableHead} or {@link TableBody} containing {@link TableCell TableCells}.
  */
-public class TableRow extends CustomNode {
-}
+public class TableRow extends CustomNode {}

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TablesExtension.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.gfm.tables;
 
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.tables.internal.TableBlockParser;
 import org.commonmark.ext.gfm.tables.internal.TableHtmlNodeRenderer;
@@ -13,26 +14,25 @@ import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.commonmark.renderer.text.TextContentRenderer;
 
-import java.util.Set;
-
 /**
  * Extension for GFM tables using "|" pipes (GitHub Flavored Markdown).
- * <p>
- * Create it with {@link #create()} and then configure it on the builders
- * ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)},
- * {@link HtmlRenderer.Builder#extensions(Iterable)}).
- * </p>
- * <p>
- * The parsed tables are turned into {@link TableBlock} blocks.
- * </p>
  *
- * @see <a href="https://github.github.com/gfm/#tables-extension-">Tables (extension) in GitHub Flavored Markdown Spec</a>
+ * <p>Create it with {@link #create()} and then configure it on the builders ({@link
+ * org.commonmark.parser.Parser.Builder#extensions(Iterable)}, {@link
+ * HtmlRenderer.Builder#extensions(Iterable)}).
+ *
+ * <p>The parsed tables are turned into {@link TableBlock} blocks.
+ *
+ * @see <a href="https://github.github.com/gfm/#tables-extension-">Tables (extension) in GitHub
+ *     Flavored Markdown Spec</a>
  */
-public class TablesExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension,
-        TextContentRenderer.TextContentRendererExtension, MarkdownRenderer.MarkdownRendererExtension {
+public class TablesExtension
+        implements Parser.ParserExtension,
+                HtmlRenderer.HtmlRendererExtension,
+                TextContentRenderer.TextContentRendererExtension,
+                MarkdownRenderer.MarkdownRendererExtension {
 
-    private TablesExtension() {
-    }
+    private TablesExtension() {}
 
     public static Extension create() {
         return new TablesExtension();
@@ -55,16 +55,17 @@ public class TablesExtension implements Parser.ParserExtension, HtmlRenderer.Htm
 
     @Override
     public void extend(MarkdownRenderer.Builder rendererBuilder) {
-        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(MarkdownNodeRendererContext context) {
-                return new TableMarkdownNodeRenderer(context);
-            }
+        rendererBuilder.nodeRendererFactory(
+                new MarkdownNodeRendererFactory() {
+                    @Override
+                    public NodeRenderer create(MarkdownNodeRendererContext context) {
+                        return new TableMarkdownNodeRenderer(context);
+                    }
 
-            @Override
-            public Set<Character> getSpecialCharacters() {
-                return Set.of('|');
-            }
-        });
+                    @Override
+                    public Set<Character> getSpecialCharacters() {
+                        return Set.of('|');
+                    }
+                });
     }
 }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
@@ -1,5 +1,7 @@
 package org.commonmark.ext.gfm.tables.internal;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.commonmark.ext.gfm.tables.*;
 import org.commonmark.node.Block;
 import org.commonmark.node.Node;
@@ -9,9 +11,6 @@ import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.SourceLines;
 import org.commonmark.parser.block.*;
 import org.commonmark.text.Characters;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class TableBlockParser extends AbstractBlockParser {
 
@@ -42,8 +41,10 @@ public class TableBlockParser extends AbstractBlockParser {
         int pipe = Characters.find('|', content, state.getNextNonSpaceIndex());
         if (pipe != -1) {
             if (pipe == state.getNextNonSpaceIndex()) {
-                // If we *only* have a pipe character (and whitespace), that is not a valid table row and ends the table.
-                if (Characters.skipSpaceTab(content, pipe + 1, content.length()) == content.length()) {
+                // If we *only* have a pipe character (and whitespace), that is not a valid table
+                // row and ends the table.
+                if (Characters.skipSpaceTab(content, pipe + 1, content.length())
+                        == content.length()) {
                     // We also don't want the pipe to be added via lazy continuation.
                     canHaveLazyContinuationLines = false;
                     return BlockContinue.none();
@@ -88,7 +89,8 @@ public class TableBlockParser extends AbstractBlockParser {
         // Body starts at index 2. 0 is header, 1 is separator.
         for (int rowIndex = 2; rowIndex < rowLines.size(); rowIndex++) {
             SourceLine rowLine = rowLines.get(rowIndex);
-            SourceSpan sourceSpan = rowIndex < sourceSpans.size() ? sourceSpans.get(rowIndex) : null;
+            SourceSpan sourceSpan =
+                    rowIndex < sourceSpans.size() ? sourceSpans.get(rowIndex) : null;
             List<SourceLine> cells = split(rowLine);
             TableRow row = new TableRow();
             if (sourceSpan != null) {
@@ -103,7 +105,8 @@ public class TableBlockParser extends AbstractBlockParser {
             }
 
             if (body == null) {
-                // It's valid to have a table without body. In that case, don't add an empty TableBody node.
+                // It's valid to have a table without body. In that case, don't add an empty
+                // TableBody node.
                 body = new TableBody();
                 block.appendChild(body);
             }
@@ -152,9 +155,10 @@ public class TableBlockParser extends AbstractBlockParser {
             switch (c) {
                 case '\\':
                     if (i + 1 < cellEnd && row.charAt(i + 1) == '|') {
-                        // Pipe is special for table parsing. An escaped pipe doesn't result in a new cell, but is
-                        // passed down to inline parsing as an unescaped pipe. Note that that applies even for the `\|`
-                        // in an input like `\\|` - in other words, table parsing doesn't support escaping backslashes.
+                        // Pipe is special for table parsing. An escaped pipe doesn't result in a
+                        // new cell, but is passed down to inline parsing as an unescaped pipe. Note
+                        // that that applies even for the `\|` in an input like `\\|` - in other
+                        // words, table parsing doesn't support escaping backslashes.
                         sb.append('|');
                         i++;
                     } else {
@@ -176,7 +180,10 @@ public class TableBlockParser extends AbstractBlockParser {
         }
         if (sb.length() > 0) {
             String content = sb.toString();
-            cells.add(SourceLine.of(content, line.substring(cellStart, line.getContent().length()).getSourceSpan()));
+            cells.add(
+                    SourceLine.of(
+                            content,
+                            line.substring(cellStart, line.getContent().length()).getSourceSpan()));
         }
         return cells;
     }
@@ -211,7 +218,8 @@ public class TableBlockParser extends AbstractBlockParser {
                 case '-':
                 case ':':
                     if (pipes == 0 && !columns.isEmpty()) {
-                        // Need a pipe after the first column (first column doesn't need to start with one)
+                        // Need a pipe after the first column (first column doesn't need to start
+                        // with one)
                         return null;
                     }
                     boolean left = false;
@@ -274,9 +282,14 @@ public class TableBlockParser extends AbstractBlockParser {
         @Override
         public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
             List<SourceLine> paragraphLines = matchedBlockParser.getParagraphLines().getLines();
-            if (!paragraphLines.isEmpty() && Characters.find('|', paragraphLines.get(paragraphLines.size() - 1).getContent(), 0) != -1) {
+            if (paragraphLines.isEmpty()) {
+                return BlockStart.none();
+            }
+            var previousLine = paragraphLines.get(paragraphLines.size() - 1).getContent();
+            if (Characters.find('|', previousLine, 0) != -1) {
                 SourceLine line = state.getLine();
-                SourceLine separatorLine = line.substring(state.getIndex(), line.getContent().length());
+                SourceLine separatorLine =
+                        line.substring(state.getIndex(), line.getContent().length());
                 List<TableCellInfo> columns = parseSeparator(separatorLine.getContent());
                 if (columns != null && !columns.isEmpty()) {
                     SourceLine paragraph = paragraphLines.get(paragraphLines.size() - 1);

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableHtmlNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableHtmlNodeRenderer.java
@@ -1,11 +1,10 @@
 package org.commonmark.ext.gfm.tables.internal;
 
+import java.util.Map;
 import org.commonmark.ext.gfm.tables.*;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlWriter;
-
-import java.util.Map;
 
 public class TableHtmlNodeRenderer extends TableNodeRenderer {
 
@@ -69,7 +68,8 @@ public class TableHtmlNodeRenderer extends TableNodeRenderer {
 
     private Map<String, String> getCellAttributes(TableCell tableCell, String tagName) {
         if (tableCell.getAlignment() != null) {
-            return context.extendAttributes(tableCell, tagName, Map.of("align", getAlignValue(tableCell.getAlignment())));
+            return context.extendAttributes(
+                    tableCell, tagName, Map.of("align", getAlignValue(tableCell.getAlignment())));
         } else {
             return context.extendAttributes(tableCell, tagName, Map.of());
         }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableMarkdownNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableMarkdownNodeRenderer.java
@@ -1,16 +1,16 @@
 package org.commonmark.ext.gfm.tables.internal;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.commonmark.ext.gfm.tables.*;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
 import org.commonmark.renderer.markdown.MarkdownWriter;
 import org.commonmark.text.AsciiMatcher;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
- * The Table node renderer that is needed for rendering GFM tables (GitHub Flavored Markdown) to text content.
+ * The Table node renderer that is needed for rendering GFM tables (GitHub Flavored Markdown) to
+ * text content.
  */
 public class TableMarkdownNodeRenderer extends TableNodeRenderer {
     private final MarkdownWriter writer;

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableNodeRenderer.java
@@ -1,10 +1,9 @@
 package org.commonmark.ext.gfm.tables.internal;
 
+import java.util.Set;
 import org.commonmark.ext.gfm.tables.*;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.NodeRenderer;
-
-import java.util.Set;
 
 abstract class TableNodeRenderer implements NodeRenderer {
 
@@ -15,8 +14,7 @@ abstract class TableNodeRenderer implements NodeRenderer {
                 TableHead.class,
                 TableBody.class,
                 TableRow.class,
-                TableCell.class
-        );
+                TableCell.class);
     }
 
     @Override

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableTextContentNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableTextContentNodeRenderer.java
@@ -10,7 +10,8 @@ import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentWriter;
 
 /**
- * The Table node renderer that is needed for rendering GFM tables (GitHub Flavored Markdown) to text content.
+ * The Table node renderer that is needed for rendering GFM tables (GitHub Flavored Markdown) to
+ * text content.
  */
 public class TableTextContentNodeRenderer extends TableNodeRenderer {
 

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TableMarkdownRendererTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TableMarkdownRendererTest.java
@@ -1,19 +1,19 @@
 package org.commonmark.ext.gfm.tables;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class TableMarkdownRendererTest {
 
     private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER =
+            MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void testHeadNoBody() {
@@ -60,7 +60,8 @@ public class TableMarkdownRendererTest {
 
     @Test
     public void testEscaped() {
-        // `|` in Text nodes needs to be escaped, otherwise the generated Markdown does not get parsed back as a table
+        // `|` in Text nodes needs to be escaped, otherwise the generated Markdown does not get
+        // parsed back as a table
         assertRoundTrip("\\|Abc\\|\n\\|---\\|\n");
     }
 

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesSpecTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesSpecTest.java
@@ -1,5 +1,7 @@
 package org.commonmark.ext.gfm.tables;
 
+import java.util.List;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -12,19 +14,16 @@ import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
-import java.util.Set;
-
 @ParameterizedClass
 @MethodSource("data")
 public class TablesSpecTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
-    @Parameter
-    Example example;
+    @Parameter Example example;
 
     static List<Example> data() {
         return ExampleReader.readExamples(TestResources.getGfmSpec(), "table");

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -1,5 +1,9 @@
 package org.commonmark.ext.gfm.tables;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.*;
 import org.commonmark.parser.IncludeSourceSpans;
@@ -9,16 +13,12 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class TablesTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void mustHaveHeaderAndSeparator() {
@@ -28,22 +28,26 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void separatorMustBeOneOrMore() {
-        assertRendering("Abc|Def\n-|-", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "</table>\n");
-        assertRendering("Abc|Def\n--|--", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n-|-",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "</table>\n");
+        assertRendering(
+                "Abc|Def\n--|--",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "</table>\n");
     }
 
     @Test
@@ -55,14 +59,16 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void separatorCanHaveLeadingSpaceThenPipe() {
-        assertRendering("Abc|Def\n |---|---", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n |---|---",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "</table>\n");
     }
 
     @Test
@@ -77,25 +83,28 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void oneHeadNoBody() {
-        assertRendering("Abc|Def\n---|---", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n---|---",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void oneColumnOneHeadNoBody() {
-        String expected = "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "</table>\n";
+        String expected =
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "</table>\n";
         assertRendering("|Abc\n|---\n", expected);
         assertRendering("|Abc|\n|---|\n", expected);
         assertRendering("Abc|\n---|\n", expected);
@@ -108,18 +117,19 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void oneColumnOneHeadOneBody() {
-        String expected = "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n";
+        String expected =
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n";
         assertRendering("|Abc\n|---\n|1", expected);
         assertRendering("|Abc|\n|---|\n|1|", expected);
         assertRendering("Abc|\n---|\n1|", expected);
@@ -130,38 +140,42 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void oneHeadOneBody() {
-        assertRendering("Abc|Def\n---|---\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n---|---\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void spaceBeforeSeparator() {
-        assertRendering("  |Abc|Def|\n  |---|---|\n  |1|2|", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "  |Abc|Def|\n  |---|---|\n  |1|2|",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
@@ -171,368 +185,408 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void padding() {
-        assertRendering(" Abc  | Def \n --- | --- \n 1 | 2 ", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                " Abc  | Def \n --- | --- \n 1 | 2 ",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void paddingWithCodeBlockIndentation() {
-        assertRendering("Abc|Def\n---|---\n    1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n---|---\n    1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void pipesOnOutside() {
-        assertRendering("|Abc|Def|\n|---|---|\n|1|2|", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "|Abc|Def|\n|---|---|\n|1|2|",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void pipesOnOutsideWhitespaceAfterHeader() {
-        assertRendering("|Abc|Def| \n|---|---|\n|1|2|", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "|Abc|Def| \n|---|---|\n|1|2|",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void pipesOnOutsideZeroLengthHeaders() {
         // This is literally what someone has done IRL - it helped to expose
         // an issue with parsing the last header cell correctly
-        assertRendering("||center header||\n" +
-                        "-|-------------|-\n" +
-                        "1|      2      |3",
-                "<table>\n" +
-                        "<thead>\n" +
-                        "<tr>\n" +
-                        "<th></th>\n" +
-                        "<th>center header</th>\n" +
-                        "<th></th>\n" +
-                        "</tr>\n" +
-                        "</thead>\n" +
-                        "<tbody>\n" +
-                        "<tr>\n" +
-                        "<td>1</td>\n" +
-                        "<td>2</td>\n" +
-                        "<td>3</td>\n" +
-                        "</tr>\n" +
-                        "</tbody>\n" +
-                        "</table>\n");
+        assertRendering(
+                "||center header||\n" + "-|-------------|-\n" + "1|      2      |3",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th></th>\n"
+                        + "<th>center header</th>\n"
+                        + "<th></th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "<td>3</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void inlineElements() {
-        assertRendering("*Abc*|Def\n---|---\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th><em>Abc</em></th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "*Abc*|Def\n---|---\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th><em>Abc</em></th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void escapedPipe() {
-        assertRendering("Abc|Def\n---|---\n1\\|2|20", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1|2</td>\n" +
-                "<td>20</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n---|---\n1\\|2|20",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1|2</td>\n"
+                        + "<td>20</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void escapedBackslash() {
-        // This is a bit weird in the GFM spec IMO. `1\\|2` looks like an escaped backslash, followed by a pipe
-        // (so two cells). Instead, the `\|` is parsed as an escaped pipe first, so just a single cell. The inline
-        // parser then gets `1\|2` which renders as `1|2`.
-        assertRendering("Abc|Def\n---|---\n1\\\\|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1|2</td>\n" +
-                "<td></td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        // This is a bit weird in the GFM spec IMO. `1\\|2` looks like an escaped backslash,
+        // followed by a pipe (so two cells). Instead, the `\|` is parsed as an escaped pipe first,
+        // so just a single cell. The inline parser then gets `1\|2` which renders as `1|2`.
+        assertRendering(
+                "Abc|Def\n---|---\n1\\\\|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1|2</td>\n"
+                        + "<td></td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void escapedOther() {
-        // This is a tricky one. For \`, we don't want to remove the backslash when we parse the table, otherwise
-        // inline parsing is wrong. So we have to be careful where we do/don't consume the backslash.
-        assertRendering("Abc|Def\n---|---\n1|\\`not code`", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>`not code`</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        // This is a tricky one. For \`, we don't want to remove the backslash when we parse the
+        // table, otherwise inline parsing is wrong. So we have to be careful where we do/don't
+        // consume the backslash.
+        assertRendering(
+                "Abc|Def\n---|---\n1|\\`not code`",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>`not code`</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void backslashAtEnd() {
-        assertRendering("Abc|Def\n---|---\n1|2\\", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2\\</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n---|---\n1|2\\",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2\\</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void alignLeft() {
-        assertRendering("Abc|Def\n:-|-\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"left\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"left\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
-        assertRendering("Abc|Def\n:-|-\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"left\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"left\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
-        assertRendering("Abc|Def\n:---|---\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"left\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"left\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n:-|-\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"left\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"left\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
+        assertRendering(
+                "Abc|Def\n:-|-\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"left\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"left\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
+        assertRendering(
+                "Abc|Def\n:---|---\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"left\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"left\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void alignRight() {
-        assertRendering("Abc|Def\n-:|-\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"right\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"right\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
-        assertRendering("Abc|Def\n--:|--\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"right\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"right\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
-        assertRendering("Abc|Def\n---:|---\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"right\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"right\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n-:|-\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"right\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"right\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
+        assertRendering(
+                "Abc|Def\n--:|--\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"right\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"right\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
+        assertRendering(
+                "Abc|Def\n---:|---\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"right\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"right\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void alignCenter() {
-        assertRendering("Abc|Def\n:-:|-\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"center\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"center\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
-        assertRendering("Abc|Def\n:--:|--\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"center\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"center\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
-        assertRendering("Abc|Def\n:---:|---\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"center\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"center\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n:-:|-\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"center\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"center\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
+        assertRendering(
+                "Abc|Def\n:--:|--\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"center\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"center\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
+        assertRendering(
+                "Abc|Def\n:---:|---\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"center\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"center\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void alignCenterSecond() {
-        assertRendering("Abc|Def\n---|:---:\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th align=\"center\">Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td align=\"center\">2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n---|:---:\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th align=\"center\">Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td align=\"center\">2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void alignLeftWithSpaces() {
-        assertRendering("Abc|Def\n :--- |---\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th align=\"left\">Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td align=\"left\">1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n :--- |---\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"left\">Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"left\">1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
@@ -545,249 +599,272 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void bodyCanNotHaveMoreColumnsThanHead() {
-        assertRendering("Abc|Def\n---|---\n1|2|3", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n---|---\n1|2|3",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void bodyWithFewerColumnsThanHeadResultsInEmptyCells() {
-        assertRendering("Abc|Def|Ghi\n---|---|---\n1|2", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "<th>Ghi</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "<td></td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def|Ghi\n---|---|---\n1|2",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "<th>Ghi</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "<td></td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void insideBlockQuote() {
-        assertRendering("> Abc|Def\n> ---|---\n> 1|2", "<blockquote>\n" +
-                "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n" +
-                "</blockquote>\n");
+        assertRendering(
+                "> Abc|Def\n> ---|---\n> 1|2",
+                "<blockquote>\n"
+                        + "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n"
+                        + "</blockquote>\n");
     }
 
     @Test
     public void tableWithLazyContinuationLine() {
-        assertRendering("Abc|Def\n---|---\n1|2\nlazy", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "<tr>\n" +
-                "<td>lazy</td>\n" +
-                "<td></td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "Abc|Def\n---|---\n1|2\nlazy",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "<tr>\n"
+                        + "<td>lazy</td>\n"
+                        + "<td></td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void issue142() {
-        assertRendering("||Alveolar|Bilabial\n" +
-                        "|:--|:-:|:-:\n" +
-                        "|**Plosive**|t, d|b\n" +
-                        "|**Tap**|ɾ|",
-                "<table>\n" +
-                        "<thead>\n" +
-                        "<tr>\n" +
-                        "<th align=\"left\"></th>\n" +
-                        "<th align=\"center\">Alveolar</th>\n" +
-                        "<th align=\"center\">Bilabial</th>\n" +
-                        "</tr>\n" +
-                        "</thead>\n" +
-                        "<tbody>\n" +
-                        "<tr>\n" +
-                        "<td align=\"left\"><strong>Plosive</strong></td>\n" +
-                        "<td align=\"center\">t, d</td>\n" +
-                        "<td align=\"center\">b</td>\n" +
-                        "</tr>\n" +
-                        "<tr>\n" +
-                        "<td align=\"left\"><strong>Tap</strong></td>\n" +
-                        "<td align=\"center\">ɾ</td>\n" +
-                        "<td align=\"center\"></td>\n" +
-                        "</tr>\n" +
-                        "</tbody>\n" +
-                        "</table>\n");
+        assertRendering(
+                "||Alveolar|Bilabial\n"
+                        + "|:--|:-:|:-:\n"
+                        + "|**Plosive**|t, d|b\n"
+                        + "|**Tap**|ɾ|",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th align=\"left\"></th>\n"
+                        + "<th align=\"center\">Alveolar</th>\n"
+                        + "<th align=\"center\">Bilabial</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td align=\"left\"><strong>Plosive</strong></td>\n"
+                        + "<td align=\"center\">t, d</td>\n"
+                        + "<td align=\"center\">b</td>\n"
+                        + "</tr>\n"
+                        + "<tr>\n"
+                        + "<td align=\"left\"><strong>Tap</strong></td>\n"
+                        + "<td align=\"center\">ɾ</td>\n"
+                        + "<td align=\"center\"></td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void danglingPipe() {
-        assertRendering("Abc|Def\n" +
-                "---|---\n" +
-                "1|2\n" +
-                "|", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n" +
-                "<p>|</p>\n");
+        assertRendering(
+                "Abc|Def\n" + "---|---\n" + "1|2\n" + "|",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n"
+                        + "<p>|</p>\n");
 
-        assertRendering("Abc|Def\n" +
-                "---|---\n" +
-                "1|2\n" +
-                "  |  ", "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>Abc</th>\n" +
-                "<th>Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n" +
-                "<p>|</p>\n");
+        assertRendering(
+                "Abc|Def\n" + "---|---\n" + "1|2\n" + "  |  ",
+                "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>Abc</th>\n"
+                        + "<th>Def</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>1</td>\n"
+                        + "<td>2</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n"
+                        + "<p>|</p>\n");
     }
 
     @Test
     public void interruptsParagraph() {
-        assertRendering("text\n" +
-                "|a  |\n" +
-                "|---|\n" +
-                "|b  |", "<p>text</p>\n" +
-                "<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th>a</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>b</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertRendering(
+                "text\n" + "|a  |\n" + "|---|\n" + "|b  |",
+                "<p>text</p>\n"
+                        + "<table>\n"
+                        + "<thead>\n"
+                        + "<tr>\n"
+                        + "<th>a</th>\n"
+                        + "</tr>\n"
+                        + "</thead>\n"
+                        + "<tbody>\n"
+                        + "<tr>\n"
+                        + "<td>b</td>\n"
+                        + "</tr>\n"
+                        + "</tbody>\n"
+                        + "</table>\n");
     }
 
     @Test
     public void attributeProviderIsApplied() {
-        AttributeProviderFactory factory = context -> (node, tagName, attributes) -> {
-            if (node instanceof TableBlock) {
-                attributes.put("test", "block");
-            } else if (node instanceof TableHead) {
-                attributes.put("test", "head");
-            } else if (node instanceof TableBody) {
-                attributes.put("test", "body");
-            } else if (node instanceof TableRow) {
-                attributes.put("test", "row");
-            } else if (node instanceof TableCell) {
-                attributes.put("test", "cell");
-            }
-        };
-        HtmlRenderer renderer = HtmlRenderer.builder()
-                .attributeProviderFactory(factory)
-                .extensions(EXTENSIONS)
-                .build();
+        AttributeProviderFactory factory =
+                context ->
+                        (node, tagName, attributes) -> {
+                            if (node instanceof TableBlock) {
+                                attributes.put("test", "block");
+                            } else if (node instanceof TableHead) {
+                                attributes.put("test", "head");
+                            } else if (node instanceof TableBody) {
+                                attributes.put("test", "body");
+                            } else if (node instanceof TableRow) {
+                                attributes.put("test", "row");
+                            } else if (node instanceof TableCell) {
+                                attributes.put("test", "cell");
+                            }
+                        };
+        HtmlRenderer renderer =
+                HtmlRenderer.builder()
+                        .attributeProviderFactory(factory)
+                        .extensions(EXTENSIONS)
+                        .build();
         String rendered = renderer.render(PARSER.parse("Abc|Def\n---|---\n1|2"));
-        assertThat(rendered).isEqualTo("<table test=\"block\">\n" +
-                "<thead test=\"head\">\n" +
-                "<tr test=\"row\">\n" +
-                "<th test=\"cell\">Abc</th>\n" +
-                "<th test=\"cell\">Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody test=\"body\">\n" +
-                "<tr test=\"row\">\n" +
-                "<td test=\"cell\">1</td>\n" +
-                "<td test=\"cell\">2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertThat(rendered)
+                .isEqualTo(
+                        "<table test=\"block\">\n"
+                                + "<thead test=\"head\">\n"
+                                + "<tr test=\"row\">\n"
+                                + "<th test=\"cell\">Abc</th>\n"
+                                + "<th test=\"cell\">Def</th>\n"
+                                + "</tr>\n"
+                                + "</thead>\n"
+                                + "<tbody test=\"body\">\n"
+                                + "<tr test=\"row\">\n"
+                                + "<td test=\"cell\">1</td>\n"
+                                + "<td test=\"cell\">2</td>\n"
+                                + "</tr>\n"
+                                + "</tbody>\n"
+                                + "</table>\n");
     }
 
     @Test
     public void columnWidthIsRecorded() {
-        AttributeProviderFactory factory = context -> (node, tagName, attributes) -> {
-            if (node instanceof TableCell && "th".equals(tagName)) {
-                attributes.put("width", ((TableCell) node).getWidth() + "em");
-            }
-        };
-        HtmlRenderer renderer = HtmlRenderer.builder()
-                .attributeProviderFactory(factory)
-                .extensions(EXTENSIONS)
-                .build();
+        AttributeProviderFactory factory =
+                context ->
+                        (node, tagName, attributes) -> {
+                            if (node instanceof TableCell && "th".equals(tagName)) {
+                                attributes.put("width", ((TableCell) node).getWidth() + "em");
+                            }
+                        };
+        HtmlRenderer renderer =
+                HtmlRenderer.builder()
+                        .attributeProviderFactory(factory)
+                        .extensions(EXTENSIONS)
+                        .build();
         String rendered = renderer.render(PARSER.parse("Abc|Def\n-----|---\n1|2"));
-        assertThat(rendered).isEqualTo("<table>\n" +
-                "<thead>\n" +
-                "<tr>\n" +
-                "<th width=\"5em\">Abc</th>\n" +
-                "<th width=\"3em\">Def</th>\n" +
-                "</tr>\n" +
-                "</thead>\n" +
-                "<tbody>\n" +
-                "<tr>\n" +
-                "<td>1</td>\n" +
-                "<td>2</td>\n" +
-                "</tr>\n" +
-                "</tbody>\n" +
-                "</table>\n");
+        assertThat(rendered)
+                .isEqualTo(
+                        "<table>\n"
+                                + "<thead>\n"
+                                + "<tr>\n"
+                                + "<th width=\"5em\">Abc</th>\n"
+                                + "<th width=\"3em\">Def</th>\n"
+                                + "</tr>\n"
+                                + "</thead>\n"
+                                + "<tbody>\n"
+                                + "<tr>\n"
+                                + "<td>1</td>\n"
+                                + "<td>2</td>\n"
+                                + "</tr>\n"
+                                + "</tbody>\n"
+                                + "</table>\n");
     }
 
     @Test
     public void sourceSpans() {
-        Parser parser = Parser.builder()
-                .extensions(EXTENSIONS)
-                .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
-                .build();
+        Parser parser =
+                Parser.builder()
+                        .extensions(EXTENSIONS)
+                        .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                        .build();
         Node document = parser.parse("Abc|Def\n---|---\n|1|2\n 3|four|\n|||\n");
 
         TableBlock block = (TableBlock) document.getFirstChild();
-        assertThat(block.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 7),
-                SourceSpan.of(2, 0, 16, 4), SourceSpan.of(3, 0, 21, 8), SourceSpan.of(4, 0, 30, 3)));
+        assertThat(block.getSourceSpans())
+                .isEqualTo(
+                        List.of(
+                                SourceSpan.of(0, 0, 0, 7),
+                                SourceSpan.of(1, 0, 8, 7),
+                                SourceSpan.of(2, 0, 16, 4),
+                                SourceSpan.of(3, 0, 21, 8),
+                                SourceSpan.of(4, 0, 30, 3)));
 
         TableHead head = (TableHead) block.getFirstChild();
         assertThat(head.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 7)));
@@ -797,30 +874,41 @@ public class TablesTest extends RenderingTestCase {
         TableCell headRowCell1 = (TableCell) headRow.getFirstChild();
         TableCell headRowCell2 = (TableCell) headRow.getLastChild();
         assertThat(headRowCell1.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 3)));
-        assertThat(headRowCell1.getFirstChild().getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 3)));
+        assertThat(headRowCell1.getFirstChild().getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(0, 0, 0, 3)));
         assertThat(headRowCell2.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 4, 4, 3)));
-        assertThat(headRowCell2.getFirstChild().getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 4, 4, 3)));
+        assertThat(headRowCell2.getFirstChild().getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(0, 4, 4, 3)));
 
         TableBody body = (TableBody) block.getLastChild();
-        assertThat(body.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(2, 0, 16, 4), SourceSpan.of(3, 0, 21, 8), SourceSpan.of(4, 0, 30, 3)));
+        assertThat(body.getSourceSpans())
+                .isEqualTo(
+                        List.of(
+                                SourceSpan.of(2, 0, 16, 4),
+                                SourceSpan.of(3, 0, 21, 8),
+                                SourceSpan.of(4, 0, 30, 3)));
 
         TableRow bodyRow1 = (TableRow) body.getFirstChild();
         assertThat(bodyRow1.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(2, 0, 16, 4)));
         TableCell bodyRow1Cell1 = (TableCell) bodyRow1.getFirstChild();
         TableCell bodyRow1Cell2 = (TableCell) bodyRow1.getLastChild();
         assertThat(bodyRow1Cell1.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(2, 1, 17, 1)));
-        assertThat(bodyRow1Cell1.getFirstChild().getSourceSpans()).isEqualTo(List.of(SourceSpan.of(2, 1, 17, 1)));
+        assertThat(bodyRow1Cell1.getFirstChild().getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(2, 1, 17, 1)));
         assertThat(bodyRow1Cell2.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(2, 3, 19, 1)));
-        assertThat(bodyRow1Cell2.getFirstChild().getSourceSpans()).isEqualTo(List.of(SourceSpan.of(2, 3, 19, 1)));
+        assertThat(bodyRow1Cell2.getFirstChild().getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(2, 3, 19, 1)));
 
         TableRow bodyRow2 = (TableRow) body.getFirstChild().getNext();
         assertThat(bodyRow2.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(3, 0, 21, 8)));
         TableCell bodyRow2Cell1 = (TableCell) bodyRow2.getFirstChild();
         TableCell bodyRow2Cell2 = (TableCell) bodyRow2.getLastChild();
         assertThat(bodyRow2Cell1.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(3, 1, 22, 1)));
-        assertThat(bodyRow2Cell1.getFirstChild().getSourceSpans()).isEqualTo(List.of(SourceSpan.of(3, 1, 22, 1)));
+        assertThat(bodyRow2Cell1.getFirstChild().getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(3, 1, 22, 1)));
         assertThat(bodyRow2Cell2.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(3, 3, 24, 4)));
-        assertThat(bodyRow2Cell2.getFirstChild().getSourceSpans()).isEqualTo(List.of(SourceSpan.of(3, 3, 24, 4)));
+        assertThat(bodyRow2Cell2.getFirstChild().getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(3, 3, 24, 4)));
 
         TableRow bodyRow3 = (TableRow) body.getLastChild();
         assertThat(bodyRow3.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(4, 0, 30, 3)));
@@ -832,15 +920,12 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void sourceSpansWhenInterrupting() {
-        var parser = Parser.builder()
-                .extensions(EXTENSIONS)
-                .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
-                .build();
-        var document = parser.parse("a\n" +
-                "bc\n" +
-                "|de|\n" +
-                "|---|\n" +
-                "|fg|");
+        var parser =
+                Parser.builder()
+                        .extensions(EXTENSIONS)
+                        .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                        .build();
+        var document = parser.parse("a\n" + "bc\n" + "|de|\n" + "|---|\n" + "|fg|");
 
         var paragraph = (Paragraph) document.getFirstChild();
         var text = (Text) paragraph.getFirstChild();
@@ -849,15 +934,16 @@ public class TablesTest extends RenderingTestCase {
         var text2 = (Text) text.getNext().getNext();
         assertThat(text2.getLiteral()).isEqualTo("bc");
 
-        assertThat(paragraph.getSourceSpans()).isEqualTo(List.of(
-                SourceSpan.of(0, 0, 0, 1),
-                SourceSpan.of(1, 0, 2, 2)));
+        assertThat(paragraph.getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(0, 0, 0, 1), SourceSpan.of(1, 0, 2, 2)));
 
         var table = (TableBlock) document.getLastChild();
-        assertThat(table.getSourceSpans()).isEqualTo(List.of(
-                SourceSpan.of(2, 0, 5, 4),
-                SourceSpan.of(3, 0, 10, 5),
-                SourceSpan.of(4, 0, 16, 4)));
+        assertThat(table.getSourceSpans())
+                .isEqualTo(
+                        List.of(
+                                SourceSpan.of(2, 0, 5, 4),
+                                SourceSpan.of(3, 0, 10, 5),
+                                SourceSpan.of(4, 0, 16, 4)));
     }
 
     @Override

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTextContentTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTextContentTest.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.gfm.tables;
 
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.text.LineBreakRendering;
@@ -7,19 +8,25 @@ import org.commonmark.renderer.text.TextContentRenderer;
 import org.commonmark.testutil.Asserts;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
 public class TablesTextContentTest {
 
     private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final TextContentRenderer RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS).build();
+    private static final TextContentRenderer RENDERER =
+            TextContentRenderer.builder().extensions(EXTENSIONS).build();
 
-    private static final TextContentRenderer COMPACT_RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS).build();
-    private static final TextContentRenderer SEPARATE_RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS)
-            .lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS).build();
-    private static final TextContentRenderer STRIPPED_RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS)
-            .lineBreakRendering(LineBreakRendering.STRIP).build();
+    private static final TextContentRenderer COMPACT_RENDERER =
+            TextContentRenderer.builder().extensions(EXTENSIONS).build();
+    private static final TextContentRenderer SEPARATE_RENDERER =
+            TextContentRenderer.builder()
+                    .extensions(EXTENSIONS)
+                    .lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS)
+                    .build();
+    private static final TextContentRenderer STRIPPED_RENDERER =
+            TextContentRenderer.builder()
+                    .extensions(EXTENSIONS)
+                    .lineBreakRendering(LineBreakRendering.STRIP)
+                    .build();
 
     @Test
     public void oneHeadNoBody() {

--- a/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/HeadingAnchorExtension.java
+++ b/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/HeadingAnchorExtension.java
@@ -6,17 +6,20 @@ import org.commonmark.renderer.html.HtmlRenderer;
 
 /**
  * Extension for adding auto generated IDs to headings.
- * <p>
- * Create it with {@link #create()} or {@link #builder()} and then configure it on the
- * renderer builder ({@link HtmlRenderer.Builder#extensions(Iterable)}).
- * <p>
- * The heading text will be used to create the id. Multiple headings with the
- * same text will result in appending a hyphen and number. For example:
+ *
+ * <p>Create it with {@link #create()} or {@link #builder()} and then configure it on the renderer
+ * builder ({@link HtmlRenderer.Builder#extensions(Iterable)}).
+ *
+ * <p>The heading text will be used to create the id. Multiple headings with the same text will
+ * result in appending a hyphen and number. For example:
+ *
  * <pre><code>
  * # Heading
  * # Heading
  * </code></pre>
+ *
  * will result in
+ *
  * <pre><code>
  * &lt;h1 id="heading"&gt;Heading&lt;/h1&gt;
  * &lt;h1 id="heading-1"&gt;Heading&lt;/h1&gt;
@@ -52,7 +55,8 @@ public class HeadingAnchorExtension implements HtmlRenderer.HtmlRendererExtensio
 
     @Override
     public void extend(HtmlRenderer.Builder rendererBuilder) {
-        rendererBuilder.attributeProviderFactory(context -> HeadingIdAttributeProvider.create(defaultId, idPrefix, idSuffix));
+        rendererBuilder.attributeProviderFactory(
+                context -> HeadingIdAttributeProvider.create(defaultId, idPrefix, idSuffix));
     }
 
     public static class Builder {
@@ -61,7 +65,8 @@ public class HeadingAnchorExtension implements HtmlRenderer.HtmlRendererExtensio
         private String idSuffix = "";
 
         /**
-         * @param value Default value for the id to take if no generated id can be extracted. Default "id"
+         * @param value Default value for the id to take if no generated id can be extracted.
+         *     Default "id"
          * @return {@code this}
          */
         public Builder defaultId(String value) {

--- a/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/IdGenerator.java
+++ b/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/IdGenerator.java
@@ -7,8 +7,8 @@ import java.util.regex.Pattern;
 
 /**
  * Generates strings to be used as identifiers.
- * <p>
- * Use {@link #builder()} to create an instance.
+ *
+ * <p>Use {@link #builder()} to create an instance.
  */
 public class IdGenerator {
     private final Pattern allowedCharacters;
@@ -33,35 +33,35 @@ public class IdGenerator {
     }
 
     /**
-     * <p>
      * Generate an ID based on the provided text and previously generated IDs.
-     * <p>
-     * This method is not thread safe, concurrent calls can end up
-     * with non-unique identifiers.
-     * <p>
-     * Note that collision can occur in the case that
-     * <ul>
-     * <li>Method called with 'X'</li>
-     * <li>Method called with 'X' again</li>
-     * <li>Method called with 'X-1'</li>
-     * </ul>
-     * <p>
-     * In that case, the three generated IDs will be:
-     * <ul>
-     * <li>X</li>
-     * <li>X-1</li>
-     * <li>X-1</li>
-     * </ul>
-     * <p>
-     * Therefore if collisions are unacceptable you should ensure that
-     * numbers are stripped from end of {@code text}.
      *
-     * @param text Text that the identifier should be based on. Will be normalised, then used to generate the
-     * identifier.
-     * @return {@code text} if this is the first instance that the {@code text} has been passed
-     * to the method. Otherwise, {@code text + "-" + X} will be returned, where X is the number of times
-     * that {@code text} has previously been passed in. If {@code text} is empty, the default
-     * identifier given in the constructor will be used.
+     * <p>This method is not thread safe, concurrent calls can end up with non-unique identifiers.
+     *
+     * <p>Note that collision can occur in the case that
+     *
+     * <ul>
+     *   <li>Method called with 'X'
+     *   <li>Method called with 'X' again
+     *   <li>Method called with 'X-1'
+     * </ul>
+     *
+     * <p>In that case, the three generated IDs will be:
+     *
+     * <ul>
+     *   <li>X
+     *   <li>X-1
+     *   <li>X-1
+     * </ul>
+     *
+     * <p>Therefore if collisions are unacceptable you should ensure that numbers are stripped from
+     * end of {@code text}.
+     *
+     * @param text Text that the identifier should be based on. Will be normalised, then used to
+     *     generate the identifier.
+     * @return {@code text} if this is the first instance that the {@code text} has been passed to
+     *     the method. Otherwise, {@code text + "-" + X} will be returned, where X is the number of
+     *     times that {@code text} has previously been passed in. If {@code text} is empty, the
+     *     default identifier given in the constructor will be used.
      */
     public String generateId(String text) {
         String normalizedIdentity = text != null ? normalizeText(text) : defaultIdentifier;
@@ -85,7 +85,8 @@ public class IdGenerator {
         try {
             return Pattern.compile(regex, Pattern.UNICODE_CHARACTER_CLASS);
         } catch (IllegalArgumentException e) {
-            // Android only supports the flag in API level 24. But it actually uses Unicode character classes by
+            // Android only supports the flag in API level 24. But it actually uses Unicode
+            // character classes by
             // default, so not specifying the flag is ok. See issue #71.
             return Pattern.compile(regex);
         }
@@ -119,7 +120,8 @@ public class IdGenerator {
         }
 
         /**
-         * @param defaultId the default identifier to use in case the provided text is empty or only contains unusable characters
+         * @param defaultId the default identifier to use in case the provided text is empty or only
+         *     contains unusable characters
          * @return {@code this}
          */
         public Builder defaultId(String defaultId) {

--- a/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/internal/HeadingIdAttributeProvider.java
+++ b/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/internal/HeadingIdAttributeProvider.java
@@ -1,26 +1,23 @@
 package org.commonmark.ext.heading.anchor.internal;
 
-import org.commonmark.ext.heading.anchor.IdGenerator;
-import org.commonmark.renderer.html.AttributeProvider;
-import org.commonmark.node.*;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.commonmark.ext.heading.anchor.IdGenerator;
+import org.commonmark.node.*;
+import org.commonmark.renderer.html.AttributeProvider;
 
 public class HeadingIdAttributeProvider implements AttributeProvider {
 
     private final IdGenerator idGenerator;
 
     private HeadingIdAttributeProvider(String defaultId, String prefix, String suffix) {
-        idGenerator = IdGenerator.builder()
-                .defaultId(defaultId)
-                .prefix(prefix)
-                .suffix(suffix)
-                .build();
+        idGenerator =
+                IdGenerator.builder().defaultId(defaultId).prefix(prefix).suffix(suffix).build();
     }
 
-    public static HeadingIdAttributeProvider create(String defaultId, String prefix, String suffix) {
+    public static HeadingIdAttributeProvider create(
+            String defaultId, String prefix, String suffix) {
         return new HeadingIdAttributeProvider(defaultId, prefix, suffix);
     }
 
@@ -31,17 +28,18 @@ public class HeadingIdAttributeProvider implements AttributeProvider {
 
             final List<String> wordList = new ArrayList<>();
 
-            node.accept(new AbstractVisitor() {
-                @Override
-                public void visit(Text text) {
-                    wordList.add(text.getLiteral());
-                }
+            node.accept(
+                    new AbstractVisitor() {
+                        @Override
+                        public void visit(Text text) {
+                            wordList.add(text.getLiteral());
+                        }
 
-                @Override
-                public void visit(Code code) {
-                    wordList.add(code.getLiteral());
-                }
-            });
+                        @Override
+                        public void visit(Code code) {
+                            wordList.add(code.getLiteral());
+                        }
+                    });
 
             String finalString = "";
             for (String word : wordList) {

--- a/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorConfigurationTest.java
+++ b/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorConfigurationTest.java
@@ -1,34 +1,31 @@
 package org.commonmark.ext.heading.anchor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class HeadingAnchorConfigurationTest {
 
     private static final Parser PARSER = Parser.builder().build();
 
     private HtmlRenderer buildRenderer(String defaultId, String prefix, String suffix) {
-        Extension ext = HeadingAnchorExtension.builder()
-                .defaultId(defaultId)
-                .idPrefix(prefix)
-                .idSuffix(suffix)
-                .build();
-        return HtmlRenderer.builder()
-                .extensions(List.of(ext))
-                .build();
+        Extension ext =
+                HeadingAnchorExtension.builder()
+                        .defaultId(defaultId)
+                        .idPrefix(prefix)
+                        .idSuffix(suffix)
+                        .build();
+        return HtmlRenderer.builder().extensions(List.of(ext)).build();
     }
 
     @Test
     public void testDefaultConfigurationHasNoAdditions() {
-        HtmlRenderer renderer = HtmlRenderer.builder()
-                .extensions(List.of(HeadingAnchorExtension.create()))
-                .build();
+        HtmlRenderer renderer =
+                HtmlRenderer.builder().extensions(List.of(HeadingAnchorExtension.create())).build();
         assertThat(doRender(renderer, "# ")).isEqualTo("<h1 id=\"id\"></h1>\n");
     }
 
@@ -53,5 +50,4 @@ public class HeadingAnchorConfigurationTest {
     private String doRender(HtmlRenderer renderer, String text) {
         return renderer.render(PARSER.parse(text));
     }
-
 }

--- a/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorTest.java
+++ b/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorTest.java
@@ -1,34 +1,35 @@
 package org.commonmark.ext.heading.anchor;
 
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
 public class HeadingAnchorTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(HeadingAnchorExtension.create());
     private static final Parser PARSER = Parser.builder().build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void baseCaseSingleHeader() {
-        assertRendering("# Heading here\n",
-                "<h1 id=\"heading-here\">Heading here</h1>\n");
+        assertRendering("# Heading here\n", "<h1 id=\"heading-here\">Heading here</h1>\n");
     }
 
     @Test
     public void singleHeaderWithCodeBlock() {
-        assertRendering("Hi there\n# Heading `here`\n",
+        assertRendering(
+                "Hi there\n# Heading `here`\n",
                 "<p>Hi there</p>\n<h1 id=\"heading-here\">Heading <code>here</code></h1>\n");
     }
 
     @Test
     public void duplicateHeadersMakeUniqueIds() {
-        assertRendering("# Heading here\n# Heading here",
+        assertRendering(
+                "# Heading here\n# Heading here",
                 "<h1 id=\"heading-here\">Heading here</h1>\n<h1 id=\"heading-here-1\">Heading here</h1>\n");
     }
 
@@ -44,34 +45,40 @@ public class HeadingAnchorTest extends RenderingTestCase {
 
     @Test
     public void testExplicitHeaderCollision() {
-        assertRendering("# Header\n# Header\n# Header-1",
-                "<h1 id=\"header\">Header</h1>\n" +
-                        "<h1 id=\"header-1\">Header</h1>\n" +
-                        "<h1 id=\"header-1\">Header-1</h1>\n");
+        assertRendering(
+                "# Header\n# Header\n# Header-1",
+                "<h1 id=\"header\">Header</h1>\n"
+                        + "<h1 id=\"header-1\">Header</h1>\n"
+                        + "<h1 id=\"header-1\">Header-1</h1>\n");
     }
 
     @Test
     public void testCaseIsIgnoredWhenComparingIds() {
-        assertRendering("# HEADING here\n" +
-                        "# heading here",
-                "<h1 id=\"heading-here\">HEADING here</h1>\n" +
-                        "<h1 id=\"heading-here-1\">heading here</h1>\n");
+        assertRendering(
+                "# HEADING here\n" + "# heading here",
+                "<h1 id=\"heading-here\">HEADING here</h1>\n"
+                        + "<h1 id=\"heading-here-1\">heading here</h1>\n");
     }
 
     @Test
     public void testNestedBlocks() {
-        assertRendering("## `h` `e` **l** *l* o",
+        assertRendering(
+                "## `h` `e` **l** *l* o",
                 "<h2 id=\"h-e-l-l-o\"><code>h</code> <code>e</code> <strong>l</strong> <em>l</em> o</h2>\n");
     }
 
     @Test
     public void boldEmphasisCharacters() {
-        assertRendering("# _hello_ **there**", "<h1 id=\"hello-there\"><em>hello</em> <strong>there</strong></h1>\n");
+        assertRendering(
+                "# _hello_ **there**",
+                "<h1 id=\"hello-there\"><em>hello</em> <strong>there</strong></h1>\n");
     }
 
     @Test
     public void testStrongEmphasis() {
-        assertRendering("# _**Hi there**_", "<h1 id=\"hi-there\"><em><strong>Hi there</strong></em></h1>\n");
+        assertRendering(
+                "# _**Hi there**_",
+                "<h1 id=\"hi-there\"><em><strong>Hi there</strong></em></h1>\n");
     }
 
     @Test
@@ -86,7 +93,9 @@ public class HeadingAnchorTest extends RenderingTestCase {
 
     @Test
     public void testCombiningDiaeresis() {
-        assertRendering("# Product\u036D\u036B", "<h1 id=\"product\u036D\u036B\">Product\u036D\u036B</h1>\n");
+        assertRendering(
+                "# Product\u036D\u036B",
+                "<h1 id=\"product\u036D\u036B\">Product\u036D\u036B</h1>\n");
     }
 
     @Override

--- a/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/ImageAttributes.java
+++ b/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/ImageAttributes.java
@@ -1,13 +1,10 @@
 package org.commonmark.ext.image.attributes;
 
+import java.util.Map;
 import org.commonmark.node.CustomNode;
 import org.commonmark.node.Delimited;
 
-import java.util.Map;
-
-/**
- * A node containing text and other inline nodes as children.
- */
+/** A node containing text and other inline nodes as children. */
 public class ImageAttributes extends CustomNode implements Delimited {
 
     private final Map<String, String> attributes;

--- a/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/ImageAttributesExtension.java
+++ b/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/ImageAttributesExtension.java
@@ -8,18 +8,17 @@ import org.commonmark.renderer.html.HtmlRenderer;
 
 /**
  * Extension for adding attributes to image nodes.
- * <p>
- * Create it with {@link #create()} and then configure it on the builders
- * ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)},
- * {@link HtmlRenderer.Builder#extensions(Iterable)}).
- * </p>
+ *
+ * <p>Create it with {@link #create()} and then configure it on the builders ({@link
+ * org.commonmark.parser.Parser.Builder#extensions(Iterable)}, {@link
+ * HtmlRenderer.Builder#extensions(Iterable)}).
  *
  * @since 0.15.0
  */
-public class ImageAttributesExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension {
+public class ImageAttributesExtension
+        implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension {
 
-    private ImageAttributesExtension() {
-    }
+    private ImageAttributesExtension() {}
 
     public static Extension create() {
         return new ImageAttributesExtension();
@@ -32,6 +31,7 @@ public class ImageAttributesExtension implements Parser.ParserExtension, HtmlRen
 
     @Override
     public void extend(HtmlRenderer.Builder rendererBuilder) {
-        rendererBuilder.attributeProviderFactory(context -> ImageAttributesAttributeProvider.create());
+        rendererBuilder.attributeProviderFactory(
+                context -> ImageAttributesAttributeProvider.create());
     }
 }

--- a/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesAttributeProvider.java
+++ b/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesAttributeProvider.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.image.attributes.internal;
 
+import java.util.*;
 import org.commonmark.ext.image.attributes.ImageAttributes;
 import org.commonmark.node.AbstractVisitor;
 import org.commonmark.node.CustomNode;
@@ -7,12 +8,9 @@ import org.commonmark.node.Image;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.html.AttributeProvider;
 
-import java.util.*;
-
 public class ImageAttributesAttributeProvider implements AttributeProvider {
 
-    private ImageAttributesAttributeProvider() {
-    }
+    private ImageAttributesAttributeProvider() {}
 
     public static ImageAttributesAttributeProvider create() {
         return new ImageAttributesAttributeProvider();
@@ -21,17 +19,18 @@ public class ImageAttributesAttributeProvider implements AttributeProvider {
     @Override
     public void setAttributes(Node node, String tagName, final Map<String, String> attributes) {
         if (node instanceof Image) {
-            node.accept(new AbstractVisitor() {
-                @Override
-                public void visit(CustomNode node) {
-                    if (node instanceof ImageAttributes) {
-                        ImageAttributes imageAttributes = (ImageAttributes) node;
-                        attributes.putAll(imageAttributes.getAttributes());
-                        // Now that we have used the image attributes we remove the node.
-                        imageAttributes.unlink();
-                    }
-                }
-            });
+            node.accept(
+                    new AbstractVisitor() {
+                        @Override
+                        public void visit(CustomNode node) {
+                            if (node instanceof ImageAttributes) {
+                                ImageAttributes imageAttributes = (ImageAttributes) node;
+                                attributes.putAll(imageAttributes.getAttributes());
+                                // Now that we have used the image attributes we remove the node.
+                                imageAttributes.unlink();
+                            }
+                        }
+                    });
         }
     }
 }

--- a/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesDelimiterProcessor.java
+++ b/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesDelimiterProcessor.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.image.attributes.internal;
 
+import java.util.*;
 import org.commonmark.ext.image.attributes.ImageAttributes;
 import org.commonmark.node.Image;
 import org.commonmark.node.Node;
@@ -7,8 +8,6 @@ import org.commonmark.node.Nodes;
 import org.commonmark.node.Text;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 import org.commonmark.parser.delimiter.DelimiterRun;
-
-import java.util.*;
 
 public class ImageAttributesDelimiterProcessor implements DelimiterProcessor {
 
@@ -36,8 +35,8 @@ public class ImageAttributesDelimiterProcessor implements DelimiterProcessor {
             return 0;
         }
 
-        // Check if the attributes can be applied - if the previous node is an Image, and if all the attributes are in
-        // the set of SUPPORTED_ATTRIBUTES
+        // Check if the attributes can be applied - if the previous node is an Image, and if all the
+        // attributes are in the set of SUPPORTED_ATTRIBUTES
         Text opener = openingRun.getOpener();
         Node nodeToStyle = opener.getPrevious();
         if (!(nodeToStyle instanceof Image)) {
@@ -53,7 +52,8 @@ public class ImageAttributesDelimiterProcessor implements DelimiterProcessor {
                 content.append(((Text) node).getLiteral());
                 toUnlink.add(node);
             } else {
-                // This node type is not supported, so stop here (no need to check any further ones).
+                // This node type is not supported, so stop here (no need to check any further
+                // ones).
                 return 0;
             }
         }
@@ -65,7 +65,8 @@ public class ImageAttributesDelimiterProcessor implements DelimiterProcessor {
             if (attribute.length > 1 && SUPPORTED_ATTRIBUTES.contains(attribute[0].toLowerCase())) {
                 attributesMap.put(attribute[0], attribute[1]);
             } else {
-                // This attribute is not supported, so stop here (no need to check any further ones).
+                // This attribute is not supported, so stop here (no need to check any further
+                // ones).
                 return 0;
             }
         }

--- a/commonmark-ext-image-attributes/src/test/java/org/commonmark/ext/image/attributes/ImageAttributesTest.java
+++ b/commonmark-ext-image-attributes/src/test/java/org/commonmark/ext/image/attributes/ImageAttributesTest.java
@@ -1,5 +1,9 @@
 package org.commonmark.ext.image.attributes;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.Node;
 import org.commonmark.node.Paragraph;
@@ -10,44 +14,48 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class ImageAttributesTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(ImageAttributesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void baseCase() {
-        assertRendering("![text](/url.png){height=5}",
+        assertRendering(
+                "![text](/url.png){height=5}",
                 "<p><img src=\"/url.png\" alt=\"text\" height=\"5\" /></p>\n");
 
-        assertRendering("![text](/url.png){height=5 width=6}",
+        assertRendering(
+                "![text](/url.png){height=5 width=6}",
                 "<p><img src=\"/url.png\" alt=\"text\" height=\"5\" width=\"6\" /></p>\n");
 
-        assertRendering("![text](/url.png){height=99px   width=100px}",
+        assertRendering(
+                "![text](/url.png){height=99px   width=100px}",
                 "<p><img src=\"/url.png\" alt=\"text\" height=\"99px\" width=\"100px\" /></p>\n");
 
-        assertRendering("![text](/url.png){width=100 height=100}",
+        assertRendering(
+                "![text](/url.png){width=100 height=100}",
                 "<p><img src=\"/url.png\" alt=\"text\" width=\"100\" height=\"100\" /></p>\n");
 
-        assertRendering("![text](/url.png){height=4.8 width=3.14}",
+        assertRendering(
+                "![text](/url.png){height=4.8 width=3.14}",
                 "<p><img src=\"/url.png\" alt=\"text\" height=\"4.8\" width=\"3.14\" /></p>\n");
 
-        assertRendering("![text](/url.png){Width=18 HeIgHt=1001}",
+        assertRendering(
+                "![text](/url.png){Width=18 HeIgHt=1001}",
                 "<p><img src=\"/url.png\" alt=\"text\" Width=\"18\" HeIgHt=\"1001\" /></p>\n");
 
-        assertRendering("![text](/url.png){height=green width=blue}",
+        assertRendering(
+                "![text](/url.png){height=green width=blue}",
                 "<p><img src=\"/url.png\" alt=\"text\" height=\"green\" width=\"blue\" /></p>\n");
     }
 
     @Test
     public void doubleDelimiters() {
-        assertRendering("![text](/url.png){{height=5}}",
+        assertRendering(
+                "![text](/url.png){{height=5}}",
                 "<p><img src=\"/url.png\" alt=\"text\" />{{height=5}}</p>\n");
     }
 
@@ -58,55 +66,66 @@ public class ImageAttributesTest extends RenderingTestCase {
 
     @Test
     public void unsupportedStyleNamesAreLeftUnchanged() {
-        assertRendering("![text](/url.png){j=502 K=101 img=2 url=5}",
+        assertRendering(
+                "![text](/url.png){j=502 K=101 img=2 url=5}",
                 "<p><img src=\"/url.png\" alt=\"text\" />{j=502 K=101 img=2 url=5}</p>\n");
-        assertRendering("![foo](/url.png){height=3 invalid}\n",
+        assertRendering(
+                "![foo](/url.png){height=3 invalid}\n",
                 "<p><img src=\"/url.png\" alt=\"foo\" />{height=3 invalid}</p>\n");
-        assertRendering("![foo](/url.png){height=3 *test*}\n",
+        assertRendering(
+                "![foo](/url.png){height=3 *test*}\n",
                 "<p><img src=\"/url.png\" alt=\"foo\" />{height=3 <em>test</em>}</p>\n");
     }
 
     @Test
     public void styleWithNoValueIsIgnored() {
-        assertRendering("![text](/url.png){height}",
+        assertRendering(
+                "![text](/url.png){height}",
                 "<p><img src=\"/url.png\" alt=\"text\" />{height}</p>\n");
     }
 
     @Test
     public void repeatedStyleNameUsesFinalOne() {
-        assertRendering("![text](/url.png){height=4 height=5 width=1 height=6}",
+        assertRendering(
+                "![text](/url.png){height=4 height=5 width=1 height=6}",
                 "<p><img src=\"/url.png\" alt=\"text\" height=\"6\" width=\"1\" /></p>\n");
     }
 
     @Test
     public void styleValuesAreEscaped() {
-        assertRendering("![text](/url.png){height=<img}",
+        assertRendering(
+                "![text](/url.png){height=<img}",
                 "<p><img src=\"/url.png\" alt=\"text\" height=\"&lt;img\" /></p>\n");
-        assertRendering("![text](/url.png){height=\"\"img}",
+        assertRendering(
+                "![text](/url.png){height=\"\"img}",
                 "<p><img src=\"/url.png\" alt=\"text\" height=\"&quot;&quot;img\" /></p>\n");
     }
 
     @Test
     public void imageAltTextWithSpaces() {
-        assertRendering("![Android SDK Manager](/contrib/android-sdk-manager.png){height=502 width=101}",
+        assertRendering(
+                "![Android SDK Manager](/contrib/android-sdk-manager.png){height=502 width=101}",
                 "<p><img src=\"/contrib/android-sdk-manager.png\" alt=\"Android SDK Manager\" height=\"502\" width=\"101\" /></p>\n");
     }
 
     @Test
     public void imageAltTextWithSoftLineBreak() {
-        assertRendering("![foo\nbar](/url){height=101 width=202}\n",
+        assertRendering(
+                "![foo\nbar](/url){height=101 width=202}\n",
                 "<p><img src=\"/url\" alt=\"foo\nbar\" height=\"101\" width=\"202\" /></p>\n");
     }
 
     @Test
     public void imageAltTextWithHardLineBreak() {
-        assertRendering("![foo  \nbar](/url){height=506 width=1}\n",
+        assertRendering(
+                "![foo  \nbar](/url){height=506 width=1}\n",
                 "<p><img src=\"/url\" alt=\"foo\nbar\" height=\"506\" width=\"1\" /></p>\n");
     }
 
     @Test
     public void imageAltTextWithEntities() {
-        assertRendering("![foo &auml;](/url){height=99 width=100}\n",
+        assertRendering(
+                "![foo &auml;](/url){height=99 width=100}\n",
                 "<p><img src=\"/url\" alt=\"foo \u00E4\" height=\"99\" width=\"100\" /></p>\n");
     }
 
@@ -114,20 +133,24 @@ public class ImageAttributesTest extends RenderingTestCase {
     public void textNodesAreUnchanged() {
         assertRendering("x{height=3 width=4}\n", "<p>x{height=3 width=4}</p>\n");
         assertRendering("x {height=3 width=4}\n", "<p>x {height=3 width=4}</p>\n");
-        assertRendering("\\documentclass[12pt]{article}\n", "<p>\\documentclass[12pt]{article}</p>\n");
-        assertRendering("some *text*{height=3 width=4}\n", "<p>some <em>text</em>{height=3 width=4}</p>\n");
+        assertRendering(
+                "\\documentclass[12pt]{article}\n", "<p>\\documentclass[12pt]{article}</p>\n");
+        assertRendering(
+                "some *text*{height=3 width=4}\n", "<p>some <em>text</em>{height=3 width=4}</p>\n");
         assertRendering("{NN} text", "<p>{NN} text</p>\n");
         assertRendering("{}", "<p>{}</p>\n");
     }
 
     @Test
     public void sourceSpans() {
-        Parser parser = Parser.builder()
-                .extensions(EXTENSIONS)
-                .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
-                .build();
+        Parser parser =
+                Parser.builder()
+                        .extensions(EXTENSIONS)
+                        .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                        .build();
 
-        // This doesn't result in image attributes, so source spans should be for the single (merged) text node.
+        // This doesn't result in image attributes, so source spans should be for the single
+        // (merged) text node.
         Node document = parser.parse("x{height=3 width=4}\n");
         Paragraph block = (Paragraph) document.getFirstChild();
         Node text = block.getFirstChild();

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/Ins.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/Ins.java
@@ -3,9 +3,7 @@ package org.commonmark.ext.ins;
 import org.commonmark.node.CustomNode;
 import org.commonmark.node.Delimited;
 
-/**
- * An ins node containing text and other inline nodes as children.
- */
+/** An ins node containing text and other inline nodes as children. */
 public class Ins extends CustomNode implements Delimited {
 
     private static final String DELIMITER = "++";

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/InsExtension.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/InsExtension.java
@@ -1,5 +1,6 @@
 package org.commonmark.ext.ins;
 
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.ext.ins.internal.InsDelimiterProcessor;
 import org.commonmark.ext.ins.internal.InsHtmlNodeRenderer;
@@ -13,23 +14,22 @@ import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.commonmark.renderer.text.TextContentRenderer;
 
-import java.util.Set;
-
 /**
  * Extension for ins using ++
- * <p>
- * Create it with {@link #create()} and then configure it on the builders
- * ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)},
- * {@link HtmlRenderer.Builder#extensions(Iterable)}).
- * </p>
- * <p>
- * The parsed ins text regions are turned into {@link Ins} nodes.
- * </p>
+ *
+ * <p>Create it with {@link #create()} and then configure it on the builders ({@link
+ * org.commonmark.parser.Parser.Builder#extensions(Iterable)}, {@link
+ * HtmlRenderer.Builder#extensions(Iterable)}).
+ *
+ * <p>The parsed ins text regions are turned into {@link Ins} nodes.
  */
-public class InsExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension, TextContentRenderer.TextContentRendererExtension, MarkdownRenderer.MarkdownRendererExtension {
+public class InsExtension
+        implements Parser.ParserExtension,
+                HtmlRenderer.HtmlRendererExtension,
+                TextContentRenderer.TextContentRendererExtension,
+                MarkdownRenderer.MarkdownRendererExtension {
 
-    private InsExtension() {
-    }
+    private InsExtension() {}
 
     public static Extension create() {
         return new InsExtension();
@@ -52,18 +52,20 @@ public class InsExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRe
 
     @Override
     public void extend(MarkdownRenderer.Builder rendererBuilder) {
-        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(MarkdownNodeRendererContext context) {
-                return new InsMarkdownNodeRenderer(context);
-            }
+        rendererBuilder.nodeRendererFactory(
+                new MarkdownNodeRendererFactory() {
+                    @Override
+                    public NodeRenderer create(MarkdownNodeRendererContext context) {
+                        return new InsMarkdownNodeRenderer(context);
+                    }
 
-            @Override
-            public Set<Character> getSpecialCharacters() {
-                // We technically don't need to escape single occurrences of +, but that's all the extension API
-                // exposes currently.
-                return Set.of('+');
-            }
-        });
+                    @Override
+                    public Set<Character> getSpecialCharacters() {
+                        // We technically don't need to escape single occurrences of +, but that's
+                        // all the extension API
+                        // exposes currently.
+                        return Set.of('+');
+                    }
+                });
     }
 }

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsDelimiterProcessor.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsDelimiterProcessor.java
@@ -28,7 +28,8 @@ public class InsDelimiterProcessor implements DelimiterProcessor {
     @Override
     public int process(DelimiterRun openingRun, DelimiterRun closingRun) {
         if (openingRun.length() >= 2 && closingRun.length() >= 2) {
-            // Use exactly two delimiters even if we have more, and don't care about internal openers/closers.
+            // Use exactly two delimiters even if we have more, and don't care about internal
+            // openers/closers.
 
             Text opener = openingRun.getOpener();
 

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsHtmlNodeRenderer.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsHtmlNodeRenderer.java
@@ -1,10 +1,9 @@
 package org.commonmark.ext.ins.internal;
 
+import java.util.Map;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlWriter;
-
-import java.util.Map;
 
 public class InsHtmlNodeRenderer extends InsNodeRenderer {
 

--- a/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsNodeRenderer.java
+++ b/commonmark-ext-ins/src/main/java/org/commonmark/ext/ins/internal/InsNodeRenderer.java
@@ -1,10 +1,9 @@
 package org.commonmark.ext.ins.internal;
 
+import java.util.Set;
 import org.commonmark.ext.ins.Ins;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.NodeRenderer;
-
-import java.util.Set;
 
 abstract class InsNodeRenderer implements NodeRenderer {
 

--- a/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsMarkdownRendererTest.java
+++ b/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsMarkdownRendererTest.java
@@ -1,19 +1,19 @@
 package org.commonmark.ext.ins;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class InsMarkdownRendererTest {
 
     private static final Set<Extension> EXTENSIONS = Set.of(InsExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER =
+            MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void testStrikethrough() {

--- a/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsTest.java
+++ b/commonmark-ext-ins/src/test/java/org/commonmark/ext/ins/InsTest.java
@@ -1,5 +1,9 @@
 package org.commonmark.ext.ins;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.Node;
 import org.commonmark.node.Paragraph;
@@ -11,18 +15,14 @@ import org.commonmark.renderer.text.TextContentRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class InsTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(InsExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
-    private static final TextContentRenderer CONTENT_RENDERER = TextContentRenderer.builder()
-            .extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final TextContentRenderer CONTENT_RENDERER =
+            TextContentRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void onePlusIsNotEnough() {
@@ -68,13 +68,15 @@ public class InsTest extends RenderingTestCase {
 
     @Test
     public void insWholeParagraphWithOtherDelimiters() {
-        assertRendering("++Paragraph with *emphasis* and __strong emphasis__++",
+        assertRendering(
+                "++Paragraph with *emphasis* and __strong emphasis__++",
                 "<p><ins>Paragraph with <em>emphasis</em> and <strong>strong emphasis</strong></ins></p>\n");
     }
 
     @Test
     public void insideBlockQuote() {
-        assertRendering("> underline ++that++",
+        assertRendering(
+                "> underline ++that++",
                 "<blockquote>\n<p>underline <ins>that</ins></p>\n</blockquote>\n");
     }
 
@@ -94,10 +96,11 @@ public class InsTest extends RenderingTestCase {
 
     @Test
     public void sourceSpans() {
-        Parser parser = Parser.builder()
-                .extensions(EXTENSIONS)
-                .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
-                .build();
+        Parser parser =
+                Parser.builder()
+                        .extensions(EXTENSIONS)
+                        .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                        .build();
 
         Node document = parser.parse("hey ++there++\n");
         Paragraph block = (Paragraph) document.getFirstChild();

--- a/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/TaskListItemMarker.java
+++ b/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/TaskListItemMarker.java
@@ -2,9 +2,7 @@ package org.commonmark.ext.task.list.items;
 
 import org.commonmark.node.CustomNode;
 
-/**
- * A marker node indicating that a list item contains a task.
- */
+/** A marker node indicating that a list item contains a task. */
 public class TaskListItemMarker extends CustomNode {
 
     private final boolean checked;

--- a/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/TaskListItemsExtension.java
+++ b/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/TaskListItemsExtension.java
@@ -14,19 +14,19 @@ import org.commonmark.renderer.markdown.MarkdownRenderer;
 
 /**
  * Extension for adding task list items.
- * <p>
- * Create it with {@link #create()} and then configure it on the builders
- * ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)},
- * {@link HtmlRenderer.Builder#extensions(Iterable)}).
- * </p>
+ *
+ * <p>Create it with {@link #create()} and then configure it on the builders ({@link
+ * org.commonmark.parser.Parser.Builder#extensions(Iterable)}, {@link
+ * HtmlRenderer.Builder#extensions(Iterable)}).
  *
  * @since 0.15.0
  */
-public class TaskListItemsExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension,
-        MarkdownRenderer.MarkdownRendererExtension {
+public class TaskListItemsExtension
+        implements Parser.ParserExtension,
+                HtmlRenderer.HtmlRendererExtension,
+                MarkdownRenderer.MarkdownRendererExtension {
 
-    private TaskListItemsExtension() {
-    }
+    private TaskListItemsExtension() {}
 
     public static Extension create() {
         return new TaskListItemsExtension();
@@ -44,16 +44,17 @@ public class TaskListItemsExtension implements Parser.ParserExtension, HtmlRende
 
     @Override
     public void extend(MarkdownRenderer.Builder rendererBuilder) {
-        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(MarkdownNodeRendererContext context) {
-                return new TaskListItemMarkdownNodeRenderer(context);
-            }
+        rendererBuilder.nodeRendererFactory(
+                new MarkdownNodeRendererFactory() {
+                    @Override
+                    public NodeRenderer create(MarkdownNodeRendererContext context) {
+                        return new TaskListItemMarkdownNodeRenderer(context);
+                    }
 
-            @Override
-            public Set<Character> getSpecialCharacters() {
-                return Set.of();
-            }
-        });
+                    @Override
+                    public Set<Character> getSpecialCharacters() {
+                        return Set.of();
+                    }
+                });
     }
 }

--- a/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/internal/TaskListItemHtmlNodeRenderer.java
+++ b/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/internal/TaskListItemHtmlNodeRenderer.java
@@ -1,12 +1,11 @@
 package org.commonmark.ext.task.list.items.internal;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.commonmark.ext.task.list.items.TaskListItemMarker;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlWriter;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 public class TaskListItemHtmlNodeRenderer extends TaskListItemNodeRenderer {
 

--- a/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/internal/TaskListItemPostProcessor.java
+++ b/commonmark-ext-task-list-items/src/main/java/org/commonmark/ext/task/list/items/internal/TaskListItemPostProcessor.java
@@ -1,12 +1,11 @@
 package org.commonmark.ext.task.list.items.internal;
 
-import org.commonmark.ext.task.list.items.TaskListItemMarker;
-import org.commonmark.node.*;
-import org.commonmark.parser.PostProcessor;
-
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.commonmark.ext.task.list.items.TaskListItemMarker;
+import org.commonmark.node.*;
+import org.commonmark.parser.PostProcessor;
 
 public class TaskListItemPostProcessor implements PostProcessor {
 
@@ -31,14 +30,16 @@ public class TaskListItemPostProcessor implements PostProcessor {
                     Matcher matcher = REGEX_TASK_LIST_ITEM.matcher(textNode.getLiteral());
                     if (matcher.matches()) {
                         String checked = matcher.group(1);
-                        boolean isChecked = Objects.equals(checked, "X") || Objects.equals(checked, "x");
+                        boolean isChecked =
+                                Objects.equals(checked, "X") || Objects.equals(checked, "x");
 
                         // Add the task list item marker node as the first child of the list item.
                         listItem.prependChild(new TaskListItemMarker(isChecked));
 
-                        // Parse the node using the input after the task marker (in other words, group 2 from the matcher).
-                        // (Note that the String has been trimmed, so we should add a space between the
-                        // TaskListItemMarker and the text that follows it when we come to render it).
+                        // Parse the node using the input after the task marker (in other words,
+                        // group 2 from the matcher). (Note that the String has been trimmed, so we
+                        // should add a space between the TaskListItemMarker and the text that
+                        // follows it when we come to render it).
                         textNode.setLiteral(matcher.group(2));
                     }
                 }

--- a/commonmark-ext-task-list-items/src/test/java/org/commonmark/ext/task/list/items/TaskListItemMarkdownRendererTest.java
+++ b/commonmark-ext-task-list-items/src/test/java/org/commonmark/ext/task/list/items/TaskListItemMarkdownRendererTest.java
@@ -1,5 +1,7 @@
 package org.commonmark.ext.task.list.items;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.BulletList;
@@ -12,13 +14,12 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class TaskListItemMarkdownRendererTest {
 
     private static final Set<Extension> EXTENSIONS = Set.of(TaskListItemsExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER =
+            MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void testCheckedRoundTrip() {

--- a/commonmark-ext-task-list-items/src/test/java/org/commonmark/ext/task/list/items/TaskListItemsTest.java
+++ b/commonmark-ext-task-list-items/src/test/java/org/commonmark/ext/task/list/items/TaskListItemsTest.java
@@ -1,87 +1,116 @@
 package org.commonmark.ext.task.list.items;
 
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
 public class TaskListItemsTest extends RenderingTestCase {
 
     private static final Set<Extension> EXTENSIONS = Set.of(TaskListItemsExtension.create());
-    private static final String HTML_CHECKED = "<input type=\"checkbox\" disabled=\"\" checked=\"\">";
+    private static final String HTML_CHECKED =
+            "<input type=\"checkbox\" disabled=\"\" checked=\"\">";
     private static final String HTML_UNCHECKED = "<input type=\"checkbox\" disabled=\"\">";
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void baseCase() {
-        assertRendering("- [x] this is *done*\n", "<ul>\n<li>" + HTML_CHECKED + " this is <em>done</em></li>\n</ul>\n");
+        assertRendering(
+                "- [x] this is *done*\n",
+                "<ul>\n<li>" + HTML_CHECKED + " this is <em>done</em></li>\n</ul>\n");
 
-        assertRendering("- [ ] do this\n", "<ul>\n<li>" + HTML_UNCHECKED + " do this</li>\n</ul>\n");
+        assertRendering(
+                "- [ ] do this\n", "<ul>\n<li>" + HTML_UNCHECKED + " do this</li>\n</ul>\n");
 
-        assertRendering("- [x] foo\n" +
-                        "  - [ ] bar\n" +
-                        "  - [x] baz\n" +
-                        "- [ ] bim",
-                "<ul>\n" +
-                "<li>" + HTML_CHECKED + " foo\n" +
-                "<ul>\n" +
-                "<li>" + HTML_UNCHECKED + " bar</li>\n" +
-                "<li>" + HTML_CHECKED + " baz</li>\n" +
-                "</ul>\n" +
-                "</li>\n" +
-                "<li>" + HTML_UNCHECKED + " bim</li>\n" +
-                "</ul>\n");
+        assertRendering(
+                "- [x] foo\n" + "  - [ ] bar\n" + "  - [x] baz\n" + "- [ ] bim",
+                "<ul>\n"
+                        + "<li>"
+                        + HTML_CHECKED
+                        + " foo\n"
+                        + "<ul>\n"
+                        + "<li>"
+                        + HTML_UNCHECKED
+                        + " bar</li>\n"
+                        + "<li>"
+                        + HTML_CHECKED
+                        + " baz</li>\n"
+                        + "</ul>\n"
+                        + "</li>\n"
+                        + "<li>"
+                        + HTML_UNCHECKED
+                        + " bim</li>\n"
+                        + "</ul>\n");
 
-        assertRendering("*   [ ]   do this\n*   [ ]   and this",
-                "<ul>\n<li>" + HTML_UNCHECKED + " do this</li>\n<li>" + HTML_UNCHECKED + " and this</li>\n</ul>\n");
+        assertRendering(
+                "*   [ ]   do this\n*   [ ]   and this",
+                "<ul>\n<li>"
+                        + HTML_UNCHECKED
+                        + " do this</li>\n<li>"
+                        + HTML_UNCHECKED
+                        + " and this</li>\n</ul>\n");
 
-        assertRendering("+ [x] one\n" +
-                        "  - [ ] two\n" +
-                        "    * [x] three\n",
-                "<ul>\n" +
-                "<li>" + HTML_CHECKED + " one\n" +
-                "<ul>\n" +
-                "<li>" + HTML_UNCHECKED + " two\n" +
-                "<ul>\n" +
-                "<li>" + HTML_CHECKED + " three</li>\n" +
-                "</ul>\n" +
-                "</li>\n" +
-                "</ul>\n" +
-                "</li>\n" +
-                "</ul>\n");
+        assertRendering(
+                "+ [x] one\n" + "  - [ ] two\n" + "    * [x] three\n",
+                "<ul>\n"
+                        + "<li>"
+                        + HTML_CHECKED
+                        + " one\n"
+                        + "<ul>\n"
+                        + "<li>"
+                        + HTML_UNCHECKED
+                        + " two\n"
+                        + "<ul>\n"
+                        + "<li>"
+                        + HTML_CHECKED
+                        + " three</li>\n"
+                        + "</ul>\n"
+                        + "</li>\n"
+                        + "</ul>\n"
+                        + "</li>\n"
+                        + "</ul>\n");
 
-        assertRendering("TODO list\n" +
-                        "---------\n" +
-                        "- [ ] first task\n" +
-                        "- [x] second task\n" +
-                        "- [ ] third task\n\n" +
-                        "Let me know when you are finished",
-                "<h2>TODO list</h2>\n" +
-                "<ul>\n" +
-                "<li>" + HTML_UNCHECKED + " first task</li>\n" +
-                "<li>" + HTML_CHECKED + " second task</li>\n" +
-                "<li>" + HTML_UNCHECKED + " third task</li>\n" +
-                "</ul>\n" +
-                "<p>Let me know when you are finished</p>\n");
+        assertRendering(
+                "TODO list\n"
+                        + "---------\n"
+                        + "- [ ] first task\n"
+                        + "- [x] second task\n"
+                        + "- [ ] third task\n\n"
+                        + "Let me know when you are finished",
+                "<h2>TODO list</h2>\n"
+                        + "<ul>\n"
+                        + "<li>"
+                        + HTML_UNCHECKED
+                        + " first task</li>\n"
+                        + "<li>"
+                        + HTML_CHECKED
+                        + " second task</li>\n"
+                        + "<li>"
+                        + HTML_UNCHECKED
+                        + " third task</li>\n"
+                        + "</ul>\n"
+                        + "<p>Let me know when you are finished</p>\n");
     }
 
     @Test
     public void notListItem() {
         assertRendering("[x] this is not a task\n", "<p>[x] this is not a task</p>\n");
-        assertRendering(" [ ] this is not a task either\n", "<p>[ ] this is not a task either</p>\n");
+        assertRendering(
+                " [ ] this is not a task either\n", "<p>[ ] this is not a task either</p>\n");
     }
 
     @Test
     public void notValidTaskFormat() {
         assertRendering("- [x]no space\n", "<ul>\n<li>[x]no space</li>\n</ul>\n");
-        assertRendering("- [O] is not a _task_\n", "<ul>\n<li>[O] is not a <em>task</em></li>\n</ul>\n");
+        assertRendering(
+                "- [O] is not a _task_\n", "<ul>\n<li>[O] is not a <em>task</em></li>\n</ul>\n");
         assertRendering("* [] neither is this\n", "<ul>\n<li>[] neither is this</li>\n</ul>\n");
-        assertRendering("* [  ] nor this\n" +
-                        "* [XX] nor this\n",
+        assertRendering(
+                "* [  ] nor this\n" + "* [XX] nor this\n",
                 "<ul>\n<li>[  ] nor this</li>\n<li>[XX] nor this</li>\n</ul>\n");
         assertRendering("+ [x]] is not a task\n", "<ul>\n<li>[x]] is not a task</li>\n</ul>\n");
         assertRendering("- [x isn't\n", "<ul>\n<li>[x isn't</li>\n</ul>\n");
@@ -91,7 +120,9 @@ public class TaskListItemsTest extends RenderingTestCase {
         assertRendering("+ (x) sorry no\n", "<ul>\n<li>(x) sorry no</li>\n</ul>\n");
         assertRendering("+ {x} sorry not sorry\n", "<ul>\n<li>{x} sorry not sorry</li>\n</ul>\n");
         assertRendering("+ [[x]] nooo\n", "<ul>\n<li>[[x]] nooo</li>\n</ul>\n");
-        assertRendering("+ text before [x] is not a task\n", "<ul>\n<li>text before [x] is not a task</li>\n</ul>\n");
+        assertRendering(
+                "+ text before [x] is not a task\n",
+                "<ul>\n<li>text before [x] is not a task</li>\n</ul>\n");
         assertRendering("* [x]  \n* [ ]  \n", "<ul>\n<li>[x]</li>\n<li>[ ]</li>\n</ul>\n");
     }
 

--- a/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterBlock.java
+++ b/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterBlock.java
@@ -2,5 +2,4 @@ package org.commonmark.ext.front.matter;
 
 import org.commonmark.node.CustomBlock;
 
-public class YamlFrontMatterBlock extends CustomBlock {
-}
+public class YamlFrontMatterBlock extends CustomBlock {}

--- a/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterExtension.java
+++ b/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterExtension.java
@@ -13,19 +13,18 @@ import org.commonmark.renderer.markdown.MarkdownRenderer;
 
 /**
  * Extension for YAML-like metadata.
- * <p>
- * Create it with {@link #create()} and then configure it on the builders
- * ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)},
- * {@link HtmlRenderer.Builder#extensions(Iterable)}).
- * </p>
- * <p>
- * The parsed metadata is turned into {@link YamlFrontMatterNode}. You can access the metadata using {@link YamlFrontMatterVisitor}.
- * </p>
+ *
+ * <p>Create it with {@link #create()} and then configure it on the builders ({@link
+ * org.commonmark.parser.Parser.Builder#extensions(Iterable)}, {@link
+ * HtmlRenderer.Builder#extensions(Iterable)}).
+ *
+ * <p>The parsed metadata is turned into {@link YamlFrontMatterNode}. You can access the metadata
+ * using {@link YamlFrontMatterVisitor}.
  */
-public class YamlFrontMatterExtension implements Parser.ParserExtension, MarkdownRenderer.MarkdownRendererExtension {
+public class YamlFrontMatterExtension
+        implements Parser.ParserExtension, MarkdownRenderer.MarkdownRendererExtension {
 
-    private YamlFrontMatterExtension() {
-    }
+    private YamlFrontMatterExtension() {}
 
     @Override
     public void extend(Parser.Builder parserBuilder) {
@@ -38,16 +37,17 @@ public class YamlFrontMatterExtension implements Parser.ParserExtension, Markdow
 
     @Override
     public void extend(MarkdownRenderer.Builder rendererBuilder) {
-        rendererBuilder.nodeRendererFactory(new MarkdownNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(MarkdownNodeRendererContext context) {
-                return new YamlFrontMatterMarkdownNodeRenderer(context);
-            }
+        rendererBuilder.nodeRendererFactory(
+                new MarkdownNodeRendererFactory() {
+                    @Override
+                    public NodeRenderer create(MarkdownNodeRendererContext context) {
+                        return new YamlFrontMatterMarkdownNodeRenderer(context);
+                    }
 
-            @Override
-            public Set<Character> getSpecialCharacters() {
-                return Set.of();
-            }
-        });
+                    @Override
+                    public Set<Character> getSpecialCharacters() {
+                        return Set.of();
+                    }
+                });
     }
 }

--- a/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterNode.java
+++ b/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterNode.java
@@ -1,8 +1,7 @@
 package org.commonmark.ext.front.matter;
 
-import org.commonmark.node.CustomNode;
-
 import java.util.List;
+import org.commonmark.node.CustomNode;
 
 public class YamlFrontMatterNode extends CustomNode {
     private String key;

--- a/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterVisitor.java
+++ b/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterVisitor.java
@@ -1,11 +1,10 @@
 package org.commonmark.ext.front.matter;
 
-import org.commonmark.node.AbstractVisitor;
-import org.commonmark.node.CustomNode;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.commonmark.node.AbstractVisitor;
+import org.commonmark.node.CustomNode;
 
 public class YamlFrontMatterVisitor extends AbstractVisitor {
     private Map<String, List<String>> data;
@@ -17,7 +16,9 @@ public class YamlFrontMatterVisitor extends AbstractVisitor {
     @Override
     public void visit(CustomNode customNode) {
         if (customNode instanceof YamlFrontMatterNode) {
-            data.put(((YamlFrontMatterNode) customNode).getKey(), ((YamlFrontMatterNode) customNode).getValues());
+            data.put(
+                    ((YamlFrontMatterNode) customNode).getKey(),
+                    ((YamlFrontMatterNode) customNode).getValues());
         } else {
             super.visit(customNode);
         }

--- a/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/internal/YamlFrontMatterBlockParser.java
+++ b/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/internal/YamlFrontMatterBlockParser.java
@@ -1,18 +1,18 @@
 package org.commonmark.ext.front.matter.internal;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.commonmark.ext.front.matter.YamlFrontMatterBlock;
 import org.commonmark.ext.front.matter.YamlFrontMatterNode;
 import org.commonmark.node.Block;
 import org.commonmark.node.Document;
 import org.commonmark.parser.block.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class YamlFrontMatterBlockParser extends AbstractBlockParser {
-    private static final Pattern REGEX_METADATA = Pattern.compile("^[ ]{0,3}([A-Za-z0-9._-]+):\\s*(.*)");
+    private static final Pattern REGEX_METADATA =
+            Pattern.compile("^[ ]{0,3}([A-Za-z0-9._-]+):\\s*(.*)");
     private static final Pattern REGEX_METADATA_LIST = Pattern.compile("^[ ]+-\\s*(.*)");
     private static final Pattern REGEX_METADATA_LITERAL = Pattern.compile("^\\s*(.*)");
     private static final Pattern REGEX_BEGIN = Pattern.compile("^-{3}(\\s.*)?");
@@ -95,9 +95,7 @@ public class YamlFrontMatterBlockParser extends AbstractBlockParser {
         } else if (s.startsWith("\"") && s.endsWith("\"")) {
             String inner = s.substring(1, s.length() - 1);
             // Only support escaped `\` and `"`, nothing else.
-            return inner
-                    .replace("\\\"", "\"")
-                    .replace("\\\\", "\\");
+            return inner.replace("\\\"", "\"").replace("\\\\", "\\");
         } else {
             return s;
         }
@@ -109,9 +107,11 @@ public class YamlFrontMatterBlockParser extends AbstractBlockParser {
             CharSequence line = state.getLine().getContent();
             BlockParser parentParser = matchedBlockParser.getMatchedBlockParser();
             // check whether this line is the first line of whole document or not
-            if (parentParser.getBlock() instanceof Document && parentParser.getBlock().getFirstChild() == null &&
-                    REGEX_BEGIN.matcher(line).matches()) {
-                return BlockStart.of(new YamlFrontMatterBlockParser()).atIndex(state.getNextNonSpaceIndex());
+            if (parentParser.getBlock() instanceof Document
+                    && parentParser.getBlock().getFirstChild() == null
+                    && REGEX_BEGIN.matcher(line).matches()) {
+                return BlockStart.of(new YamlFrontMatterBlockParser())
+                        .atIndex(state.getNextNonSpaceIndex());
             }
 
             return BlockStart.none();

--- a/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterMarkdownRendererTest.java
+++ b/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterMarkdownRendererTest.java
@@ -1,5 +1,8 @@
 package org.commonmark.ext.front.matter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.commonmark.Extension;
 import org.commonmark.node.Document;
 import org.commonmark.node.Node;
@@ -9,15 +12,12 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class YamlFrontMatterMarkdownRendererTest {
 
     private static final List<Extension> EXTENSIONS = List.of(YamlFrontMatterExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER =
+            MarkdownRenderer.builder().extensions(EXTENSIONS).build();
 
     // ===== Round-trip tests (parse string -> render -> compare to input) =====
 
@@ -43,7 +43,8 @@ public class YamlFrontMatterMarkdownRendererTest {
 
     @Test
     public void testRoundTripLiteralBlock() {
-        assertRoundTrip("---\ndescription: |\n  first line\n  second line\n---\n\nMarkdown content\n");
+        assertRoundTrip(
+                "---\ndescription: |\n  first line\n  second line\n---\n\nMarkdown content\n");
     }
 
     @Test
@@ -84,7 +85,9 @@ public class YamlFrontMatterMarkdownRendererTest {
 
     @Test
     public void testProgrammaticallyBuilt() {
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("title", List.of("My Document"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("title", List.of("My Document"))));
 
         assertRenderedEquals(doc, "---\ntitle: My Document\n---\n\nMarkdown content\n");
     }
@@ -93,29 +96,40 @@ public class YamlFrontMatterMarkdownRendererTest {
 
     @Test
     public void testValueWithColonSpace() {
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("key", List.of("value with a: colon inside"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(
+                                new YamlFrontMatterNode(
+                                        "key", List.of("value with a: colon inside"))));
 
-        assertRenderedEquals(doc, "---\nkey: 'value with a: colon inside'\n---\n\nMarkdown content\n");
+        assertRenderedEquals(
+                doc, "---\nkey: 'value with a: colon inside'\n---\n\nMarkdown content\n");
     }
 
     @Test
     public void testValueWithColonNoSpace() {
         // Colon without trailing space is fine unquoted (e.g. timestamps, URLs)
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("time", List.of("12:30:00"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("time", List.of("12:30:00"))));
 
         assertRenderedEquals(doc, "---\ntime: 12:30:00\n---\n\nMarkdown content\n");
     }
 
     @Test
     public void testValueStartingWithDash() {
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("key", List.of("- not a list"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("key", List.of("- not a list"))));
 
         assertRenderedEquals(doc, "---\nkey: '- not a list'\n---\n\nMarkdown content\n");
     }
 
     @Test
     public void testValueStartingWithUnmatchedBracket() {
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("key", List.of("[broken"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("key", List.of("[broken"))));
 
         assertRenderedEquals(doc, "---\nkey: '[broken'\n---\n\nMarkdown content\n");
     }
@@ -123,14 +137,18 @@ public class YamlFrontMatterMarkdownRendererTest {
     @Test
     public void testValueStartingWithMatchedBrackets() {
         // Valid flow list - should NOT be quoted
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("flowList", List.of("[1, 2, 3]"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("flowList", List.of("[1, 2, 3]"))));
 
         assertRenderedEquals(doc, "---\nflowList: [1, 2, 3]\n---\n\nMarkdown content\n");
     }
 
     @Test
     public void testValueStartingWithUnmatchedBrace() {
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("key", List.of("{broken"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("key", List.of("{broken"))));
 
         assertRenderedEquals(doc, "---\nkey: '{broken'\n---\n\nMarkdown content\n");
     }
@@ -138,35 +156,47 @@ public class YamlFrontMatterMarkdownRendererTest {
     @Test
     public void testValueStartingWithMatchedBraces() {
         // Valid flow mapping - should NOT be quoted
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("flowMapping", List.of("{key: val}"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("flowMapping", List.of("{key: val}"))));
 
         assertRenderedEquals(doc, "---\nflowMapping: {key: val}\n---\n\nMarkdown content\n");
     }
 
     @Test
     public void testValueContainingHashComment() {
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("key", List.of("value # not a comment"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("key", List.of("value # not a comment"))));
 
         assertRenderedEquals(doc, "---\nkey: 'value # not a comment'\n---\n\nMarkdown content\n");
     }
 
     @Test
     public void testValueContainingApostrophe() {
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("key", List.of("it's a test"))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("key", List.of("it's a test"))));
 
         assertRenderedEquals(doc, "---\nkey: 'it''s a test'\n---\n\nMarkdown content\n");
     }
 
     @Test
     public void testEmptyStringValue() {
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("empty", List.of(""))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(new YamlFrontMatterNode("empty", List.of(""))));
 
         assertRenderedEquals(doc, "---\nempty: ''\n---\n\nMarkdown content\n");
     }
 
     @Test
     public void testValueStartingWithDoubleQuote() {
-        var doc = buildDocumentWithFrontMatter(List.of(new YamlFrontMatterNode("key", List.of("\"quotes within value\""))));
+        var doc =
+                buildDocumentWithFrontMatter(
+                        List.of(
+                                new YamlFrontMatterNode(
+                                        "key", List.of("\"quotes within value\""))));
 
         assertRenderedEquals(doc, "---\nkey: '\"quotes within value\"'\n---\n\nMarkdown content\n");
     }

--- a/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterTest.java
+++ b/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterTest.java
@@ -1,5 +1,10 @@
 package org.commonmark.ext.front.matter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.commonmark.Extension;
 import org.commonmark.node.CustomNode;
 import org.commonmark.node.Node;
@@ -8,24 +13,15 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class YamlFrontMatterTest extends RenderingTestCase {
     private static final Set<Extension> EXTENSIONS = Set.of(YamlFrontMatterExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
     @Test
     public void simpleValue() {
-        final String input = "---" +
-                "\nhello: world" +
-                "\n..." +
-                "\n" +
-                "\ngreat";
+        final String input = "---" + "\nhello: world" + "\n..." + "\n" + "\ngreat";
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -40,11 +36,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void emptyValue() {
-        final String input = "---" +
-                "\nkey:" +
-                "\n---" +
-                "\n" +
-                "\ngreat";
+        final String input = "---" + "\nkey:" + "\n---" + "\n" + "\ngreat";
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -58,13 +50,8 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void listValues() {
-        final String input = "---" +
-                "\nlist:" +
-                "\n  - value1" +
-                "\n  - value2" +
-                "\n..." +
-                "\n" +
-                "\ngreat";
+        final String input =
+                "---" + "\nlist:" + "\n  - value1" + "\n  - value2" + "\n..." + "\n" + "\ngreat";
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -80,13 +67,14 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void literalValue1() {
-        final String input = "---" +
-                "\nliteral: |" +
-                "\n  hello markdown!" +
-                "\n  literal thing..." +
-                "\n---" +
-                "\n" +
-                "\ngreat";
+        final String input =
+                "---"
+                        + "\nliteral: |"
+                        + "\n  hello markdown!"
+                        + "\n  literal thing..."
+                        + "\n---"
+                        + "\n"
+                        + "\ngreat";
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -101,12 +89,8 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void literalValue2() {
-        final String input = "---" +
-                "\nliteral: |" +
-                "\n  - hello markdown!" +
-                "\n---" +
-                "\n" +
-                "\ngreat";
+        final String input =
+                "---" + "\nliteral: |" + "\n  - hello markdown!" + "\n---" + "\n" + "\ngreat";
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -121,17 +105,18 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void complexValues() {
-        final String input = "---" +
-                "\nsimple: value" +
-                "\nliteral: |" +
-                "\n  hello markdown!" +
-                "\n" +
-                "\n  literal literal" +
-                "\nlist:" +
-                "\n    - value1" +
-                "\n    - value2" +
-                "\n---" +
-                "\ngreat";
+        final String input =
+                "---"
+                        + "\nsimple: value"
+                        + "\nliteral: |"
+                        + "\n  hello markdown!"
+                        + "\n"
+                        + "\n  literal literal"
+                        + "\nlist:"
+                        + "\n    - value1"
+                        + "\n    - value2"
+                        + "\n---"
+                        + "\ngreat";
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -156,9 +141,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void empty() {
-        final String input = "---\n" +
-                "---\n" +
-                "test";
+        final String input = "---\n" + "---\n" + "test";
         final String rendered = "<p>test</p>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -170,12 +153,10 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void yamlInParagraph() {
-        final String input = "# hello\n" +
-                "\nhello markdown world!" +
-                "\n---" +
-                "\nhello: world" +
-                "\n---";
-        final String rendered = "<h1>hello</h1>\n<h2>hello markdown world!</h2>\n<h2>hello: world</h2>\n";
+        final String input =
+                "# hello\n" + "\nhello markdown world!" + "\n---" + "\nhello: world" + "\n---";
+        final String rendered =
+                "<h1>hello</h1>\n<h2>hello markdown world!</h2>\n<h2>hello: world</h2>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
 
@@ -186,10 +167,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void yamlOnSecondLine() {
-        final String input = "hello\n" +
-                "\n---" +
-                "\nhello: world" +
-                "\n---";
+        final String input = "hello\n" + "\n---" + "\nhello: world" + "\n---";
         final String rendered = "<p>hello</p>\n<hr />\n<h2>hello: world</h2>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -201,8 +179,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void nonMatchedStartTag() {
-        final String input = "----\n" +
-                "test";
+        final String input = "----\n" + "test";
         final String rendered = "<hr />\n<p>test</p>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -214,9 +191,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void inList() {
-        final String input = "* ---\n" +
-                "  ---\n" +
-                "test";
+        final String input = "* ---\n" + "  ---\n" + "test";
         final String rendered = "<ul>\n<li>\n<hr />\n<hr />\n</li>\n</ul>\n<p>test</p>\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
@@ -228,10 +203,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void visitorIgnoresOtherCustomNodes() {
-        final String input = "---" +
-                "\nhello: world" +
-                "\n---" +
-                "\n";
+        final String input = "---" + "\nhello: world" + "\n---" + "\n";
 
         YamlFrontMatterVisitor visitor = new YamlFrontMatterVisitor();
         Node document = PARSER.parse(input);
@@ -246,10 +218,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void nodesCanBeModified() {
-        final String input = "---" +
-                "\nhello: world" +
-                "\n---" +
-                "\n";
+        final String input = "---" + "\nhello: world" + "\n---" + "\n";
 
         Node document = PARSER.parse(input);
         YamlFrontMatterNode node = (YamlFrontMatterNode) document.getFirstChild().getFirstChild();
@@ -267,10 +236,7 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void dotInKeys() {
-        final String input = "---" +
-                "\nms.author: author" +
-                "\n---" +
-                "\n";
+        final String input = "---" + "\nms.author: author" + "\n---" + "\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
 
@@ -282,12 +248,8 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void singleQuotedLiterals() {
-        final String input = "---" +
-                "\nstring: 'It''s me'" +
-                "\nlist:" +
-                "\n  - 'I''m here'" +
-                "\n---" +
-                "\n";
+        final String input =
+                "---" + "\nstring: 'It''s me'" + "\nlist:" + "\n  - 'I''m here'" + "\n---" + "\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
 
@@ -298,12 +260,13 @@ public class YamlFrontMatterTest extends RenderingTestCase {
 
     @Test
     public void doubleQuotedLiteral() {
-        final String input = "---" +
-                "\nstring: \"backslash: \\\\ quote: \\\"\"" +
-                "\nlist:" +
-                "\n  - \"hey\"" +
-                "\n---" +
-                "\n";
+        final String input =
+                "---"
+                        + "\nstring: \"backslash: \\\\ quote: \\\"\""
+                        + "\nlist:"
+                        + "\n  - \"hey\""
+                        + "\n---"
+                        + "\n";
 
         Map<String, List<String>> data = getFrontMatter(input);
 
@@ -326,6 +289,5 @@ public class YamlFrontMatterTest extends RenderingTestCase {
     }
 
     // Custom node for tests
-    private static class TestNode extends CustomNode {
-    }
+    private static class TestNode extends CustomNode {}
 }

--- a/commonmark-integration-test/src/main/java/org/commonmark/integration/IntegrationTests.java
+++ b/commonmark-integration-test/src/main/java/org/commonmark/integration/IntegrationTests.java
@@ -9,8 +9,5 @@ package org.commonmark.integration;
 // And the javadoc plugin doesn't like if there's no classes with documentation,
 //
 
-/**
- * Module with integration tests.
- */
-public class IntegrationTests {
-}
+/** Module with integration tests. */
+public class IntegrationTests {}

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/BoundsIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/BoundsIntegrationTest.java
@@ -1,5 +1,8 @@
 package org.commonmark.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.testutil.TestResources;
@@ -9,21 +12,14 @@ import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Tests various substrings of the spec examples to check for out of bounds exceptions.
- */
+/** Tests various substrings of the spec examples to check for out of bounds exceptions. */
 @ParameterizedClass
 @MethodSource("data")
 public class BoundsIntegrationTest {
 
     private static final Parser PARSER = Parser.builder().build();
 
-    @Parameter
-    String input;
+    @Parameter String input;
 
     static List<String> data() {
         return ExampleReader.readExampleSources(TestResources.getSpec());

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/Extensions.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/Extensions.java
@@ -1,5 +1,6 @@
 package org.commonmark.integration;
 
+import java.util.List;
 import org.commonmark.Extension;
 import org.commonmark.ext.autolink.AutolinkExtension;
 import org.commonmark.ext.footnotes.FootnotesExtension;
@@ -11,18 +12,17 @@ import org.commonmark.ext.image.attributes.ImageAttributesExtension;
 import org.commonmark.ext.ins.InsExtension;
 import org.commonmark.ext.task.list.items.TaskListItemsExtension;
 
-import java.util.List;
-
 public class Extensions {
 
-    static final List<Extension> ALL_EXTENSIONS = List.of(
-            AutolinkExtension.create(),
-            FootnotesExtension.create(),
-            ImageAttributesExtension.create(),
-            InsExtension.create(),
-            AlertsExtension.create(),
-            StrikethroughExtension.create(),
-            TablesExtension.create(),
-            TaskListItemsExtension.create(),
-            YamlFrontMatterExtension.create());
+    static final List<Extension> ALL_EXTENSIONS =
+            List.of(
+                    AutolinkExtension.create(),
+                    FootnotesExtension.create(),
+                    ImageAttributesExtension.create(),
+                    InsExtension.create(),
+                    AlertsExtension.create(),
+                    StrikethroughExtension.create(),
+                    TablesExtension.create(),
+                    TaskListItemsExtension.create(),
+                    YamlFrontMatterExtension.create());
 }

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/ExtensionsIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/ExtensionsIntegrationTest.java
@@ -5,30 +5,30 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests to ensure all extensions work well together.
- */
+/** Tests to ensure all extensions work well together. */
 public class ExtensionsIntegrationTest extends RenderingTestCase {
 
-    protected static final Parser PARSER = Parser.builder()
-            .extensions(Extensions.ALL_EXTENSIONS)
-            .build();
-    protected static final HtmlRenderer RENDERER = HtmlRenderer.builder()
-            .extensions(Extensions.ALL_EXTENSIONS)
-            .percentEncodeUrls(true)
-            .build();
+    protected static final Parser PARSER =
+            Parser.builder().extensions(Extensions.ALL_EXTENSIONS).build();
+    protected static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder()
+                    .extensions(Extensions.ALL_EXTENSIONS)
+                    .percentEncodeUrls(true)
+                    .build();
 
     @Test
     public void testImageAttributes() {
-        assertRendering("![text](/url.png){height=5 width=6}", "<p><img src=\"/url.png\" alt=\"text\" height=\"5\" width=\"6\" /></p>\n");
+        assertRendering(
+                "![text](/url.png){height=5 width=6}",
+                "<p><img src=\"/url.png\" alt=\"text\" height=\"5\" width=\"6\" /></p>\n");
     }
 
     @Test
     public void testTaskListItems() {
-        assertRendering("- [ ] task to do\n- [x] task done\n",
-                "<ul>\n<li><input type=\"checkbox\" disabled=\"\"> task to do</li>\n" +
-                        "<li><input type=\"checkbox\" disabled=\"\" checked=\"\"> task done</li>\n</ul>\n");
-
+        assertRendering(
+                "- [ ] task to do\n- [x] task done\n",
+                "<ul>\n<li><input type=\"checkbox\" disabled=\"\"> task to do</li>\n"
+                        + "<li><input type=\"checkbox\" disabled=\"\" checked=\"\"> task done</li>\n</ul>\n");
     }
 
     @Override

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/MarkdownRendererIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/MarkdownRendererIntegrationTest.java
@@ -1,15 +1,17 @@
 package org.commonmark.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class MarkdownRendererIntegrationTest {
 
-    private static final Parser PARSER = Parser.builder().extensions(Extensions.ALL_EXTENSIONS).build();
-    private static final MarkdownRenderer RENDERER = MarkdownRenderer.builder().extensions(Extensions.ALL_EXTENSIONS).build();
+    private static final Parser PARSER =
+            Parser.builder().extensions(Extensions.ALL_EXTENSIONS).build();
+    private static final MarkdownRenderer RENDERER =
+            MarkdownRenderer.builder().extensions(Extensions.ALL_EXTENSIONS).build();
 
     @Test
     public void testStrikethroughInTable() {

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/PegDownBenchmark.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/PegDownBenchmark.java
@@ -1,5 +1,6 @@
 package org.commonmark.integration;
 
+import java.util.List;
 import org.commonmark.testutil.TestResources;
 import org.commonmark.testutil.example.ExampleReader;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -12,20 +13,21 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.pegdown.Extensions;
 import org.pegdown.PegDownProcessor;
 
-import java.util.List;
-
 @State(Scope.Benchmark)
 public class PegDownBenchmark {
 
     private static final String SPEC = TestResources.readAsString(TestResources.getSpec());
-    private static final List<String> SPEC_EXAMPLES = ExampleReader.readExampleSources(TestResources.getSpec());
-    private static final PegDownProcessor PROCESSOR = new PegDownProcessor(Extensions.FENCED_CODE_BLOCKS);
+    private static final List<String> SPEC_EXAMPLES =
+            ExampleReader.readExampleSources(TestResources.getSpec());
+    private static final PegDownProcessor PROCESSOR =
+            new PegDownProcessor(Extensions.FENCED_CODE_BLOCKS);
 
     public static void main(String[] args) throws Exception {
-        Options options = new OptionsBuilder()
-                .parent(new CommandLineOptions(args))
-                .include(PegDownBenchmark.class.getName() + ".*")
-                .build();
+        Options options =
+                new OptionsBuilder()
+                        .parent(new CommandLineOptions(args))
+                        .include(PegDownBenchmark.class.getName() + ".*")
+                        .build();
         new Runner(options).run();
     }
 
@@ -47,5 +49,4 @@ public class PegDownBenchmark {
         }
         return length;
     }
-
 }

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/SourceSpanIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/SourceSpanIntegrationTest.java
@@ -3,15 +3,14 @@ package org.commonmark.integration;
 import org.commonmark.parser.IncludeSourceSpans;
 import org.commonmark.parser.Parser;
 
-/**
- * Spec and all extensions, with source spans enabled.
- */
+/** Spec and all extensions, with source spans enabled. */
 public class SourceSpanIntegrationTest extends SpecIntegrationTest {
 
-    protected static final Parser PARSER = Parser.builder()
-            .extensions(Extensions.ALL_EXTENSIONS)
-            .includeSourceSpans(IncludeSourceSpans.BLOCKS)
-            .build();
+    protected static final Parser PARSER =
+            Parser.builder()
+                    .extensions(Extensions.ALL_EXTENSIONS)
+                    .includeSourceSpans(IncludeSourceSpans.BLOCKS)
+                    .build();
 
     @Override
     protected String render(String source) {

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
@@ -1,22 +1,24 @@
 package org.commonmark.integration;
 
-import org.commonmark.renderer.html.HtmlRenderer;
+import static org.commonmark.testutil.Asserts.assertRendering;
+
+import java.util.*;
 import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.SpecTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
-
-import static org.commonmark.testutil.Asserts.assertRendering;
-
-/**
- * Tests that the spec examples still render the same with all extensions enabled.
- */
+/** Tests that the spec examples still render the same with all extensions enabled. */
 public class SpecIntegrationTest extends SpecTestCase {
 
-    protected static final Parser PARSER = Parser.builder().extensions(Extensions.ALL_EXTENSIONS).build();
+    protected static final Parser PARSER =
+            Parser.builder().extensions(Extensions.ALL_EXTENSIONS).build();
     // The spec says URL-escaping is optional, but the examples assume that it's enabled.
-    protected static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(Extensions.ALL_EXTENSIONS).percentEncodeUrls(true).build();
+    protected static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder()
+                    .extensions(Extensions.ALL_EXTENSIONS)
+                    .percentEncodeUrls(true)
+                    .build();
     protected static final Map<String, String> OVERRIDDEN_EXAMPLES = getOverriddenExamples();
 
     @Test
@@ -37,22 +39,35 @@ public class SpecIntegrationTest extends SpecTestCase {
         Map<String, String> m = new HashMap<>();
 
         // Not a spec autolink because of space, but the resulting text contains a valid URL
-        m.put("<https://foo.bar/baz bim>\n", "<p>&lt;<a href=\"https://foo.bar/baz\">https://foo.bar/baz</a> bim&gt;</p>\n");
+        m.put(
+                "<https://foo.bar/baz bim>\n",
+                "<p>&lt;<a href=\"https://foo.bar/baz\">https://foo.bar/baz</a> bim&gt;</p>\n");
 
         // Not a spec autolink, but the resulting text contains a valid email
-        m.put("<foo\\+@bar.example.com>\n", "<p>&lt;<a href=\"mailto:foo+@bar.example.com\">foo+@bar.example.com</a>&gt;</p>\n");
+        m.put(
+                "<foo\\+@bar.example.com>\n",
+                "<p>&lt;<a href=\"mailto:foo+@bar.example.com\">foo+@bar.example.com</a>&gt;</p>\n");
 
-        // Not a spec autolink because of unknown scheme, but autolink extension doesn't limit schemes
-        m.put("<heck://bing.bong>\n", "<p>&lt;<a href=\"heck://bing.bong%3E\">heck://bing.bong&gt;</a></p>\n");
+        // Not a spec autolink because of unknown scheme, but autolink extension doesn't limit
+        // schemes
+        m.put(
+                "<heck://bing.bong>\n",
+                "<p>&lt;<a href=\"heck://bing.bong%3E\">heck://bing.bong&gt;</a></p>\n");
 
         // Not a spec autolink because of spaces, but autolink extension doesn't limit schemes
-        m.put("< https://foo.bar >\n", "<p>&lt; <a href=\"https://foo.bar\">https://foo.bar</a> &gt;</p>\n");
+        m.put(
+                "< https://foo.bar >\n",
+                "<p>&lt; <a href=\"https://foo.bar\">https://foo.bar</a> &gt;</p>\n");
 
         // Plain autolink
-        m.put("https://example.com\n", "<p><a href=\"https://example.com\">https://example.com</a></p>\n");
+        m.put(
+                "https://example.com\n",
+                "<p><a href=\"https://example.com\">https://example.com</a></p>\n");
 
         // Plain autolink
-        m.put("foo@bar.example.com\n", "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n");
+        m.put(
+                "foo@bar.example.com\n",
+                "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n");
 
         // YAML front matter block
         m.put("---\nFoo\n---\nBar\n---\nBaz\n", "<h2>Bar</h2>\n<p>Baz</p>\n");
@@ -60,5 +75,4 @@ public class SpecIntegrationTest extends SpecTestCase {
 
         return m;
     }
-
 }

--- a/commonmark-integration-test/src/test/java/org/commonmark/ui/DingusApp.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/ui/DingusApp.java
@@ -1,18 +1,17 @@
 package org.commonmark.ui;
 
-import org.commonmark.parser.Parser;
-import org.commonmark.renderer.html.HtmlRenderer;
-import org.commonmark.renderer.text.TextContentRenderer;
-
 import java.awt.*;
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.renderer.text.TextContentRenderer;
 
 /**
- * Simple UI to quickly test out different rendering of CommonMark inputs.
- * Similar to <a href="https://spec.commonmark.org/dingus/">commonmark.js dingus</a>.
- **/
+ * Simple UI to quickly test out different rendering of CommonMark inputs. Similar to <a
+ * href="https://spec.commonmark.org/dingus/">commonmark.js dingus</a>.
+ */
 public class DingusApp {
 
     private final Parser parser = Parser.builder().build();
@@ -57,21 +56,22 @@ public class DingusApp {
         input.setLineWrap(true);
         input.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
 
-        input.getDocument().addDocumentListener(new DocumentListener() {
-            @Override
-            public void insertUpdate(DocumentEvent e) {
-                updateOutput(input.getText());
-            }
+        input.getDocument()
+                .addDocumentListener(
+                        new DocumentListener() {
+                            @Override
+                            public void insertUpdate(DocumentEvent e) {
+                                updateOutput(input.getText());
+                            }
 
-            @Override
-            public void removeUpdate(DocumentEvent e) {
-                updateOutput(input.getText());
-            }
+                            @Override
+                            public void removeUpdate(DocumentEvent e) {
+                                updateOutput(input.getText());
+                            }
 
-            @Override
-            public void changedUpdate(DocumentEvent e) {
-            }
-        });
+                            @Override
+                            public void changedUpdate(DocumentEvent e) {}
+                        });
 
         tabbedPane.addTab("HTML rendered", htmlVisualRendererOutput);
         tabbedPane.addTab("HTML source", htmlSourceRendererOutput);
@@ -79,10 +79,11 @@ public class DingusApp {
 
         tabbedPane.addChangeListener(e -> updateOutput(input.getText()));
 
-        input.setText("# Example\n" +
-                "Enter text *here* and see how it renders on the right.\n\n" +
-                "* Try\n* this\n\n" +
-                "```\nor this\n```");
+        input.setText(
+                "# Example\n"
+                        + "Enter text *here* and see how it renders on the right.\n\n"
+                        + "* Try\n* this\n\n"
+                        + "```\nor this\n```");
         updateOutput(input.getText());
 
         frame.setLayout(new GridLayout());

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/Asserts.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/Asserts.java
@@ -3,7 +3,8 @@ package org.commonmark.testutil;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class Asserts {
-    public static void assertRendering(String source, String expectedRendering, String actualRendering) {
+    public static void assertRendering(
+            String source, String expectedRendering, String actualRendering) {
         // include source for better assertion errors
         String expected = showTabs(expectedRendering + "\n\n" + source);
         String actual = showTabs(actualRendering + "\n\n" + source);

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/SpecTestCase.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/SpecTestCase.java
@@ -1,19 +1,17 @@
 package org.commonmark.testutil;
 
+import java.util.List;
 import org.commonmark.testutil.example.Example;
 import org.commonmark.testutil.example.ExampleReader;
 import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
-
 @ParameterizedClass
 @MethodSource("data")
 public abstract class SpecTestCase {
 
-    @Parameter
-    protected Example example;
+    @Parameter protected Example example;
 
     static List<Example> data() {
         return ExampleReader.readExamples(TestResources.getSpec());

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
@@ -20,13 +20,14 @@ public class TestResources {
     public static List<URL> getRegressions() {
         return List.of(
                 TestResources.class.getResource("/cmark-regression.txt"),
-                TestResources.class.getResource("/commonmark.js-regression.txt")
-        );
+                TestResources.class.getResource("/commonmark.js-regression.txt"));
     }
 
     public static String readAsString(URL url) {
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
+        try (BufferedReader reader =
+                new BufferedReader(
+                        new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 sb.append(line);

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/example/Example.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/example/Example.java
@@ -9,7 +9,13 @@ public class Example {
     private final String source;
     private final String html;
 
-    public Example(String filename, String section, String info, int exampleNumber, String source, String html) {
+    public Example(
+            String filename,
+            String section,
+            String info,
+            int exampleNumber,
+            String source,
+            String html) {
         this.filename = filename;
         this.section = section;
         this.info = info;

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/example/ExampleReader.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/example/ExampleReader.java
@@ -10,7 +10,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * Reader for files containing examples of CommonMark source and the expected HTML rendering (e.g. spec.txt).
+ * Reader for files containing examples of CommonMark source and the expected HTML rendering (e.g.
+ * spec.txt).
  */
 public class ExampleReader {
 
@@ -45,11 +46,15 @@ public class ExampleReader {
 
     public static List<Example> readExamples(URL url, String info) {
         var examples = readExamples(url);
-        return examples.stream().filter(e -> e.getInfo().contains(info)).collect(Collectors.toList());
+        return examples.stream()
+                .filter(e -> e.getInfo().contains(info))
+                .collect(Collectors.toList());
     }
 
     public static List<Object[]> readExampleObjects(URL url, String info) {
-        return readExamples(url, info).stream().map(e -> new Object[]{e}).collect(Collectors.toList());
+        return readExamples(url, info).stream()
+                .map(e -> new Object[] {e})
+                .collect(Collectors.toList());
     }
 
     public static List<String> readExampleSources(URL url) {
@@ -64,8 +69,8 @@ public class ExampleReader {
     private List<Example> read() throws IOException {
         resetContents();
 
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 processLine(line);
@@ -101,8 +106,15 @@ public class ExampleReader {
             case HTML:
                 if (line.equals("````````````````````````````````")) {
                     state = State.BEFORE;
-                    examples.add(new Example(filename, section, info, exampleNumber,
-                            source.toString(), html.toString()));
+                    var example =
+                            new Example(
+                                    filename,
+                                    section,
+                                    info,
+                                    exampleNumber,
+                                    source.toString(),
+                                    html.toString());
+                    examples.add(example);
                     resetContents();
                 } else {
                     html.append(line).append('\n');
@@ -117,6 +129,8 @@ public class ExampleReader {
     }
 
     private enum State {
-        BEFORE, SOURCE, HTML
+        BEFORE,
+        SOURCE,
+        HTML
     }
 }

--- a/commonmark/src/main/java/org/commonmark/Extension.java
+++ b/commonmark/src/main/java/org/commonmark/Extension.java
@@ -2,10 +2,9 @@ package org.commonmark;
 
 /**
  * Base interface for a parser/renderer extension.
- * <p>
- * Doesn't have any methods itself, but has specific sub interfaces to
- * configure parser/renderer. This base interface is for convenience, so that a list of extensions can be built and then
- * used for configuring both the parser and renderer in the same way.
+ *
+ * <p>Doesn't have any methods itself, but has specific sub interfaces to configure parser/renderer.
+ * This base interface is for convenience, so that a list of extensions can be built and then used
+ * for configuring both the parser and renderer in the same way.
  */
-public interface Extension {
-}
+public interface Extension {}

--- a/commonmark/src/main/java/org/commonmark/internal/BlockContent.java
+++ b/commonmark/src/main/java/org/commonmark/internal/BlockContent.java
@@ -25,5 +25,4 @@ class BlockContent {
     public String getString() {
         return sb.toString();
     }
-
 }

--- a/commonmark/src/main/java/org/commonmark/internal/BlockContinueImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/BlockContinueImpl.java
@@ -25,5 +25,4 @@ public class BlockContinueImpl extends BlockContinue {
     public boolean isFinalize() {
         return finalize;
     }
-
 }

--- a/commonmark/src/main/java/org/commonmark/internal/BlockQuoteParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/BlockQuoteParser.java
@@ -42,7 +42,9 @@ public class BlockQuoteParser extends AbstractBlockParser {
 
     private static boolean isMarker(ParserState state, int index) {
         CharSequence line = state.getLine().getContent();
-        return state.getIndent() < Parsing.CODE_BLOCK_INDENT && index < line.length() && line.charAt(index) == '>';
+        return state.getIndent() < Parsing.CODE_BLOCK_INDENT
+                && index < line.length()
+                && line.charAt(index) == '>';
     }
 
     public static class Factory extends AbstractBlockParserFactory {

--- a/commonmark/src/main/java/org/commonmark/internal/Bracket.java
+++ b/commonmark/src/main/java/org/commonmark/internal/Bracket.java
@@ -3,65 +3,81 @@ package org.commonmark.internal;
 import org.commonmark.node.Text;
 import org.commonmark.parser.beta.Position;
 
-/**
- * Opening bracket for links ({@code [}), images ({@code ![}), or links with other markers.
- */
+/** Opening bracket for links ({@code [}), images ({@code ![}), or links with other markers. */
 public class Bracket {
 
-    /**
-     * The node of a marker such as {@code !} if present, null otherwise.
-     */
+    /** The node of a marker such as {@code !} if present, null otherwise. */
     public final Text markerNode;
 
-    /**
-     * The position of the marker if present, null otherwise.
-     */
+    /** The position of the marker if present, null otherwise. */
     public final Position markerPosition;
 
-    /**
-     * The node of {@code [}.
-     */
+    /** The node of {@code [}. */
     public final Text bracketNode;
 
-    /**
-     * The position of {@code [}.
-     */
+    /** The position of {@code [}. */
     public final Position bracketPosition;
 
-    /**
-     * The position of the content (after the opening bracket)
-     */
+    /** The position of the content (after the opening bracket) */
     public final Position contentPosition;
 
-    /**
-     * Previous bracket.
-     */
+    /** Previous bracket. */
     public final Bracket previous;
 
-    /**
-     * Previous delimiter (emphasis, etc) before this bracket.
-     */
+    /** Previous delimiter (emphasis, etc) before this bracket. */
     public final Delimiter previousDelimiter;
 
-    /**
-     * Whether this bracket is allowed to form a link/image (also known as "active").
-     */
+    /** Whether this bracket is allowed to form a link/image (also known as "active"). */
     public boolean allowed = true;
 
     /**
-     * Whether there is an unescaped bracket (opening or closing) after this opening bracket in the text parsed so far.
+     * Whether there is an unescaped bracket (opening or closing) after this opening bracket in the
+     * text parsed so far.
      */
     public boolean bracketAfter = false;
 
-    static public Bracket link(Text bracketNode, Position bracketPosition, Position contentPosition, Bracket previous, Delimiter previousDelimiter) {
-        return new Bracket(null, null, bracketNode, bracketPosition, contentPosition, previous, previousDelimiter);
+    public static Bracket link(
+            Text bracketNode,
+            Position bracketPosition,
+            Position contentPosition,
+            Bracket previous,
+            Delimiter previousDelimiter) {
+        return new Bracket(
+                null,
+                null,
+                bracketNode,
+                bracketPosition,
+                contentPosition,
+                previous,
+                previousDelimiter);
     }
 
-    static public Bracket withMarker(Text markerNode, Position markerPosition, Text bracketNode, Position bracketPosition, Position contentPosition, Bracket previous, Delimiter previousDelimiter) {
-        return new Bracket(markerNode, markerPosition, bracketNode, bracketPosition, contentPosition, previous, previousDelimiter);
+    public static Bracket withMarker(
+            Text markerNode,
+            Position markerPosition,
+            Text bracketNode,
+            Position bracketPosition,
+            Position contentPosition,
+            Bracket previous,
+            Delimiter previousDelimiter) {
+        return new Bracket(
+                markerNode,
+                markerPosition,
+                bracketNode,
+                bracketPosition,
+                contentPosition,
+                previous,
+                previousDelimiter);
     }
 
-    private Bracket(Text markerNode, Position markerPosition, Text bracketNode, Position bracketPosition, Position contentPosition, Bracket previous, Delimiter previousDelimiter) {
+    private Bracket(
+            Text markerNode,
+            Position markerPosition,
+            Text bracketNode,
+            Position bracketPosition,
+            Position contentPosition,
+            Bracket previous,
+            Delimiter previousDelimiter) {
         this.markerNode = markerNode;
         this.markerPosition = markerPosition;
         this.bracketNode = bracketNode;

--- a/commonmark/src/main/java/org/commonmark/internal/Definitions.java
+++ b/commonmark/src/main/java/org/commonmark/internal/Definitions.java
@@ -1,9 +1,8 @@
 package org.commonmark.internal;
 
-import org.commonmark.node.DefinitionMap;
-
 import java.util.HashMap;
 import java.util.Map;
+import org.commonmark.node.DefinitionMap;
 
 public class Definitions {
 

--- a/commonmark/src/main/java/org/commonmark/internal/Delimiter.java
+++ b/commonmark/src/main/java/org/commonmark/internal/Delimiter.java
@@ -1,13 +1,10 @@
 package org.commonmark.internal;
 
+import java.util.List;
 import org.commonmark.node.Text;
 import org.commonmark.parser.delimiter.DelimiterRun;
 
-import java.util.List;
-
-/**
- * Delimiter (emphasis, strong emphasis or custom emphasis).
- */
+/** Delimiter (emphasis, strong emphasis or custom emphasis). */
 public class Delimiter implements DelimiterRun {
 
     public final List<Text> characters;
@@ -23,7 +20,12 @@ public class Delimiter implements DelimiterRun {
     public Delimiter previous;
     public Delimiter next;
 
-    public Delimiter(List<Text> characters, char delimiterChar, boolean canOpen, boolean canClose, Delimiter previous) {
+    public Delimiter(
+            List<Text> characters,
+            char delimiterChar,
+            boolean canOpen,
+            boolean canClose,
+            Delimiter previous) {
         this.characters = characters;
         this.delimiterChar = delimiterChar;
         this.canOpen = canOpen;
@@ -65,7 +67,8 @@ public class Delimiter implements DelimiterRun {
     @Override
     public Iterable<Text> getOpeners(int length) {
         if (!(length >= 1 && length <= length())) {
-            throw new IllegalArgumentException("length must be between 1 and " + length() + ", was " + length);
+            throw new IllegalArgumentException(
+                    "length must be between 1 and " + length() + ", was " + length);
         }
 
         return characters.subList(characters.size() - length, characters.size());
@@ -74,7 +77,8 @@ public class Delimiter implements DelimiterRun {
     @Override
     public Iterable<Text> getClosers(int length) {
         if (!(length >= 1 && length <= length())) {
-            throw new IllegalArgumentException("length must be between 1 and " + length() + ", was " + length);
+            throw new IllegalArgumentException(
+                    "length must be between 1 and " + length() + ", was " + length);
         }
 
         return characters.subList(0, length);

--- a/commonmark/src/main/java/org/commonmark/internal/DocumentBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/DocumentBlockParser.java
@@ -29,5 +29,4 @@ public class DocumentBlockParser extends AbstractBlockParser {
     public BlockContinue tryContinue(ParserState state) {
         return BlockContinue.atIndex(state.getIndex());
     }
-
 }

--- a/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/DocumentParser.java
@@ -1,5 +1,8 @@
 package org.commonmark.internal;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.util.*;
 import org.commonmark.internal.util.LineReader;
 import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.*;
@@ -7,26 +10,24 @@ import org.commonmark.parser.IncludeSourceSpans;
 import org.commonmark.parser.InlineParserFactory;
 import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.SourceLines;
-import org.commonmark.parser.beta.LinkProcessor;
 import org.commonmark.parser.beta.InlineContentParserFactory;
+import org.commonmark.parser.beta.LinkProcessor;
 import org.commonmark.parser.block.*;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 import org.commonmark.text.Characters;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.util.*;
-
 public class DocumentParser implements ParserState {
 
-    private static final Set<Class<? extends Block>> CORE_FACTORY_TYPES = new LinkedHashSet<>(List.of(
-            BlockQuote.class,
-            Heading.class,
-            FencedCodeBlock.class,
-            HtmlBlock.class,
-            ThematicBreak.class,
-            ListBlock.class,
-            IndentedCodeBlock.class));
+    private static final Set<Class<? extends Block>> CORE_FACTORY_TYPES =
+            new LinkedHashSet<>(
+                    List.of(
+                            BlockQuote.class,
+                            Heading.class,
+                            FencedCodeBlock.class,
+                            HtmlBlock.class,
+                            ThematicBreak.class,
+                            ListBlock.class,
+                            IndentedCodeBlock.class));
 
     private static final Map<Class<? extends Block>, BlockParserFactory> NODES_TO_CORE_FACTORIES;
 
@@ -44,24 +45,16 @@ public class DocumentParser implements ParserState {
 
     private SourceLine line;
 
-    /**
-     * Line index (0-based)
-     */
+    /** Line index (0-based) */
     private int lineIndex = -1;
 
-    /**
-     * current index (offset) in input line (0-based)
-     */
+    /** current index (offset) in input line (0-based) */
     private int index = 0;
 
-    /**
-     * current column of input line (tab causes column to go to next 4-space tab stop) (0-based)
-     */
+    /** current column of input line (tab causes column to go to next 4-space tab stop) (0-based) */
     private int column = 0;
 
-    /**
-     * if the current column is within a tab character (partially consumed tab)
-     */
+    /** if the current column is within a tab character (partially consumed tab) */
     private boolean columnIsInTab;
 
     private int nextNonSpace = 0;
@@ -83,10 +76,15 @@ public class DocumentParser implements ParserState {
     private final List<OpenBlockParser> openBlockParsers = new ArrayList<>();
     private final List<BlockParser> allBlockParsers = new ArrayList<>();
 
-    public DocumentParser(List<BlockParserFactory> blockParserFactories, InlineParserFactory inlineParserFactory,
-                          List<InlineContentParserFactory> inlineContentParserFactories, List<DelimiterProcessor> delimiterProcessors,
-                          List<LinkProcessor> linkProcessors, Set<Character> linkMarkers,
-                          IncludeSourceSpans includeSourceSpans, int maxOpenBlockParsers) {
+    public DocumentParser(
+            List<BlockParserFactory> blockParserFactories,
+            InlineParserFactory inlineParserFactory,
+            List<InlineContentParserFactory> inlineContentParserFactories,
+            List<DelimiterProcessor> delimiterProcessors,
+            List<LinkProcessor> linkProcessors,
+            Set<Character> linkMarkers,
+            IncludeSourceSpans includeSourceSpans,
+            int maxOpenBlockParsers) {
         this.blockParserFactories = blockParserFactories;
         this.inlineParserFactory = inlineParserFactory;
         this.inlineContentParserFactories = inlineContentParserFactories;
@@ -104,8 +102,11 @@ public class DocumentParser implements ParserState {
         return CORE_FACTORY_TYPES;
     }
 
-    public static List<BlockParserFactory> calculateBlockParserFactories(List<BlockParserFactory> customBlockParserFactories, Set<Class<? extends Block>> enabledBlockTypes) {
-        // By having the custom factories come first, extensions are able to change behavior of core syntax.
+    public static List<BlockParserFactory> calculateBlockParserFactories(
+            List<BlockParserFactory> customBlockParserFactories,
+            Set<Class<? extends Block>> enabledBlockTypes) {
+        // By having the custom factories come first, extensions are able to change behavior of core
+        // syntax.
         List<BlockParserFactory> list = new ArrayList<>(customBlockParserFactories);
         for (Class<? extends Block> blockType : enabledBlockTypes) {
             list.add(NODES_TO_CORE_FACTORIES.get(blockType));
@@ -116,21 +117,25 @@ public class DocumentParser implements ParserState {
     public static void checkEnabledBlockTypes(Set<Class<? extends Block>> enabledBlockTypes) {
         for (Class<? extends Block> enabledBlockType : enabledBlockTypes) {
             if (!NODES_TO_CORE_FACTORIES.containsKey(enabledBlockType)) {
-                throw new IllegalArgumentException("Can't enable block type " + enabledBlockType + ", possible options are: " + NODES_TO_CORE_FACTORIES.keySet());
+                throw new IllegalArgumentException(
+                        "Can't enable block type "
+                                + enabledBlockType
+                                + ", possible options are: "
+                                + NODES_TO_CORE_FACTORIES.keySet());
             }
         }
     }
 
-    /**
-     * The main parsing function. Returns a parsed document AST.
-     */
+    /** The main parsing function. Returns a parsed document AST. */
     public Document parse(String input) {
         int lineStart = 0;
         int lineBreak;
         while ((lineBreak = Characters.findLineBreak(input, lineStart)) != -1) {
             String line = input.substring(lineStart, lineBreak);
             parseLine(line, lineStart);
-            if (lineBreak + 1 < input.length() && input.charAt(lineBreak) == '\r' && input.charAt(lineBreak + 1) == '\n') {
+            if (lineBreak + 1 < input.length()
+                    && input.charAt(lineBreak) == '\r'
+                    && input.charAt(lineBreak + 1) == '\n') {
                 lineStart = lineBreak + 2;
             } else {
                 lineStart = lineBreak + 1;
@@ -196,14 +201,15 @@ public class DocumentParser implements ParserState {
     }
 
     /**
-     * Analyze a line of text and update the document appropriately. We parse markdown text by calling this on each
-     * line of input, then finalizing the document.
+     * Analyze a line of text and update the document appropriately. We parse markdown text by
+     * calling this on each line of input, then finalizing the document.
      */
     private void parseLine(String ln, int inputIndex) {
         setLine(ln, inputIndex);
 
         // For each containing block, try to parse the associated line start.
-        // The document will always match, so we can skip the first block parser and start at 1 matches
+        // The document will always match, so we can skip the first block parser and start at 1
+        // matches
         int matches = 1;
         for (int i = 1; i < openBlockParsers.size(); i++) {
             OpenBlockParser openBlockParser = openBlockParsers.get(i);
@@ -239,13 +245,16 @@ public class DocumentParser implements ParserState {
 
         // Unless last matched container is a code block, try new container starts,
         // adding children to the last matched container:
-        boolean tryBlockStarts = blockParser.getBlock() instanceof Paragraph || blockParser.isContainer();
+        boolean tryBlockStarts =
+                blockParser.getBlock() instanceof Paragraph || blockParser.isContainer();
         while (tryBlockStarts) {
             lastIndex = index;
             findNextNonSpace();
 
             // this is a little performance optimization:
-            if (isBlank() || (indent < Parsing.CODE_BLOCK_INDENT && Characters.isLetter(this.line.getContent(), nextNonSpace))) {
+            if (isBlank()
+                    || (indent < Parsing.CODE_BLOCK_INDENT
+                            && Characters.isLetter(this.line.getContent(), nextNonSpace))) {
                 setNewIndex(nextNonSpace);
                 break;
             }
@@ -259,7 +268,8 @@ public class DocumentParser implements ParserState {
             startedNewBlock = true;
             int sourceIndex = getIndex();
 
-            // We're starting a new block. If we have any previous blocks that need to be closed, we need to do it now.
+            // We're starting a new block. If we have any previous blocks that need to be closed, we
+            // need to do it now.
             if (unmatchedBlocks > 0) {
                 closeBlockParsers(unmatchedBlocks);
                 unmatchedBlocks = 0;
@@ -272,11 +282,15 @@ public class DocumentParser implements ParserState {
             }
 
             List<SourceSpan> replacedSourceSpans = null;
-            if (blockStart.getReplaceParagraphLines() >= 1 || blockStart.isReplaceActiveBlockParser()) {
+            if (blockStart.getReplaceParagraphLines() >= 1
+                    || blockStart.isReplaceActiveBlockParser()) {
                 var activeBlockParser = getActiveBlockParser();
                 if (activeBlockParser instanceof ParagraphParser) {
                     var paragraphParser = (ParagraphParser) activeBlockParser;
-                    var lines = blockStart.isReplaceActiveBlockParser() ? Integer.MAX_VALUE : blockStart.getReplaceParagraphLines();
+                    var lines =
+                            blockStart.isReplaceActiveBlockParser()
+                                    ? Integer.MAX_VALUE
+                                    : blockStart.getReplaceParagraphLines();
                     replacedSourceSpans = replaceParagraphLines(lines, paragraphParser);
                 } else if (blockStart.isReplaceActiveBlockParser()) {
                     replacedSourceSpans = prepareActiveBlockParserForReplacement(activeBlockParser);
@@ -297,8 +311,9 @@ public class DocumentParser implements ParserState {
         // appropriate block.
 
         // First check for a lazy continuation line
-        if (!startedNewBlock && !isBlank() &&
-                getActiveBlockParser().canHaveLazyContinuationLines()) {
+        if (!startedNewBlock
+                && !isBlank()
+                && getActiveBlockParser().canHaveLazyContinuationLines()) {
             openBlockParsers.get(openBlockParsers.size() - 1).sourceIndex = lastIndex;
             // lazy paragraph continuation
             addLine();
@@ -324,7 +339,8 @@ public class DocumentParser implements ParserState {
                 // list item
                 // ```
                 //
-                // The first line does not start a paragraph yet, but we still want to record source positions.
+                // The first line does not start a paragraph yet, but we still want to record source
+                // positions.
                 addSourceSpans();
             }
         }
@@ -416,13 +432,14 @@ public class DocumentParser implements ParserState {
     }
 
     /**
-     * Add line content to the active block parser. We assume it can accept lines -- that check should be done before
-     * calling this.
+     * Add line content to the active block parser. We assume it can accept lines -- that check
+     * should be done before calling this.
      */
     private void addLine() {
         CharSequence content;
         if (columnIsInTab) {
-            // Our column is in a partially consumed tab. Expand the remaining columns (to the next tab stop) to spaces.
+            // Our column is in a partially consumed tab. Expand the remaining columns (to the next
+            // tab stop) to spaces.
             int afterTab = index + 1;
             CharSequence rest = line.getContent().subSequence(afterTab, line.getContent().length());
             int spaces = Parsing.columnsToNextTabStop(column);
@@ -438,8 +455,10 @@ public class DocumentParser implements ParserState {
             content = line.getContent().subSequence(index, line.getContent().length());
         }
         SourceSpan sourceSpan = null;
-        if (includeSourceSpans == IncludeSourceSpans.BLOCKS_AND_INLINES && index < line.getSourceSpan().getLength()) {
-            // Note that if we're in a partially-consumed tab the length of the source span and the content don't match.
+        if (includeSourceSpans == IncludeSourceSpans.BLOCKS_AND_INLINES
+                && index < line.getSourceSpan().getLength()) {
+            // Note that if we're in a partially-consumed tab the length of the source span and the
+            // content don't match.
             sourceSpan = line.getSourceSpan().subSpan(index);
         }
         getActiveBlockParser().addLine(SourceLine.of(content, sourceSpan));
@@ -448,15 +467,17 @@ public class DocumentParser implements ParserState {
 
     private void addSourceSpans() {
         if (includeSourceSpans != IncludeSourceSpans.NONE) {
-            // Don't add source spans for Document itself (it would get the whole source text), so start at 1, not 0
+            // Don't add source spans for Document itself (it would get the whole source text), so
+            // start at 1, not 0
             for (int i = 1; i < openBlockParsers.size(); i++) {
                 var openBlockParser = openBlockParsers.get(i);
-                // In case of a lazy continuation line, the index is less than where the block parser would expect the
-                // contents to start, so let's use whichever is smaller.
+                // In case of a lazy continuation line, the index is less than where the block
+                // parser would expect the contents to start, so let's use whichever is smaller.
                 int blockIndex = Math.min(openBlockParser.sourceIndex, index);
                 int length = line.getContent().length() - blockIndex;
                 if (length != 0) {
-                    openBlockParser.blockParser.addSourceSpan(line.getSourceSpan().subSpan(blockIndex));
+                    openBlockParser.blockParser.addSourceSpan(
+                            line.getSourceSpan().subSpan(blockIndex));
                 }
             }
         }
@@ -477,10 +498,17 @@ public class DocumentParser implements ParserState {
     }
 
     /**
-     * Walk through a block & children recursively, parsing string content into inline content where appropriate.
+     * Walk through a block & children recursively, parsing string content into inline content where
+     * appropriate.
      */
     private void processInlines() {
-        var context = new InlineParserContextImpl(inlineContentParserFactories, delimiterProcessors, linkProcessors, linkMarkers, definitions);
+        var context =
+                new InlineParserContextImpl(
+                        inlineContentParserFactories,
+                        delimiterProcessors,
+                        linkProcessors,
+                        linkMarkers,
+                        definitions);
         var inlineParser = inlineParserFactory.create(context);
 
         for (var blockParser : allBlockParsers) {
@@ -489,8 +517,8 @@ public class DocumentParser implements ParserState {
     }
 
     /**
-     * Add block of type tag as a child of the tip. If the tip can't accept children, close and finalize it and try
-     * its parent, and so on until we find a block that can accept children.
+     * Add block of type tag as a child of the tip. If the tip can't accept children, close and
+     * finalize it and try its parent, and so on until we find a block that can accept children.
      */
     private void addChild(OpenBlockParser openBlockParser) {
         while (!getActiveBlockParser().canContain(openBlockParser.blockParser.getBlock())) {
@@ -522,7 +550,8 @@ public class DocumentParser implements ParserState {
         // Note that we don't want to parse inlines here, as it's getting replaced.
         deactivateBlockParser();
 
-        // Do this so that source positions are calculated, which we will carry over to the replacing block.
+        // Do this so that source positions are calculated, which we will carry over to the
+        // replacing block.
         blockParser.closeBlock();
         blockParser.getBlock().unlink();
         return blockParser.getBlock().getSourceSpans();
@@ -538,16 +567,16 @@ public class DocumentParser implements ParserState {
         for (int i = 0; i < count; i++) {
             BlockParser blockParser = deactivateBlockParser().blockParser;
             finalize(blockParser);
-            // Remember for inline parsing. Note that a lot of blocks don't need inline parsing. We could have a
-            // separate interface (e.g. BlockParserWithInlines) so that we only have to remember those that actually
-            // have inlines to parse.
+            // Remember for inline parsing. Note that a lot of blocks don't need inline parsing. We
+            // could have a separate interface (e.g. BlockParserWithInlines) so that we only have to
+            // remember those that actually have inlines to parse.
             allBlockParsers.add(blockParser);
         }
     }
 
     /**
-     * Finalize a block. Close it and do any necessary postprocessing, e.g. setting the content of blocks and
-     * collecting link reference definitions from paragraphs.
+     * Finalize a block. Close it and do any necessary postprocessing, e.g. setting the content of
+     * blocks and collecting link reference definitions from paragraphs.
      */
     private void finalize(BlockParser blockParser) {
         addDefinitionsFrom(blockParser);
@@ -560,9 +589,7 @@ public class DocumentParser implements ParserState {
         }
     }
 
-    /**
-     * Prepares the input line replacing {@code \0}
-     */
+    /** Prepares the input line replacing {@code \0} */
     private static String prepareLine(String line) {
         if (line.indexOf('\0') == -1) {
             return line;

--- a/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
@@ -1,13 +1,13 @@
 package org.commonmark.internal;
 
+import static org.commonmark.internal.util.Escaping.unescapeString;
+
 import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.Block;
 import org.commonmark.node.FencedCodeBlock;
 import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.block.*;
 import org.commonmark.text.Characters;
-
-import static org.commonmark.internal.util.Escaping.unescapeString;
 
 public class FencedCodeBlockParser extends AbstractBlockParser {
 
@@ -36,7 +36,9 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
         int nextNonSpace = state.getNextNonSpaceIndex();
         int newIndex = state.getIndex();
         CharSequence line = state.getLine().getContent();
-        if (state.getIndent() < Parsing.CODE_BLOCK_INDENT && nextNonSpace < line.length() && tryClosing(line, nextNonSpace)) {
+        if (state.getIndent() < Parsing.CODE_BLOCK_INDENT
+                && nextNonSpace < line.length()
+                && tryClosing(line, nextNonSpace)) {
             // closing fence - we're at end of line, so we can finalize now
             return BlockContinue.finished();
         } else {
@@ -78,17 +80,19 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
             }
 
             int nextNonSpace = state.getNextNonSpaceIndex();
-            FencedCodeBlockParser blockParser = checkOpener(state.getLine().getContent(), nextNonSpace, indent);
+            FencedCodeBlockParser blockParser =
+                    checkOpener(state.getLine().getContent(), nextNonSpace, indent);
             if (blockParser != null) {
-                return BlockStart.of(blockParser).atIndex(nextNonSpace + blockParser.block.getOpeningFenceLength());
+                return BlockStart.of(blockParser)
+                        .atIndex(nextNonSpace + blockParser.block.getOpeningFenceLength());
             } else {
                 return BlockStart.none();
             }
         }
     }
 
-    // spec: A code fence is a sequence of at least three consecutive backtick characters (`) or tildes (~). (Tildes and
-    // backticks cannot be mixed.)
+    // spec: A code fence is a sequence of at least three consecutive backtick characters (`) or
+    // tildes (~). (Tildes and backticks cannot be mixed.)
     private static FencedCodeBlockParser checkOpener(CharSequence line, int index, int indent) {
         int backticks = 0;
         int tildes = 0;
@@ -107,7 +111,8 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
             }
         }
         if (backticks >= 3 && tildes == 0) {
-            // spec: If the info string comes after a backtick fence, it may not contain any backtick characters.
+            // spec: If the info string comes after a backtick fence, it may not contain any
+            // backtick characters.
             if (Characters.find('`', line, index + backticks) != -1) {
                 return null;
             }
@@ -120,8 +125,9 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
         }
     }
 
-    // spec: The content of the code block consists of all subsequent lines, until a closing code fence of the same type
-    // as the code block began with (backticks or tildes), and with at least as many backticks or tildes as the opening
+    // spec: The content of the code block consists of all subsequent lines, until a closing code
+    // fence of the same type as the code block began with (backticks or tildes), and with at least
+    // as many backticks or tildes as the opening
     // code fence.
     private boolean tryClosing(CharSequence line, int index) {
         int fences = Characters.skip(fenceChar, line, index, line.length()) - index;

--- a/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
@@ -28,7 +28,8 @@ public class HeadingParser extends AbstractBlockParser {
 
     @Override
     public BlockContinue tryContinue(ParserState parserState) {
-        // In both ATX and Setext headings, once we have the heading markup, there's nothing more to parse.
+        // In both ATX and Setext headings, once we have the heading markup, there's nothing more to
+        // parse.
         return BlockContinue.none();
     }
 
@@ -48,7 +49,8 @@ public class HeadingParser extends AbstractBlockParser {
             SourceLine line = state.getLine();
             int nextNonSpace = state.getNextNonSpaceIndex();
             if (line.getContent().charAt(nextNonSpace) == '#') {
-                HeadingParser atxHeading = getAtxHeading(line.substring(nextNonSpace, line.getContent().length()));
+                HeadingParser atxHeading =
+                        getAtxHeading(line.substring(nextNonSpace, line.getContent().length()));
                 if (atxHeading != null) {
                     return BlockStart.of(atxHeading).atIndex(line.getContent().length());
                 }
@@ -68,10 +70,11 @@ public class HeadingParser extends AbstractBlockParser {
         }
     }
 
-    // spec: An ATX heading consists of a string of characters, parsed as inline content, between an opening sequence of
-    // 1-6 unescaped # characters and an optional closing sequence of any number of unescaped # characters. The opening
-    // sequence of # characters must be followed by a space or by the end of line. The optional closing sequence of #s
-    // must be preceded by a space and may be followed by spaces only.
+    // spec: An ATX heading consists of a string of characters, parsed as inline content, between an
+    // opening sequence of 1-6 unescaped # characters and an optional closing sequence of any number
+    // of unescaped # characters. The opening sequence of # characters must be followed by a space
+    // or by the end of line. The optional closing sequence of #s must be preceded by a space and
+    // may be followed by spaces only.
     private static HeadingParser getAtxHeading(SourceLine line) {
         Scanner scanner = Scanner.of(SourceLines.of(line));
         int level = scanner.matchMultiple('#');
@@ -102,7 +105,8 @@ public class HeadingParser extends AbstractBlockParser {
                     if (hashCanEnd) {
                         scanner.matchMultiple('#');
                         int whitespace = scanner.whitespace();
-                        // If there's other characters, the hashes and spaces were part of the heading
+                        // If there's other characters, the hashes and spaces were part of the
+                        // heading
                         if (scanner.hasNext()) {
                             end = scanner.position();
                         }
@@ -132,8 +136,8 @@ public class HeadingParser extends AbstractBlockParser {
         return new HeadingParser(level, source);
     }
 
-    // spec: A setext heading underline is a sequence of = characters or a sequence of - characters, with no more than
-    // 3 spaces indentation and any number of trailing spaces.
+    // spec: A setext heading underline is a sequence of = characters or a sequence of - characters,
+    // with no more than 3 spaces indentation and any number of trailing spaces.
     private static int getSetextHeadingLevel(CharSequence line, int index) {
         switch (line.charAt(index)) {
             case '=':

--- a/commonmark/src/main/java/org/commonmark/internal/HtmlBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HtmlBlockParser.java
@@ -1,12 +1,11 @@
 package org.commonmark.internal;
 
+import java.util.regex.Pattern;
 import org.commonmark.node.Block;
 import org.commonmark.node.HtmlBlock;
 import org.commonmark.node.Paragraph;
 import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.block.*;
-
-import java.util.regex.Pattern;
 
 public class HtmlBlockParser extends AbstractBlockParser {
 
@@ -15,63 +14,56 @@ public class HtmlBlockParser extends AbstractBlockParser {
     private static final String UNQUOTEDVALUE = "[^\"'=<>`\\x00-\\x20]+";
     private static final String SINGLEQUOTEDVALUE = "'[^']*'";
     private static final String DOUBLEQUOTEDVALUE = "\"[^\"]*\"";
-    private static final String ATTRIBUTEVALUE = "(?:" + UNQUOTEDVALUE + "|" + SINGLEQUOTEDVALUE
-            + "|" + DOUBLEQUOTEDVALUE + ")";
-    private static final String ATTRIBUTEVALUESPEC = "(?:" + "\\s*=" + "\\s*" + ATTRIBUTEVALUE
-            + ")";
-    private static final String ATTRIBUTE = "(?:" + "\\s+" + ATTRIBUTENAME + ATTRIBUTEVALUESPEC
-            + "?)";
+    private static final String ATTRIBUTEVALUE =
+            "(?:" + UNQUOTEDVALUE + "|" + SINGLEQUOTEDVALUE + "|" + DOUBLEQUOTEDVALUE + ")";
+    private static final String ATTRIBUTEVALUESPEC =
+            "(?:" + "\\s*=" + "\\s*" + ATTRIBUTEVALUE + ")";
+    private static final String ATTRIBUTE =
+            "(?:" + "\\s+" + ATTRIBUTENAME + ATTRIBUTEVALUESPEC + "?)";
 
     private static final String OPENTAG = "<" + TAGNAME + ATTRIBUTE + "*" + "\\s*/?>";
     private static final String CLOSETAG = "</" + TAGNAME + "\\s*[>]";
 
-    private static final Pattern[][] BLOCK_PATTERNS = new Pattern[][]{
-            {null, null}, // not used (no type 0)
-            {
-                    Pattern.compile("^<(?:script|pre|style|textarea)(?:\\s|>|$)", Pattern.CASE_INSENSITIVE),
+    private static final Pattern[][] BLOCK_PATTERNS =
+            new Pattern[][] {
+                {null, null}, // not used (no type 0)
+                {
+                    Pattern.compile(
+                            "^<(?:script|pre|style|textarea)(?:\\s|>|$)", Pattern.CASE_INSENSITIVE),
                     Pattern.compile("</(?:script|pre|style|textarea)>", Pattern.CASE_INSENSITIVE)
-            },
-            {
-                    Pattern.compile("^<!--"),
-                    Pattern.compile("-->")
-            },
-            {
-                    Pattern.compile("^<[?]"),
-                    Pattern.compile("\\?>")
-            },
-            {
-                    Pattern.compile("^<![A-Z]"),
-                    Pattern.compile(">")
-            },
-            {
-                    Pattern.compile("^<!\\[CDATA\\["),
-                    Pattern.compile("\\]\\]>")
-            },
-            {
-                    Pattern.compile("^</?(?:" +
-                            "address|article|aside|" +
-                            "base|basefont|blockquote|body|" +
-                            "caption|center|col|colgroup|" +
-                            "dd|details|dialog|dir|div|dl|dt|" +
-                            "fieldset|figcaption|figure|footer|form|frame|frameset|" +
-                            "h1|h2|h3|h4|h5|h6|head|header|hr|html|" +
-                            "iframe|" +
-                            "legend|li|link|" +
-                            "main|menu|menuitem|" +
-                            "nav|noframes|" +
-                            "ol|optgroup|option|" +
-                            "p|param|" +
-                            "search|section|summary|" +
-                            "table|tbody|td|tfoot|th|thead|title|tr|track|" +
-                            "ul" +
-                            ")(?:\\s|[/]?[>]|$)", Pattern.CASE_INSENSITIVE),
+                },
+                {Pattern.compile("^<!--"), Pattern.compile("-->")},
+                {Pattern.compile("^<[?]"), Pattern.compile("\\?>")},
+                {Pattern.compile("^<![A-Z]"), Pattern.compile(">")},
+                {Pattern.compile("^<!\\[CDATA\\["), Pattern.compile("\\]\\]>")},
+                {
+                    Pattern.compile(
+                            "^</?(?:"
+                                    + "address|article|aside|"
+                                    + "base|basefont|blockquote|body|"
+                                    + "caption|center|col|colgroup|"
+                                    + "dd|details|dialog|dir|div|dl|dt|"
+                                    + "fieldset|figcaption|figure|footer|form|frame|frameset|"
+                                    + "h1|h2|h3|h4|h5|h6|head|header|hr|html|"
+                                    + "iframe|"
+                                    + "legend|li|link|"
+                                    + "main|menu|menuitem|"
+                                    + "nav|noframes|"
+                                    + "ol|optgroup|option|"
+                                    + "p|param|"
+                                    + "search|section|summary|"
+                                    + "table|tbody|td|tfoot|th|thead|title|tr|track|"
+                                    + "ul"
+                                    + ")(?:\\s|[/]?[>]|$)",
+                            Pattern.CASE_INSENSITIVE),
                     null // terminated by blank line
-            },
-            {
-                    Pattern.compile("^(?:" + OPENTAG + '|' + CLOSETAG + ")\\s*$", Pattern.CASE_INSENSITIVE),
+                },
+                {
+                    Pattern.compile(
+                            "^(?:" + OPENTAG + '|' + CLOSETAG + ")\\s*$", Pattern.CASE_INSENSITIVE),
                     null // terminated by blank line
-            }
-    };
+                }
+            };
 
     private final HtmlBlock block = new HtmlBlock();
     private final Pattern closingPattern;
@@ -127,14 +119,17 @@ public class HtmlBlockParser extends AbstractBlockParser {
             if (state.getIndent() < 4 && line.charAt(nextNonSpace) == '<') {
                 for (int blockType = 1; blockType <= 7; blockType++) {
                     // Type 7 can not interrupt a paragraph (not even a lazy one)
-                    if (blockType == 7 && (
-                            matchedBlockParser.getMatchedBlockParser().getBlock() instanceof Paragraph ||
-                                    state.getActiveBlockParser().canHaveLazyContinuationLines())) {
+                    if (blockType == 7
+                            && (matchedBlockParser.getMatchedBlockParser().getBlock()
+                                            instanceof Paragraph
+                                    || state.getActiveBlockParser()
+                                            .canHaveLazyContinuationLines())) {
                         continue;
                     }
                     Pattern opener = BLOCK_PATTERNS[blockType][0];
                     Pattern closer = BLOCK_PATTERNS[blockType][1];
-                    boolean matches = opener.matcher(line.subSequence(nextNonSpace, line.length())).find();
+                    boolean matches =
+                            opener.matcher(line.subSequence(nextNonSpace, line.length())).find();
                     if (matches) {
                         return BlockStart.of(new HtmlBlockParser(closer)).atIndex(state.getIndex());
                     }

--- a/commonmark/src/main/java/org/commonmark/internal/IndentedCodeBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/IndentedCodeBlockParser.java
@@ -1,5 +1,7 @@
 package org.commonmark.internal;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.Block;
 import org.commonmark.node.IndentedCodeBlock;
@@ -7,9 +9,6 @@ import org.commonmark.node.Paragraph;
 import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.block.*;
 import org.commonmark.text.Characters;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class IndentedCodeBlockParser extends AbstractBlockParser {
 
@@ -62,12 +61,14 @@ public class IndentedCodeBlockParser extends AbstractBlockParser {
         @Override
         public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
             // An indented code block cannot interrupt a paragraph.
-            if (state.getIndent() >= Parsing.CODE_BLOCK_INDENT && !state.isBlank() && !(state.getActiveBlockParser().getBlock() instanceof Paragraph)) {
-                return BlockStart.of(new IndentedCodeBlockParser()).atColumn(state.getColumn() + Parsing.CODE_BLOCK_INDENT);
+            if (state.getIndent() >= Parsing.CODE_BLOCK_INDENT
+                    && !state.isBlank()
+                    && !(state.getActiveBlockParser().getBlock() instanceof Paragraph)) {
+                return BlockStart.of(new IndentedCodeBlockParser())
+                        .atColumn(state.getColumn() + Parsing.CODE_BLOCK_INDENT);
             } else {
                 return BlockStart.none();
             }
         }
     }
 }
-

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserContextImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserContextImpl.java
@@ -1,13 +1,12 @@
 package org.commonmark.internal;
 
-import org.commonmark.node.LinkReferenceDefinition;
-import org.commonmark.parser.InlineParserContext;
-import org.commonmark.parser.beta.LinkProcessor;
-import org.commonmark.parser.beta.InlineContentParserFactory;
-import org.commonmark.parser.delimiter.DelimiterProcessor;
-
 import java.util.List;
 import java.util.Set;
+import org.commonmark.node.LinkReferenceDefinition;
+import org.commonmark.parser.InlineParserContext;
+import org.commonmark.parser.beta.InlineContentParserFactory;
+import org.commonmark.parser.beta.LinkProcessor;
+import org.commonmark.parser.delimiter.DelimiterProcessor;
 
 public class InlineParserContextImpl implements InlineParserContext {
 
@@ -17,11 +16,12 @@ public class InlineParserContextImpl implements InlineParserContext {
     private final Set<Character> linkMarkers;
     private final Definitions definitions;
 
-    public InlineParserContextImpl(List<InlineContentParserFactory> inlineContentParserFactories,
-                                   List<DelimiterProcessor> delimiterProcessors,
-                                   List<LinkProcessor> linkProcessors,
-                                   Set<Character> linkMarkers,
-                                   Definitions definitions) {
+    public InlineParserContextImpl(
+            List<InlineContentParserFactory> inlineContentParserFactories,
+            List<DelimiterProcessor> delimiterProcessors,
+            List<LinkProcessor> linkProcessors,
+            Set<Character> linkMarkers,
+            Definitions definitions) {
         this.inlineContentParserFactories = inlineContentParserFactories;
         this.delimiterProcessors = delimiterProcessors;
         this.linkProcessors = linkProcessors;

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -1,5 +1,6 @@
 package org.commonmark.internal;
 
+import java.util.*;
 import org.commonmark.internal.inline.*;
 import org.commonmark.internal.util.Escaping;
 import org.commonmark.internal.util.LinkScanner;
@@ -7,12 +8,10 @@ import org.commonmark.node.*;
 import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.InlineParserContext;
 import org.commonmark.parser.SourceLines;
-import org.commonmark.parser.beta.Scanner;
 import org.commonmark.parser.beta.*;
+import org.commonmark.parser.beta.Scanner;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 import org.commonmark.text.Characters;
-
-import java.util.*;
 
 public class InlineParserImpl implements InlineParser, InlineParserState {
 
@@ -29,27 +28,34 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
     private int trailingSpaces;
 
     /**
-     * Top delimiter (emphasis, strong emphasis or custom emphasis). (Brackets are on a separate stack, different
-     * from the algorithm described in the spec.)
+     * Top delimiter (emphasis, strong emphasis or custom emphasis). (Brackets are on a separate
+     * stack, different from the algorithm described in the spec.)
      */
     private Delimiter lastDelimiter;
 
-    /**
-     * Top opening bracket (<code>[</code> or <code>![)</code>).
-     */
+    /** Top opening bracket (<code>[</code> or <code>![)</code>). */
     private Bracket lastBracket;
 
     public InlineParserImpl(InlineParserContext context) {
         this.context = context;
-        this.inlineContentParserFactories = calculateInlineContentParserFactories(context.getCustomInlineContentParserFactories());
-        this.delimiterProcessors = calculateDelimiterProcessors(context.getCustomDelimiterProcessors());
+        this.inlineContentParserFactories =
+                calculateInlineContentParserFactories(
+                        context.getCustomInlineContentParserFactories());
+        this.delimiterProcessors =
+                calculateDelimiterProcessors(context.getCustomDelimiterProcessors());
         this.linkProcessors = calculateLinkProcessors(context.getCustomLinkProcessors());
         this.linkMarkers = calculateLinkMarkers(context.getCustomLinkMarkers());
-        this.specialCharacters = calculateSpecialCharacters(linkMarkers, this.delimiterProcessors.keySet(), this.inlineContentParserFactories);
+        this.specialCharacters =
+                calculateSpecialCharacters(
+                        linkMarkers,
+                        this.delimiterProcessors.keySet(),
+                        this.inlineContentParserFactories);
     }
 
-    private List<InlineContentParserFactory> calculateInlineContentParserFactories(List<InlineContentParserFactory> customFactories) {
-        // Custom parsers can override built-in parsers if they want, so make sure they are tried first
+    private List<InlineContentParserFactory> calculateInlineContentParserFactories(
+            List<InlineContentParserFactory> customFactories) {
+        // Custom parsers can override built-in parsers if they want, so make sure they are tried
+        // first
         var list = new ArrayList<>(customFactories);
         list.add(new BackslashInlineParser.Factory());
         list.add(new BackticksInlineParser.Factory());
@@ -60,20 +66,25 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
     }
 
     private List<LinkProcessor> calculateLinkProcessors(List<LinkProcessor> linkProcessors) {
-        // Custom link processors can override the built-in behavior, so make sure they are tried first
+        // Custom link processors can override the built-in behavior, so make sure they are tried
+        // first
         var list = new ArrayList<>(linkProcessors);
         list.add(new CoreLinkProcessor());
         return list;
     }
 
-    private static Map<Character, DelimiterProcessor> calculateDelimiterProcessors(List<DelimiterProcessor> delimiterProcessors) {
+    private static Map<Character, DelimiterProcessor> calculateDelimiterProcessors(
+            List<DelimiterProcessor> delimiterProcessors) {
         var map = new HashMap<Character, DelimiterProcessor>();
-        addDelimiterProcessors(List.of(new AsteriskDelimiterProcessor(), new UnderscoreDelimiterProcessor()), map);
+        addDelimiterProcessors(
+                List.of(new AsteriskDelimiterProcessor(), new UnderscoreDelimiterProcessor()), map);
         addDelimiterProcessors(delimiterProcessors, map);
         return map;
     }
 
-    private static void addDelimiterProcessors(Iterable<DelimiterProcessor> delimiterProcessors, Map<Character, DelimiterProcessor> map) {
+    private static void addDelimiterProcessors(
+            Iterable<DelimiterProcessor> delimiterProcessors,
+            Map<Character, DelimiterProcessor> map) {
         for (DelimiterProcessor delimiterProcessor : delimiterProcessors) {
             char opening = delimiterProcessor.getOpeningCharacter();
             char closing = delimiterProcessor.getClosingCharacter();
@@ -99,10 +110,14 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         }
     }
 
-    private static void addDelimiterProcessorForChar(char delimiterChar, DelimiterProcessor toAdd, Map<Character, DelimiterProcessor> delimiterProcessors) {
+    private static void addDelimiterProcessorForChar(
+            char delimiterChar,
+            DelimiterProcessor toAdd,
+            Map<Character, DelimiterProcessor> delimiterProcessors) {
         DelimiterProcessor existing = delimiterProcessors.put(delimiterChar, toAdd);
         if (existing != null) {
-            throw new IllegalArgumentException("Delimiter processor conflict with delimiter char '" + delimiterChar + "'");
+            throw new IllegalArgumentException(
+                    "Delimiter processor conflict with delimiter char '" + delimiterChar + "'");
         }
     }
 
@@ -115,9 +130,10 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         return bitSet;
     }
 
-    private static BitSet calculateSpecialCharacters(BitSet linkMarkers,
-                                                     Set<Character> delimiterCharacters,
-                                                     List<InlineContentParserFactory> inlineContentParserFactories) {
+    private static BitSet calculateSpecialCharacters(
+            BitSet linkMarkers,
+            Set<Character> delimiterCharacters,
+            List<InlineContentParserFactory> inlineContentParserFactories) {
         BitSet bitSet = (BitSet) linkMarkers.clone();
         for (Character c : delimiterCharacters) {
             bitSet.set(c);
@@ -150,9 +166,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         return scanner;
     }
 
-    /**
-     * Parse content in block into inline children, appending them to the block node.
-     */
+    /** Parse content in block into inline children, appending them to the block node. */
     @Override
     public void parse(SourceLines lines, Node block) {
         reset(lines);
@@ -187,9 +201,8 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
     }
 
     /**
-     * Parse the next inline element in subject, advancing our position.
-     * On success, return the new inline node.
-     * On failure, return null.
+     * Parse the next inline element in subject, advancing our position. On success, return the new
+     * inline node. On failure, return null.
      */
     private List<? extends Node> parseInline() {
         char c = scanner.peek();
@@ -230,7 +243,8 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
                     Node node = parsedInlineImpl.getNode();
                     scanner.setPosition(parsedInlineImpl.getPosition());
                     if (includeSourceSpans && node.getSourceSpans().isEmpty()) {
-                        node.setSourceSpans(scanner.getSource(position, scanner.position()).getSourceSpans());
+                        node.setSourceSpans(
+                                scanner.getSource(position, scanner.position()).getSourceSpans());
                     }
                     return List.of(node);
                 } else {
@@ -252,10 +266,9 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         return List.of(parseText());
     }
 
-    /**
-     * Attempt to parse delimiters like emphasis, strong emphasis or custom delimiters.
-     */
-    private List<? extends Node> parseDelimiters(DelimiterProcessor delimiterProcessor, char delimiterChar) {
+    /** Attempt to parse delimiters like emphasis, strong emphasis or custom delimiters. */
+    private List<? extends Node> parseDelimiters(
+            DelimiterProcessor delimiterProcessor, char delimiterChar) {
         DelimiterData res = scanDelimiters(delimiterProcessor, delimiterChar);
         if (res == null) {
             return null;
@@ -264,7 +277,8 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         List<Text> characters = res.characters;
 
         // Add entry to stack for this opener
-        lastDelimiter = new Delimiter(characters, delimiterChar, res.canOpen, res.canClose, lastDelimiter);
+        lastDelimiter =
+                new Delimiter(characters, delimiterChar, res.canOpen, res.canClose, lastDelimiter);
         if (lastDelimiter.previous != null) {
             lastDelimiter.previous.next = lastDelimiter;
         }
@@ -272,9 +286,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         return characters;
     }
 
-    /**
-     * Add open bracket to delimiter stack and add a text node to block's children.
-     */
+    /** Add open bracket to delimiter stack and add a text node to block's children. */
     private Node parseOpenBracket() {
         Position start = scanner.position();
         scanner.next();
@@ -288,10 +300,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         return node;
     }
 
-    /**
-     * If next character is {@code [}, add a bracket to the stack.
-     * Otherwise, return null.
-     */
+    /** If next character is {@code [}, add a bracket to the stack. Otherwise, return null. */
     private List<? extends Node> parseLinkMarker() {
         var markerPosition = scanner.position();
         scanner.next();
@@ -302,7 +311,15 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
             var bracketNode = text(scanner.getSource(bracketPosition, contentPosition));
 
             // Add entry to stack for this opener
-            addBracket(Bracket.withMarker(bangNode, markerPosition, bracketNode, bracketPosition, contentPosition, lastBracket, lastDelimiter));
+            addBracket(
+                    Bracket.withMarker(
+                            bangNode,
+                            markerPosition,
+                            bracketNode,
+                            bracketPosition,
+                            contentPosition,
+                            lastBracket,
+                            lastDelimiter));
             return List.of(bangNode, bracketNode);
         } else {
             return null;
@@ -310,8 +327,9 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
     }
 
     /**
-     * Try to match close bracket against an opening in the delimiter stack. Return either a link or image, or a
-     * plain [ character. If there is a matching delimiter, remove it from the delimiter stack.
+     * Try to match close bracket against an opening in the delimiter stack. Return either a link or
+     * image, or a plain [ character. If there is a matching delimiter, remove it from the delimiter
+     * stack.
      */
     private Node parseCloseBracket() {
         Position beforeClose = scanner.position();
@@ -379,7 +397,8 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         // Check to see if we have a link (or image, with a ! in front). The different types:
         // - Inline:       `[foo](/uri)` or with optional title `[foo](/uri "title")`
         // - Reference links
-        //   - Full:      `[foo][bar]` (foo is the text and bar is the label that needs to match a reference)
+        //   - Full:      `[foo][bar]` (foo is the text and bar is the label that needs to match a
+        // reference)
         //   - Collapsed: `[foo][]`    (foo is both the text and label)
         //   - Shortcut:  `[foo]`      (foo is both the text and label)
 
@@ -390,14 +409,21 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         var destinationTitle = parseInlineDestinationTitle(scanner);
         if (destinationTitle != null) {
             var text = scanner.getSource(opener.contentPosition, beforeClose).getContent();
-            return new LinkInfoImpl(opener.markerNode, opener.bracketNode, text, null, destinationTitle.destination, destinationTitle.title, afterClose);
+            return new LinkInfoImpl(
+                    opener.markerNode,
+                    opener.bracketNode,
+                    text,
+                    null,
+                    destinationTitle.destination,
+                    destinationTitle.title,
+                    afterClose);
         }
         // Not an inline link/image, rewind back to after `]`.
         scanner.setPosition(afterClose);
 
         // Maybe a reference link/image like `[foo][bar]`, `[foo][]` or `[foo]`.
-        // Note that even `[foo](` could be a valid link if foo is a reference, which is why we try this even if the `(`
-        // failed to be parsed as an inline link/image before.
+        // Note that even `[foo](` could be a valid link if foo is a reference, which is why we try
+        // this even if the `(` failed to be parsed as an inline link/image before.
 
         // See if there's a link label like `[bar]` or `[]`
         var label = parseLinkLabel(scanner);
@@ -407,17 +433,20 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         }
         var textIsReference = label == null || label.isEmpty();
         if (opener.bracketAfter && textIsReference && opener.markerNode == null) {
-            // In case of shortcut or collapsed links, the text is used as the reference. But the reference is not allowed to
-            // contain an unescaped bracket, so if that's the case we don't need to continue. This is an optimization.
+            // In case of shortcut or collapsed links, the text is used as the reference. But the
+            // reference is not allowed to contain an unescaped bracket, so if that's the case we
+            // don't need to continue. This is an optimization.
             return null;
         }
 
         var text = scanner.getSource(opener.contentPosition, beforeClose).getContent();
-        return new LinkInfoImpl(opener.markerNode, opener.bracketNode, text, label, null, null, afterClose);
+        return new LinkInfoImpl(
+                opener.markerNode, opener.bracketNode, text, label, null, null, afterClose);
     }
 
     private Node wrapBracket(Bracket opener, Node wrapperNode, boolean includeMarker) {
-        // Add all nodes between the opening bracket and now (closing bracket) as child nodes of the link
+        // Add all nodes between the opening bracket and now (closing bracket) as child nodes of the
+        // link
         Node n = opener.bracketNode.getNext();
         while (n != null) {
             Node next = n.getNext();
@@ -426,8 +455,12 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         }
 
         if (includeSourceSpans) {
-            var startPosition = includeMarker && opener.markerPosition != null ? opener.markerPosition : opener.bracketPosition;
-            wrapperNode.setSourceSpans(scanner.getSource(startPosition, scanner.position()).getSourceSpans());
+            var startPosition =
+                    includeMarker && opener.markerPosition != null
+                            ? opener.markerPosition
+                            : opener.bracketPosition;
+            wrapperNode.setSourceSpans(
+                    scanner.getSource(startPosition, scanner.position()).getSourceSpans());
         }
 
         // Process delimiters such as emphasis inside link/image
@@ -440,7 +473,8 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         opener.bracketNode.unlink();
         removeLastBracket();
 
-        // Links within links are not allowed. We found this link, so there can be no other links around it.
+        // Links within links are not allowed. We found this link, so there can be no other links
+        // around it.
         if (opener.markerNode == null) {
             disallowPreviousLinks();
         }
@@ -455,24 +489,30 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         }
 
         if (includeSourceSpans) {
-            var startPosition = includeMarker && opener.markerPosition != null ? opener.markerPosition : opener.bracketPosition;
-            node.setSourceSpans(scanner.getSource(startPosition, scanner.position()).getSourceSpans());
+            var startPosition =
+                    includeMarker && opener.markerPosition != null
+                            ? opener.markerPosition
+                            : opener.bracketPosition;
+            node.setSourceSpans(
+                    scanner.getSource(startPosition, scanner.position()).getSourceSpans());
         }
 
         removeLastBracket();
 
         // Remove nodes that we added since the opener, because we're replacing them
-        Node n = includeMarker && opener.markerNode != null ? opener.markerNode : opener.bracketNode;
+        Node n =
+                includeMarker && opener.markerNode != null ? opener.markerNode : opener.bracketNode;
         while (n != null) {
             var next = n.getNext();
             n.unlink();
             n = next;
         }
 
-        // Links within links are not allowed. We found this link, so there can be no other links around it.
-        // Note that this makes any syntax like `[foo]` behave the same as built-in links, which is probably a good
-        // default (it works for footnotes). It might be useful for a `LinkProcessor` to be able to specify the
-        // behavior; something we could add to `LinkResult` in the future if requested.
+        // Links within links are not allowed. We found this link, so there can be no other links
+        // around it. Note that this makes any syntax like `[foo]` behave the same as built-in
+        // links, which is probably a good default (it works for footnotes). It might be useful for
+        // a `LinkProcessor` to be able to specify the behavior; something we could add to
+        // `LinkResult` in the future if requested.
         if (opener.markerNode == null || !includeMarker) {
             disallowPreviousLinks();
         }
@@ -502,9 +542,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         }
     }
 
-    /**
-     * Try to parse the destination and an optional title for an inline link/image.
-     */
+    /** Try to parse the destination and an optional title for an inline link/image. */
     private static DestinationTitle parseInlineDestinationTitle(Scanner scanner) {
         if (!scanner.next('(')) {
             return null;
@@ -531,9 +569,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         return new DestinationTitle(dest, title);
     }
 
-    /**
-     * Attempt to parse link destination, returning the string or null if no match.
-     */
+    /** Attempt to parse link destination, returning the string or null if no match. */
     private static String parseLinkDestination(Scanner scanner) {
         char delimiter = scanner.peek();
         Position start = scanner.position();
@@ -553,9 +589,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         return Escaping.unescapeString(dest);
     }
 
-    /**
-     * Attempt to parse link title (sans quotes), returning the string or null if no match.
-     */
+    /** Attempt to parse link title (sans quotes), returning the string or null if no match. */
     private static String parseLinkTitle(Scanner scanner) {
         Position start = scanner.position();
         if (!LinkScanner.scanLinkTitle(scanner)) {
@@ -568,9 +602,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         return Escaping.unescapeString(title);
     }
 
-    /**
-     * Attempt to parse a link label, returning the label between the brackets or null.
-     */
+    /** Attempt to parse a link label, returning the label between the brackets or null. */
     static String parseLinkLabel(Scanner scanner) {
         if (!scanner.next('[')) {
             return null;
@@ -608,7 +640,8 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
     }
 
     /**
-     * Parse the next character as plain text, and possibly more if the following characters are non-special.
+     * Parse the next character as plain text, and possibly more if the following characters are
+     * non-special.
      */
     private Node parseText() {
         Position start = scanner.position();
@@ -626,12 +659,14 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         String content = source.getContent();
 
         if (c == '\n') {
-            // We parsed until the end of the line. Trim any trailing spaces and remember them (for hard line breaks).
+            // We parsed until the end of the line. Trim any trailing spaces and remember them (for
+            // hard line breaks).
             int end = Characters.skipBackwards(' ', content, content.length() - 1, 0) + 1;
             trailingSpaces = content.length() - end;
             content = content.substring(0, end);
         } else if (c == Scanner.END) {
-            // For the last line, both tabs and spaces are trimmed for some reason (checked with commonmark.js).
+            // For the last line, both tabs and spaces are trimmed for some reason (checked with
+            // commonmark.js).
             int end = Characters.skipSpaceTabBackwards(content, content.length() - 1, 0) + 1;
             content = content.substring(0, end);
         }
@@ -642,12 +677,14 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
     }
 
     /**
-     * Scan a sequence of characters with code delimiterChar, and return information about the number of delimiters
-     * and whether they are positioned such that they can open and/or close emphasis or strong emphasis.
+     * Scan a sequence of characters with code delimiterChar, and return information about the
+     * number of delimiters and whether they are positioned such that they can open and/or close
+     * emphasis or strong emphasis.
      *
      * @return information about delimiter run, or {@code null}
      */
-    private DelimiterData scanDelimiters(DelimiterProcessor delimiterProcessor, char delimiterChar) {
+    private DelimiterData scanDelimiters(
+            DelimiterProcessor delimiterProcessor, char delimiterChar) {
         int before = scanner.peekPreviousCodePoint();
         Position start = scanner.position();
 
@@ -670,15 +707,20 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         int after = scanner.peekCodePoint();
 
         // We could be more lazy here, in most cases we don't need to do every match case.
-        boolean beforeIsPunctuation = before == Scanner.END || Characters.isPunctuationCodePoint(before);
-        boolean beforeIsWhitespace = before == Scanner.END || Characters.isWhitespaceCodePoint(before);
-        boolean afterIsPunctuation = after == Scanner.END || Characters.isPunctuationCodePoint(after);
+        boolean beforeIsPunctuation =
+                before == Scanner.END || Characters.isPunctuationCodePoint(before);
+        boolean beforeIsWhitespace =
+                before == Scanner.END || Characters.isWhitespaceCodePoint(before);
+        boolean afterIsPunctuation =
+                after == Scanner.END || Characters.isPunctuationCodePoint(after);
         boolean afterIsWhitespace = after == Scanner.END || Characters.isWhitespaceCodePoint(after);
 
-        boolean leftFlanking = !afterIsWhitespace &&
-                (!afterIsPunctuation || beforeIsWhitespace || beforeIsPunctuation);
-        boolean rightFlanking = !beforeIsWhitespace &&
-                (!beforeIsPunctuation || afterIsWhitespace || afterIsPunctuation);
+        boolean leftFlanking =
+                !afterIsWhitespace
+                        && (!afterIsPunctuation || beforeIsWhitespace || beforeIsPunctuation);
+        boolean rightFlanking =
+                !beforeIsWhitespace
+                        && (!beforeIsPunctuation || afterIsWhitespace || afterIsPunctuation);
         boolean canOpen;
         boolean canClose;
         if (delimiterChar == '_') {
@@ -718,7 +760,9 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
             boolean openerFound = false;
             boolean potentialOpenerFound = false;
             Delimiter opener = closer.previous;
-            while (opener != null && opener != stackBottom && opener != openersBottom.get(delimiterChar)) {
+            while (opener != null
+                    && opener != stackBottom
+                    && opener != openersBottom.get(delimiterChar)) {
                 if (opener.canOpen() && opener.delimiterChar == openingDelimiterChar) {
                     potentialOpenerFound = true;
                     usedDelims = delimiterProcessor.process(opener, closer);
@@ -762,7 +806,8 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
 
             removeDelimitersBetween(opener, closer);
 
-            // No delimiter characters left to process, so we can remove delimiter and the now empty node.
+            // No delimiter characters left to process, so we can remove delimiter and the now empty
+            // node.
             if (opener.length() == 0) {
                 removeDelimiterAndNodes(opener);
             }
@@ -790,14 +835,16 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
     }
 
     /**
-     * Remove the delimiter and the corresponding text node. For used delimiters, e.g. `*` in `*foo*`.
+     * Remove the delimiter and the corresponding text node. For used delimiters, e.g. `*` in
+     * `*foo*`.
      */
     private void removeDelimiterAndNodes(Delimiter delim) {
         removeDelimiter(delim);
     }
 
     /**
-     * Remove the delimiter but keep the corresponding node as text. For unused delimiters such as `_` in `foo_bar`.
+     * Remove the delimiter but keep the corresponding node as text. For unused delimiters such as
+     * `_` in `foo_bar`.
      */
     private void removeDelimiterKeepNode(Delimiter delim) {
         removeDelimiter(delim);
@@ -897,9 +944,7 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         }
     }
 
-    /**
-     * A destination and optional title for a link or image.
-     */
+    /** A destination and optional title for a link or image. */
     private static class DestinationTitle {
         final String destination;
         final String title;
@@ -920,8 +965,14 @@ public class InlineParserImpl implements InlineParser, InlineParserState {
         private final String title;
         private final Position afterTextBracket;
 
-        private LinkInfoImpl(Text marker, Text openingBracket, String text, String label,
-                             String destination, String title, Position afterTextBracket) {
+        private LinkInfoImpl(
+                Text marker,
+                Text openingBracket,
+                String text,
+                String label,
+                String destination,
+                String title,
+                Position afterTextBracket) {
             this.marker = marker;
             this.openingBracket = openingBracket;
             this.text = text;

--- a/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
@@ -1,5 +1,8 @@
 package org.commonmark.internal;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.commonmark.internal.util.Escaping;
 import org.commonmark.internal.util.LinkScanner;
 import org.commonmark.node.LinkReferenceDefinition;
@@ -9,14 +12,11 @@ import org.commonmark.parser.SourceLines;
 import org.commonmark.parser.beta.Position;
 import org.commonmark.parser.beta.Scanner;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 /**
  * Parser for link reference definitions at the beginning of a paragraph.
  *
- * @see <a href="https://spec.commonmark.org/0.31.2/#link-reference-definitions">Link reference definitions</a>
+ * @see <a href="https://spec.commonmark.org/0.31.2/#link-reference-definitions">Link reference
+ *     definitions</a>
  */
 public class LinkReferenceDefinitionParser {
 
@@ -35,8 +35,8 @@ public class LinkReferenceDefinitionParser {
     public void parse(SourceLine line) {
         paragraphLines.add(line);
         if (state == State.PARAGRAPH) {
-            // We're in a paragraph now. Link reference definitions can only appear at the beginning, so once
-            // we're in a paragraph, there's no going back.
+            // We're in a paragraph now. Link reference definitions can only appear at the
+            // beginning, so once we're in a paragraph, there's no going back.
             return;
         }
 
@@ -44,35 +44,41 @@ public class LinkReferenceDefinitionParser {
         while (scanner.hasNext()) {
             boolean success;
             switch (state) {
-                case START_DEFINITION: {
-                    success = startDefinition(scanner);
-                    break;
-                }
-                case LABEL: {
-                    success = label(scanner);
-                    break;
-                }
-                case DESTINATION: {
-                    success = destination(scanner);
-                    break;
-                }
-                case START_TITLE: {
-                    success = startTitle(scanner);
-                    break;
-                }
-                case TITLE: {
-                    success = title(scanner);
-                    break;
-                }
-                default: {
-                    throw new IllegalStateException("Unknown parsing state: " + state);
-                }
+                case START_DEFINITION:
+                    {
+                        success = startDefinition(scanner);
+                        break;
+                    }
+                case LABEL:
+                    {
+                        success = label(scanner);
+                        break;
+                    }
+                case DESTINATION:
+                    {
+                        success = destination(scanner);
+                        break;
+                    }
+                case START_TITLE:
+                    {
+                        success = startTitle(scanner);
+                        break;
+                    }
+                case TITLE:
+                    {
+                        success = title(scanner);
+                        break;
+                    }
+                default:
+                    {
+                        throw new IllegalStateException("Unknown parsing state: " + state);
+                    }
             }
             // Parsing failed, which means we fall back to treating text as a paragraph.
             if (!success) {
                 state = State.PARAGRAPH;
-                // If parsing of the title part failed, we still have a valid reference that we can add, and we need to
-                // do it before the source span for this line is added.
+                // If parsing of the title part failed, we still have a valid reference that we can
+                // add, and we need to do it before the source span for this line is added.
                 finishReference();
                 return;
             }
@@ -104,16 +110,20 @@ public class LinkReferenceDefinitionParser {
     }
 
     List<SourceSpan> removeLines(int lines) {
-        var removedSpans = Collections.unmodifiableList(new ArrayList<>(
-                sourceSpans.subList(Math.max(sourceSpans.size() - lines, 0), sourceSpans.size())));
+        var removedSpans =
+                Collections.unmodifiableList(
+                        new ArrayList<>(
+                                sourceSpans.subList(
+                                        Math.max(sourceSpans.size() - lines, 0),
+                                        sourceSpans.size())));
         removeLast(lines, paragraphLines);
         removeLast(lines, sourceSpans);
         return removedSpans;
     }
 
     private boolean startDefinition(Scanner scanner) {
-        // Finish any outstanding references now. We don't do this earlier because we need addSourceSpan to have been
-        // called before we do it.
+        // Finish any outstanding references now. We don't do this earlier because we need
+        // addSourceSpan to have been called before we do it.
         finishReference();
 
         scanner.whitespace();
@@ -175,14 +185,15 @@ public class LinkReferenceDefinitionParser {
         }
 
         String rawDestination = scanner.getSource(start, scanner.position()).getContent();
-        destination = rawDestination.startsWith("<") ?
-                rawDestination.substring(1, rawDestination.length() - 1) :
-                rawDestination;
+        destination =
+                rawDestination.startsWith("<")
+                        ? rawDestination.substring(1, rawDestination.length() - 1)
+                        : rawDestination;
 
         int whitespace = scanner.whitespace();
         if (!scanner.hasNext()) {
-            // Destination was at end of line, so this is a valid reference for sure (and maybe a title).
-            // If not at end of line, wait for title to be valid first.
+            // Destination was at end of line, so this is a valid reference for sure (and maybe a
+            // title). If not at end of line, wait for title to be valid first.
             referenceValid = true;
             paragraphLines.clear();
         } else if (whitespace == 0) {
@@ -238,7 +249,8 @@ public class LinkReferenceDefinitionParser {
         title.append(scanner.getSource(start, scanner.position()).getContent());
 
         if (!scanner.hasNext()) {
-            // Title ran until the end of line, so continue on next line (until we find the delimiter)
+            // Title ran until the end of line, so continue on next line (until we find the
+            // delimiter)
             title.append('\n');
             return true;
         }

--- a/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
@@ -1,10 +1,9 @@
 package org.commonmark.internal;
 
+import java.util.Objects;
 import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.*;
 import org.commonmark.parser.block.*;
-
-import java.util.Objects;
 
 public class ListBlockParser extends AbstractBlockParser {
 
@@ -25,10 +24,11 @@ public class ListBlockParser extends AbstractBlockParser {
     @Override
     public boolean canContain(Block childBlock) {
         if (childBlock instanceof ListItem) {
-            // Another list item is added to this list block. If the previous line was blank, that means this list block
-            // is "loose" (not tight).
+            // Another list item is added to this list block. If the previous line was blank, that
+            // means this list block is "loose" (not tight).
             //
-            // spec: A list is loose if any of its constituent list items are separated by blank lines
+            // spec: A list is loose if any of its constituent list items are separated by blank
+            // lines
             if (hadBlankLine && linesAfterBlank == 1) {
                 block.setTight(false);
                 hadBlankLine = false;
@@ -52,16 +52,18 @@ public class ListBlockParser extends AbstractBlockParser {
         } else if (hadBlankLine) {
             linesAfterBlank++;
         }
-        // List blocks themselves don't have any markers, only list items. So try to stay in the list.
-        // If there is a block start other than list item, canContain makes sure that this list is closed.
+        // List blocks themselves don't have any markers, only list items. So try to stay in the
+        // list. If there is a block start other than list item, canContain makes sure that this
+        // list is closed.
         return BlockContinue.atIndex(state.getIndex());
     }
 
-    /**
-     * Parse a list marker and return data on the marker or null.
-     */
-    private static ListData parseList(CharSequence line, final int markerIndex, final int markerColumn,
-                                      final boolean inParagraph) {
+    /** Parse a list marker and return data on the marker or null. */
+    private static ListData parseList(
+            CharSequence line,
+            final int markerIndex,
+            final int markerColumn,
+            final boolean inParagraph) {
         ListMarkerData listMarker = parseListMarker(line, markerIndex);
         if (listMarker == null) {
             return null;
@@ -92,7 +94,8 @@ public class ListBlockParser extends AbstractBlockParser {
 
         if (inParagraph) {
             // If the list item is ordered, the start number must be 1 to interrupt a paragraph.
-            if (listBlock instanceof OrderedList && ((OrderedList) listBlock).getMarkerStartNumber() != 1) {
+            if (listBlock instanceof OrderedList
+                    && ((OrderedList) listBlock).getMarkerStartNumber() != 1) {
                 return null;
             }
             // Empty list item can not interrupt a paragraph.
@@ -128,8 +131,8 @@ public class ListBlockParser extends AbstractBlockParser {
         }
     }
 
-    // spec: An ordered list marker is a sequence of 1-9 arabic digits (0-9), followed by either a `.` character or a
-    // `)` character.
+    // spec: An ordered list marker is a sequence of 1-9 arabic digits (0-9), followed by either a
+    // `.` character or a `)` character.
     private static ListMarkerData parseOrderedList(CharSequence line, int index) {
         int digits = 0;
         int length = line.length();
@@ -184,15 +187,15 @@ public class ListBlockParser extends AbstractBlockParser {
     }
 
     /**
-     * Returns true if the two list items are of the same type,
-     * with the same delimiter and bullet character. This is used
-     * in agglomerating list items into lists.
+     * Returns true if the two list items are of the same type, with the same delimiter and bullet
+     * character. This is used in agglomerating list items into lists.
      */
     private static boolean listsMatch(ListBlock a, ListBlock b) {
         if (a instanceof BulletList && b instanceof BulletList) {
             return Objects.equals(((BulletList) a).getMarker(), ((BulletList) b).getMarker());
         } else if (a instanceof OrderedList && b instanceof OrderedList) {
-            return Objects.equals(((OrderedList) a).getMarkerDelimiter(), ((OrderedList) b).getMarkerDelimiter());
+            return Objects.equals(
+                    ((OrderedList) a).getMarkerDelimiter(), ((OrderedList) b).getMarkerDelimiter());
         }
         return false;
     }
@@ -209,20 +212,23 @@ public class ListBlockParser extends AbstractBlockParser {
             int markerIndex = state.getNextNonSpaceIndex();
             int markerColumn = state.getColumn() + state.getIndent();
             boolean inParagraph = !matchedBlockParser.getParagraphLines().isEmpty();
-            ListData listData = parseList(state.getLine().getContent(), markerIndex, markerColumn, inParagraph);
+            ListData listData =
+                    parseList(state.getLine().getContent(), markerIndex, markerColumn, inParagraph);
             if (listData == null) {
                 return BlockStart.none();
             }
 
             int newColumn = listData.contentColumn;
-            ListItemParser listItemParser = new ListItemParser(state.getIndent(), newColumn - state.getColumn());
+            ListItemParser listItemParser =
+                    new ListItemParser(state.getIndent(), newColumn - state.getColumn());
 
             // prepend the list block if needed
-            if (!(matched instanceof ListBlockParser) ||
-                    !(listsMatch((ListBlock) matched.getBlock(), listData.listBlock))) {
+            if (!(matched instanceof ListBlockParser)
+                    || !(listsMatch((ListBlock) matched.getBlock(), listData.listBlock))) {
 
                 ListBlockParser listBlockParser = new ListBlockParser(listData.listBlock);
-                // We start out with assuming a list is tight. If we find a blank line, we set it to loose later.
+                // We start out with assuming a list is tight. If we find a blank line, we set it to
+                // loose later.
                 listData.listBlock.setTight(true);
 
                 return BlockStart.of(listBlockParser, listItemParser).atColumn(newColumn);

--- a/commonmark/src/main/java/org/commonmark/internal/ListItemParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ListItemParser.java
@@ -13,8 +13,8 @@ public class ListItemParser extends AbstractBlockParser {
     private final ListItem block = new ListItem();
 
     /**
-     * Minimum number of columns that the content has to be indented (relative to the containing block) to be part of
-     * this list item.
+     * Minimum number of columns that the content has to be indented (relative to the containing
+     * block) to be part of this list item.
      */
     private int contentIndent;
 
@@ -36,8 +36,8 @@ public class ListItemParser extends AbstractBlockParser {
         if (hadBlankLine) {
             // We saw a blank line in this list item, that means the list block is loose.
             //
-            // spec: if any of its constituent list items directly contain two block-level elements with a blank line
-            // between them
+            // spec: if any of its constituent list items directly contain two block-level elements
+            // with a blank line between them
             Block parent = block.getParent();
             if (parent instanceof ListBlock) {
                 ((ListBlock) parent).setTight(false);
@@ -59,7 +59,8 @@ public class ListItemParser extends AbstractBlockParser {
                 return BlockContinue.none();
             } else {
                 Block activeBlock = state.getActiveBlockParser().getBlock();
-                // If the active block is a code block, blank lines in it should not affect if the list is tight.
+                // If the active block is a code block, blank lines in it should not affect if the
+                // list is tight.
                 hadBlankLine = activeBlock instanceof Paragraph || activeBlock instanceof ListItem;
                 return BlockContinue.atIndex(state.getNextNonSpaceIndex());
             }

--- a/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
@@ -1,5 +1,6 @@
 package org.commonmark.internal;
 
+import java.util.List;
 import org.commonmark.node.*;
 import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.SourceLine;
@@ -8,12 +9,11 @@ import org.commonmark.parser.block.AbstractBlockParser;
 import org.commonmark.parser.block.BlockContinue;
 import org.commonmark.parser.block.ParserState;
 
-import java.util.List;
-
 public class ParagraphParser extends AbstractBlockParser {
 
     private final Paragraph block = new Paragraph();
-    private final LinkReferenceDefinitionParser linkReferenceDefinitionParser = new LinkReferenceDefinitionParser();
+    private final LinkReferenceDefinitionParser linkReferenceDefinitionParser =
+            new LinkReferenceDefinitionParser();
 
     @Override
     public boolean canHaveLazyContinuationLines() {

--- a/commonmark/src/main/java/org/commonmark/internal/StaggeredDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/StaggeredDelimiterProcessor.java
@@ -1,27 +1,27 @@
 package org.commonmark.internal;
 
+import java.util.LinkedList;
+import java.util.ListIterator;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 import org.commonmark.parser.delimiter.DelimiterRun;
 
-import java.util.LinkedList;
-import java.util.ListIterator;
-
 /**
- * An implementation of DelimiterProcessor that dispatches all calls to two or more other DelimiterProcessors
- * depending on the length of the delimiter run. All child DelimiterProcessors must have different minimum
- * lengths. A given delimiter run is dispatched to the child with the largest acceptable minimum length. If no
- * child is applicable, the one with the largest minimum length is chosen.
+ * An implementation of DelimiterProcessor that dispatches all calls to two or more other
+ * DelimiterProcessors depending on the length of the delimiter run. All child DelimiterProcessors
+ * must have different minimum lengths. A given delimiter run is dispatched to the child with the
+ * largest acceptable minimum length. If no child is applicable, the one with the largest minimum
+ * length is chosen.
  */
 class StaggeredDelimiterProcessor implements DelimiterProcessor {
 
     private final char delim;
     private int minLength = 0;
-    private LinkedList<DelimiterProcessor> processors = new LinkedList<>(); // in reverse getMinLength order
+    private LinkedList<DelimiterProcessor> processors =
+            new LinkedList<>(); // in reverse getMinLength order
 
     StaggeredDelimiterProcessor(char delim) {
         this.delim = delim;
     }
-
 
     @Override
     public char getOpeningCharacter() {
@@ -51,7 +51,15 @@ class StaggeredDelimiterProcessor implements DelimiterProcessor {
                 added = true;
                 break;
             } else if (len == pLen) {
-                throw new IllegalArgumentException("Cannot add two delimiter processors for char '" + delim + "' and minimum length " + len + "; conflicting processors: " + p + ", " + dp);
+                throw new IllegalArgumentException(
+                        "Cannot add two delimiter processors for char '"
+                                + delim
+                                + "' and minimum length "
+                                + len
+                                + "; conflicting processors: "
+                                + p
+                                + ", "
+                                + dp);
             }
         }
         if (!added) {

--- a/commonmark/src/main/java/org/commonmark/internal/ThematicBreakParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ThematicBreakParser.java
@@ -41,8 +41,9 @@ public class ThematicBreakParser extends AbstractBlockParser {
         }
     }
 
-    // spec: A line consisting of 0-3 spaces of indentation, followed by a sequence of three or more matching -, _, or *
-    // characters, each followed optionally by any number of spaces, forms a thematic break.
+    // spec: A line consisting of 0-3 spaces of indentation, followed by a sequence of three or more
+    // matching -, _, or * characters, each followed optionally by any number of spaces, forms a
+    // thematic break.
     private static boolean isThematicBreak(CharSequence line, int index) {
         int dashes = 0;
         int underscores = 0;
@@ -68,8 +69,8 @@ public class ThematicBreakParser extends AbstractBlockParser {
             }
         }
 
-        return ((dashes >= 3 && underscores == 0 && asterisks == 0) ||
-                (underscores >= 3 && dashes == 0 && asterisks == 0) ||
-                (asterisks >= 3 && dashes == 0 && underscores == 0));
+        return ((dashes >= 3 && underscores == 0 && asterisks == 0)
+                || (underscores >= 3 && dashes == 0 && asterisks == 0)
+                || (asterisks >= 3 && dashes == 0 && underscores == 0));
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/AutolinkInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/AutolinkInlineParser.java
@@ -1,23 +1,21 @@
 package org.commonmark.internal.inline;
 
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.commonmark.node.Link;
 import org.commonmark.node.Text;
 import org.commonmark.parser.SourceLines;
 import org.commonmark.parser.beta.*;
 
-import java.util.Set;
-import java.util.regex.Pattern;
-
-/**
- * Attempt to parse an autolink (URL or email in pointy brackets).
- */
+/** Attempt to parse an autolink (URL or email in pointy brackets). */
 public class AutolinkInlineParser implements InlineContentParser {
 
-    private static final Pattern URI = Pattern
-            .compile("^[a-zA-Z][a-zA-Z0-9.+-]{1,31}:[^<>\u0000-\u0020]*$");
+    private static final Pattern URI =
+            Pattern.compile("^[a-zA-Z][a-zA-Z0-9.+-]{1,31}:[^<>\u0000-\u0020]*$");
 
-    private static final Pattern EMAIL = Pattern
-            .compile("^([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)$");
+    private static final Pattern EMAIL =
+            Pattern.compile(
+                    "^([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)$");
 
     @Override
     public ParsedInline tryParse(InlineParserState inlineParserState) {

--- a/commonmark/src/main/java/org/commonmark/internal/inline/BackslashInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/BackslashInlineParser.java
@@ -1,16 +1,16 @@
 package org.commonmark.internal.inline;
 
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.commonmark.internal.util.Escaping;
 import org.commonmark.node.HardLineBreak;
 import org.commonmark.node.Text;
 import org.commonmark.parser.beta.*;
 
-import java.util.Set;
-import java.util.regex.Pattern;
-
 /**
- * Parse a backslash-escaped special character, adding either the escaped  character, a hard line break
- * (if the backslash is followed by a newline), or a literal backslash to the block's children.
+ * Parse a backslash-escaped special character, adding either the escaped character, a hard line
+ * break (if the backslash is followed by a newline), or a literal backslash to the block's
+ * children.
  */
 public class BackslashInlineParser implements InlineContentParser {
 

--- a/commonmark/src/main/java/org/commonmark/internal/inline/BackticksInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/BackticksInlineParser.java
@@ -1,15 +1,15 @@
 package org.commonmark.internal.inline;
 
+import java.util.Set;
 import org.commonmark.node.Code;
 import org.commonmark.node.Text;
 import org.commonmark.parser.SourceLines;
 import org.commonmark.parser.beta.*;
 import org.commonmark.text.Characters;
 
-import java.util.Set;
-
 /**
- * Attempt to parse backticks, returning either a backtick code span or a literal sequence of backticks.
+ * Attempt to parse backticks, returning either a backtick code span or a literal sequence of
+ * backticks.
  */
 public class BackticksInlineParser implements InlineContentParser {
 
@@ -29,12 +29,13 @@ public class BackticksInlineParser implements InlineContentParser {
                 String content = scanner.getSource(afterOpening, beforeClosing).getContent();
                 content = content.replace('\n', ' ');
 
-                // spec: If the resulting string both begins and ends with a space character, but does not consist
-                // entirely of space characters, a single space character is removed from the front and back.
-                if (content.length() >= 3 &&
-                        content.charAt(0) == ' ' &&
-                        content.charAt(content.length() - 1) == ' ' &&
-                        Characters.hasNonSpace(content)) {
+                // spec: If the resulting string both begins and ends with a space character, but
+                // does not consist entirely of space characters, a single space character is
+                // removed from the front and back.
+                if (content.length() >= 3
+                        && content.charAt(0) == ' '
+                        && content.charAt(content.length() - 1) == ' '
+                        && Characters.hasNonSpace(content)) {
                     content = content.substring(1, content.length() - 1);
                 }
 

--- a/commonmark/src/main/java/org/commonmark/internal/inline/CoreLinkProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/CoreLinkProcessor.java
@@ -28,9 +28,11 @@ public class CoreLinkProcessor implements LinkProcessor {
         return LinkResult.none();
     }
 
-    private static LinkResult process(LinkInfo linkInfo, Scanner scanner, String destination, String title) {
+    private static LinkResult process(
+            LinkInfo linkInfo, Scanner scanner, String destination, String title) {
         if (linkInfo.marker() != null && linkInfo.marker().getLiteral().equals("!")) {
-            return LinkResult.wrapTextIn(new Image(destination, title), scanner.position()).includeMarker();
+            return LinkResult.wrapTextIn(new Image(destination, title), scanner.position())
+                    .includeMarker();
         }
         return LinkResult.wrapTextIn(new Link(destination, title), scanner.position());
     }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/EmphasisDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/EmphasisDelimiterProcessor.java
@@ -30,9 +30,9 @@ public abstract class EmphasisDelimiterProcessor implements DelimiterProcessor {
     @Override
     public int process(DelimiterRun openingRun, DelimiterRun closingRun) {
         // "multiple of 3" rule for internal delimiter runs
-        if ((openingRun.canClose() || closingRun.canOpen()) &&
-                closingRun.originalLength() % 3 != 0 &&
-                (openingRun.originalLength() + closingRun.originalLength()) % 3 == 0) {
+        if ((openingRun.canClose() || closingRun.canOpen())
+                && closingRun.originalLength() % 3 != 0
+                && (openingRun.originalLength() + closingRun.originalLength()) % 3 == 0) {
             return 0;
         }
 

--- a/commonmark/src/main/java/org/commonmark/internal/inline/EntityInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/EntityInlineParser.java
@@ -1,21 +1,21 @@
 package org.commonmark.internal.inline;
 
+import java.util.Set;
 import org.commonmark.internal.util.Html5Entities;
 import org.commonmark.node.Text;
 import org.commonmark.parser.beta.*;
 import org.commonmark.text.AsciiMatcher;
 
-import java.util.Set;
-
-/**
- * Attempts to parse an HTML entity or numeric character reference.
- */
+/** Attempts to parse an HTML entity or numeric character reference. */
 public class EntityInlineParser implements InlineContentParser {
 
-    private static final AsciiMatcher hex = AsciiMatcher.builder().range('0', '9').range('A', 'F').range('a', 'f').build();
+    private static final AsciiMatcher hex =
+            AsciiMatcher.builder().range('0', '9').range('A', 'F').range('a', 'f').build();
     private static final AsciiMatcher dec = AsciiMatcher.builder().range('0', '9').build();
-    private static final AsciiMatcher entityStart = AsciiMatcher.builder().range('A', 'Z').range('a', 'z').build();
-    private static final AsciiMatcher entityContinue = entityStart.newBuilder().range('0', '9').build();
+    private static final AsciiMatcher entityStart =
+            AsciiMatcher.builder().range('A', 'Z').range('a', 'z').build();
+    private static final AsciiMatcher entityContinue =
+            entityStart.newBuilder().range('0', '9').build();
 
     @Override
     public ParsedInline tryParse(InlineParserState inlineParserState) {

--- a/commonmark/src/main/java/org/commonmark/internal/inline/HtmlInlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/HtmlInlineParser.java
@@ -1,31 +1,46 @@
 package org.commonmark.internal.inline;
 
+import java.util.Set;
 import org.commonmark.node.HtmlInline;
 import org.commonmark.parser.beta.*;
 import org.commonmark.text.AsciiMatcher;
 
-import java.util.Set;
-
-/**
- * Attempt to parse inline HTML.
- */
+/** Attempt to parse inline HTML. */
 public class HtmlInlineParser implements InlineContentParser {
 
-    private static final AsciiMatcher asciiLetter = AsciiMatcher.builder().range('A', 'Z').range('a', 'z').build();
+    private static final AsciiMatcher asciiLetter =
+            AsciiMatcher.builder().range('A', 'Z').range('a', 'z').build();
 
-    // spec: A tag name consists of an ASCII letter followed by zero or more ASCII letters, digits, or hyphens (-).
+    // spec: A tag name consists of an ASCII letter followed by zero or more ASCII letters, digits,
+    // or hyphens (-).
     private static final AsciiMatcher tagNameStart = asciiLetter;
-    private static final AsciiMatcher tagNameContinue = tagNameStart.newBuilder().range('0', '9').c('-').build();
+    private static final AsciiMatcher tagNameContinue =
+            tagNameStart.newBuilder().range('0', '9').c('-').build();
 
-    // spec: An attribute name consists of an ASCII letter, _, or :, followed by zero or more ASCII letters, digits,
+    // spec: An attribute name consists of an ASCII letter, _, or :, followed by zero or more ASCII
+    // letters, digits,
     // _, ., :, or -. (Note: This is the XML specification restricted to ASCII. HTML5 is laxer.)
-    private static final AsciiMatcher attributeStart = asciiLetter.newBuilder().c('_').c(':').build();
-    private static final AsciiMatcher attributeContinue = attributeStart.newBuilder().range('0', '9').c('.').c('-').build();
-    // spec: An unquoted attribute value is a nonempty string of characters not including whitespace, ", ', =, <, >, or `.
-    private static final AsciiMatcher attributeValueEnd = AsciiMatcher.builder()
-            .c(' ').c('\t').c('\n').c('\u000B').c('\f').c('\r')
-            .c('"').c('\'').c('=').c('<').c('>').c('`')
-            .build();
+    private static final AsciiMatcher attributeStart =
+            asciiLetter.newBuilder().c('_').c(':').build();
+    private static final AsciiMatcher attributeContinue =
+            attributeStart.newBuilder().range('0', '9').c('.').c('-').build();
+    // spec: An unquoted attribute value is a nonempty string of characters not including
+    // whitespace, ", ', =, <, >, or `.
+    private static final AsciiMatcher attributeValueEnd =
+            AsciiMatcher.builder()
+                    .c(' ')
+                    .c('\t')
+                    .c('\n')
+                    .c('\u000B')
+                    .c('\f')
+                    .c('\r')
+                    .c('"')
+                    .c('\'')
+                    .c('=')
+                    .c('<')
+                    .c('>')
+                    .c('`')
+                    .build();
 
     @Override
     public ParsedInline tryParse(InlineParserState inlineParserState) {
@@ -77,16 +92,17 @@ public class HtmlInlineParser implements InlineContentParser {
     }
 
     private static boolean tryOpenTag(Scanner scanner) {
-        // spec: An open tag consists of a < character, a tag name, zero or more attributes, optional whitespace,
-        // an optional / character, and a > character.
+        // spec: An open tag consists of a < character, a tag name, zero or more attributes,
+        // optional whitespace, an optional / character, and a > character.
         scanner.next();
         scanner.match(tagNameContinue);
         boolean whitespace = scanner.whitespace() >= 1;
-        // spec: An attribute consists of whitespace, an attribute name, and an optional attribute value specification.
+        // spec: An attribute consists of whitespace, an attribute name, and an optional attribute
+        // value specification.
         while (whitespace && scanner.match(attributeStart) >= 1) {
             scanner.match(attributeContinue);
-            // spec: An attribute value specification consists of optional whitespace, a = character,
-            // optional whitespace, and an attribute value.
+            // spec: An attribute value specification consists of optional whitespace, a =
+            // character, optional whitespace, and an attribute value.
             whitespace = scanner.whitespace() >= 1;
             if (scanner.next('=')) {
                 scanner.whitespace();
@@ -119,7 +135,8 @@ public class HtmlInlineParser implements InlineContentParser {
     }
 
     private static boolean tryClosingTag(Scanner scanner) {
-        // spec: A closing tag consists of the string </, a tag name, optional whitespace, and the character >.
+        // spec: A closing tag consists of the string </, a tag name, optional whitespace, and the
+        // character >.
         scanner.next();
         if (scanner.match(tagNameStart) >= 1) {
             scanner.match(tagNameContinue);
@@ -130,8 +147,8 @@ public class HtmlInlineParser implements InlineContentParser {
     }
 
     private static boolean tryProcessingInstruction(Scanner scanner) {
-        // spec: A processing instruction consists of the string <?, a string of characters not including the string ?>,
-        // and the string ?>.
+        // spec: A processing instruction consists of the string <?, a string of characters not
+        // including the string ?>, and the string ?>.
         scanner.next();
         while (scanner.find('?') > 0) {
             scanner.next();
@@ -144,8 +161,8 @@ public class HtmlInlineParser implements InlineContentParser {
 
     private static boolean tryComment(Scanner scanner) {
         // spec: An [HTML comment](@) consists of `<!-->`, `<!--->`, or  `<!--`, a string of
-        // characters not including the string `-->`, and `-->` (see the
-        // [HTML spec](https://html.spec.whatwg.org/multipage/parsing.html#markup-declaration-open-state)).
+        // characters not including the string `-->`, and `-->` (see the [HTML
+        // spec](https://html.spec.whatwg.org/multipage/parsing.html#markup-declaration-open-state)).
 
         // Skip first `-`
         scanner.next();
@@ -169,8 +186,8 @@ public class HtmlInlineParser implements InlineContentParser {
     }
 
     private static boolean tryCdata(Scanner scanner) {
-        // spec: A CDATA section consists of the string <![CDATA[, a string of characters not including the string ]]>,
-        // and the string ]]>.
+        // spec: A CDATA section consists of the string <![CDATA[, a string of characters not
+        // including the string ]]>, and the string ]]>.
 
         // Skip `[`
         scanner.next();
@@ -189,8 +206,8 @@ public class HtmlInlineParser implements InlineContentParser {
     }
 
     private static boolean tryDeclaration(Scanner scanner) {
-        // spec: A declaration consists of the string <!, an ASCII letter, zero or more characters not including
-        // the character >, and the character >.
+        // spec: A declaration consists of the string <!, an ASCII letter, zero or more characters
+        // not including the character >, and the character >.
         scanner.match(asciiLetter);
         if (scanner.whitespace() <= 0) {
             return false;

--- a/commonmark/src/main/java/org/commonmark/internal/renderer/NodeRendererMap.java
+++ b/commonmark/src/main/java/org/commonmark/internal/renderer/NodeRendererMap.java
@@ -1,12 +1,11 @@
 package org.commonmark.internal.renderer;
 
-import org.commonmark.node.Node;
-import org.commonmark.renderer.NodeRenderer;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.commonmark.node.Node;
+import org.commonmark.renderer.NodeRenderer;
 
 public class NodeRendererMap {
 
@@ -14,7 +13,8 @@ public class NodeRendererMap {
     private final Map<Class<? extends Node>, NodeRenderer> renderers = new HashMap<>(32);
 
     /**
-     * Set the renderer for each {@link NodeRenderer#getNodeTypes()}, unless there was already a renderer set (first wins).
+     * Set the renderer for each {@link NodeRenderer#getNodeTypes()}, unless there was already a
+     * renderer set (first wins).
      */
     public void add(NodeRenderer nodeRenderer) {
         nodeRenderers.add(nodeRenderer);

--- a/commonmark/src/main/java/org/commonmark/internal/util/Escaping.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Escaping.java
@@ -16,42 +16,47 @@ public class Escaping {
     private static final Pattern ENTITY_OR_ESCAPED_CHAR =
             Pattern.compile("\\\\" + ESCAPABLE + '|' + ENTITY, Pattern.CASE_INSENSITIVE);
 
-    // From RFC 3986 (see "reserved", "unreserved") except don't escape '[' or ']' to be compatible with JS encodeURI
+    // From RFC 3986 (see "reserved", "unreserved") except don't escape '[' or ']' to be compatible
+    // with JS encodeURI
     private static final Pattern ESCAPE_IN_URI =
             Pattern.compile("(%[a-fA-F0-9]{0,2}|[^:/?#@!$&'()*+,;=a-zA-Z0-9\\-._~])");
 
     private static final char[] HEX_DIGITS =
-            new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+            new char[] {
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+            };
 
     private static final Pattern WHITESPACE = Pattern.compile("[ \t\r\n]+");
 
-    private static final Replacer UNESCAPE_REPLACER = (input, sb) -> {
-        if (input.charAt(0) == '\\') {
-            sb.append(input, 1, input.length());
-        } else {
-            sb.append(Html5Entities.entityToString(input));
-        }
-    };
+    private static final Replacer UNESCAPE_REPLACER =
+            (input, sb) -> {
+                if (input.charAt(0) == '\\') {
+                    sb.append(input, 1, input.length());
+                } else {
+                    sb.append(Html5Entities.entityToString(input));
+                }
+            };
 
-    private static final Replacer URI_REPLACER = (input, sb) -> {
-        if (input.startsWith("%")) {
-            if (input.length() == 3) {
-                // Already percent-encoded, preserve
-                sb.append(input);
-            } else {
-                // %25 is the percent-encoding for %
-                sb.append("%25");
-                sb.append(input, 1, input.length());
-            }
-        } else {
-            byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
-            for (byte b : bytes) {
-                sb.append('%');
-                sb.append(HEX_DIGITS[(b >> 4) & 0xF]);
-                sb.append(HEX_DIGITS[b & 0xF]);
-            }
-        }
-    };
+    private static final Replacer URI_REPLACER =
+            (input, sb) -> {
+                if (input.startsWith("%")) {
+                    if (input.length() == 3) {
+                        // Already percent-encoded, preserve
+                        sb.append(input);
+                    } else {
+                        // %25 is the percent-encoding for %
+                        sb.append("%25");
+                        sb.append(input, 1, input.length());
+                    }
+                } else {
+                    byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+                    for (byte b : bytes) {
+                        sb.append('%');
+                        sb.append(HEX_DIGITS[(b >> 4) & 0xF]);
+                        sb.append(HEX_DIGITS[b & 0xF]);
+                    }
+                }
+            };
 
     public static String escapeHtml(String input) {
         // Avoid building a new string in the majority of cases (nothing to escape)
@@ -89,9 +94,7 @@ public class Escaping {
         return sb != null ? sb.toString() : input;
     }
 
-    /**
-     * Replace entities and backslash escapes with literal characters.
-     */
+    /** Replace entities and backslash escapes with literal characters. */
     public static String unescapeString(String s) {
         if (BACKSLASH_OR_AMP.matcher(s).find()) {
             return replaceAll(ENTITY_OR_ESCAPED_CHAR, s, UNESCAPE_REPLACER);

--- a/commonmark/src/main/java/org/commonmark/internal/util/Html5Entities.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Html5Entities.java
@@ -51,7 +51,8 @@ public class Html5Entities {
         Map<String, String> entities = new HashMap<>();
         InputStream stream = Html5Entities.class.getResourceAsStream(ENTITY_PATH);
         Charset charset = StandardCharsets.UTF_8;
-        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream, charset))) {
+        try (BufferedReader bufferedReader =
+                new BufferedReader(new InputStreamReader(stream, charset))) {
             String line;
             while ((line = bufferedReader.readLine()) != null) {
                 if (line.isEmpty()) {
@@ -63,7 +64,8 @@ public class Html5Entities {
                 entities.put(key, value);
             }
         } catch (IOException e) {
-            throw new IllegalStateException("Failed reading data for HTML named character references", e);
+            throw new IllegalStateException(
+                    "Failed reading data for HTML named character references", e);
         }
         entities.put("NewLine", "\n");
         return entities;

--- a/commonmark/src/main/java/org/commonmark/internal/util/LineReader.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/LineReader.java
@@ -5,12 +5,13 @@ import java.io.IOException;
 import java.io.Reader;
 
 /**
- * Reads lines from a reader like {@link java.io.BufferedReader} but also returns the line terminators.
- * <p>
- * Line terminators can be either a line feed {@code "\n"}, carriage return {@code "\r"}, or a carriage return followed
- * by a line feed {@code "\r\n"}. Call {@link #getLineTerminator()} after {@link #readLine()} to obtain the
- * corresponding line terminator. If a stream has a line at the end without a terminator, {@link #getLineTerminator()}
- * returns {@code null}.
+ * Reads lines from a reader like {@link java.io.BufferedReader} but also returns the line
+ * terminators.
+ *
+ * <p>Line terminators can be either a line feed {@code "\n"}, carriage return {@code "\r"}, or a
+ * carriage return followed by a line feed {@code "\r\n"}. Call {@link #getLineTerminator()} after
+ * {@link #readLine()} to obtain the corresponding line terminator. If a stream has a line at the
+ * end without a terminator, {@link #getLineTerminator()} returns {@code null}.
  */
 public class LineReader implements Closeable {
 
@@ -34,7 +35,8 @@ public class LineReader implements Closeable {
     /**
      * Read a line of text.
      *
-     * @return the line, or {@code null} when the end of the stream has been reached and no more lines can be read
+     * @return the line, or {@code null} when the end of the stream has been reached and no more
+     *     lines can be read
      */
     public String readLine() throws IOException {
         StringBuilder sb = null;

--- a/commonmark/src/main/java/org/commonmark/internal/util/LinkScanner.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/LinkScanner.java
@@ -5,9 +5,9 @@ import org.commonmark.parser.beta.Scanner;
 public class LinkScanner {
 
     /**
-     * Attempt to scan the contents of a link label (inside the brackets), stopping after the content or returning false.
-     * The stopped position can bei either the closing {@code ]}, or the end of the line if the label continues on
-     * the next line.
+     * Attempt to scan the contents of a link label (inside the brackets), stopping after the
+     * content or returning false. The stopped position can bei either the closing {@code ]}, or the
+     * end of the line if the label continues on the next line.
      */
     public static boolean scanLinkLabelContent(Scanner scanner) {
         while (scanner.hasNext()) {
@@ -21,8 +21,8 @@ public class LinkScanner {
                 case ']':
                     return true;
                 case '[':
-                    // spec: Unescaped square bracket characters are not allowed inside the opening and closing
-                    // square brackets of link labels.
+                    // spec: Unescaped square bracket characters are not allowed inside the opening
+                    // and closing square brackets of link labels.
                     return false;
                 default:
                     scanner.next();
@@ -31,9 +31,7 @@ public class LinkScanner {
         return true;
     }
 
-    /**
-     * Attempt to scan a link destination, stopping after the destination or returning false.
-     */
+    /** Attempt to scan a link destination, stopping after the destination or returning false. */
     public static boolean scanLinkDestination(Scanner scanner) {
         if (!scanner.hasNext()) {
             return false;
@@ -115,9 +113,9 @@ public class LinkScanner {
         return true;
     }
 
-    // spec: a nonempty sequence of characters that does not start with <, does not include ASCII space or control
-    // characters, and includes parentheses only if (a) they are backslash-escaped or (b) they are part of a balanced
-    // pair of unescaped parentheses
+    // spec: a nonempty sequence of characters that does not start with <, does not include ASCII
+    // space or control characters, and includes parentheses only if (a) they are backslash-escaped
+    // or (b) they are part of a balanced pair of unescaped parentheses
     private static boolean scanLinkDestinationWithBalancedParens(Scanner scanner) {
         int parens = 0;
         boolean empty = true;

--- a/commonmark/src/main/java/org/commonmark/node/AbstractVisitor.java
+++ b/commonmark/src/main/java/org/commonmark/node/AbstractVisitor.java
@@ -2,9 +2,9 @@ package org.commonmark.node;
 
 /**
  * Abstract visitor that visits all children by default.
- * <p>
- * Can be used to only process certain nodes. If you override a method and want visiting to descend into children,
- * call {@link #visitChildren}.
+ *
+ * <p>Can be used to only process certain nodes. If you override a method and want visiting to
+ * descend into children, call {@link #visitChildren}.
  */
 public abstract class AbstractVisitor implements Visitor {
 
@@ -131,8 +131,8 @@ public abstract class AbstractVisitor implements Visitor {
     protected void visitChildren(Node parent) {
         Node node = parent.getFirstChild();
         while (node != null) {
-            // A subclass of this visitor might modify the node, resulting in getNext returning a different node or no
-            // node after visiting it. So get the next node before visiting.
+            // A subclass of this visitor might modify the node, resulting in getNext returning a
+            // different node or no node after visiting it. So get the next node before visiting.
             Node next = node.getNext();
             node.accept(this);
             node = next;

--- a/commonmark/src/main/java/org/commonmark/node/Block.java
+++ b/commonmark/src/main/java/org/commonmark/node/Block.java
@@ -1,8 +1,6 @@
 package org.commonmark.node;
 
-/**
- * Block nodes such as paragraphs, list blocks, code blocks etc.
- */
+/** Block nodes such as paragraphs, list blocks, code blocks etc. */
 public abstract class Block extends Node {
 
     @Override
@@ -13,7 +11,8 @@ public abstract class Block extends Node {
     @Override
     protected void setParent(Node parent) {
         if (!(parent instanceof Block)) {
-            throw new IllegalArgumentException("Parent of block must also be block (can not be inline)");
+            throw new IllegalArgumentException(
+                    "Parent of block must also be block (can not be inline)");
         }
         super.setParent(parent);
     }

--- a/commonmark/src/main/java/org/commonmark/node/BlockQuote.java
+++ b/commonmark/src/main/java/org/commonmark/node/BlockQuote.java
@@ -2,11 +2,12 @@ package org.commonmark.node;
 
 /**
  * A block quote, e.g.:
+ *
  * <pre>
  * &gt; Some quoted text
  * </pre>
- * <p>
- * Note that child nodes are themselves blocks, e.g. {@link Paragraph}, {@link ListBlock} etc.
+ *
+ * <p>Note that child nodes are themselves blocks, e.g. {@link Paragraph}, {@link ListBlock} etc.
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#block-quotes">CommonMark Spec</a>
  */

--- a/commonmark/src/main/java/org/commonmark/node/BulletList.java
+++ b/commonmark/src/main/java/org/commonmark/node/BulletList.java
@@ -2,13 +2,14 @@ package org.commonmark.node;
 
 /**
  * A bullet list, e.g.:
+ *
  * <pre>
  * - One
  * - Two
  * - Three
  * </pre>
- * <p>
- * The children are {@link ListItem} blocks, which contain other blocks (or nested lists).
+ *
+ * <p>The children are {@link ListItem} blocks, which contain other blocks (or nested lists).
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#list-items">CommonMark Spec: List items</a>
  */
@@ -22,7 +23,8 @@ public class BulletList extends ListBlock {
     }
 
     /**
-     * @return the bullet list marker that was used, e.g. {@code -}, {@code *} or {@code +}, if available, or null otherwise
+     * @return the bullet list marker that was used, e.g. {@code -}, {@code *} or {@code +}, if
+     *     available, or null otherwise
      */
     public String getMarker() {
         return marker;

--- a/commonmark/src/main/java/org/commonmark/node/Code.java
+++ b/commonmark/src/main/java/org/commonmark/node/Code.java
@@ -2,6 +2,7 @@ package org.commonmark.node;
 
 /**
  * Inline code span, e.g.:
+ *
  * <pre>
  * Some `inline code`
  * </pre>
@@ -12,8 +13,7 @@ public class Code extends Node {
 
     private String literal;
 
-    public Code() {
-    }
+    public Code() {}
 
     public Code(String literal) {
         this.literal = literal;
@@ -25,8 +25,8 @@ public class Code extends Node {
     }
 
     /**
-     * @return the literal text in the code span (note that it's not necessarily the raw text between tildes,
-     * e.g. when spaces are stripped)
+     * @return the literal text in the code span (note that it's not necessarily the raw text
+     *     between tildes, e.g. when spaces are stripped)
      */
     public String getLiteral() {
         return literal;

--- a/commonmark/src/main/java/org/commonmark/node/CustomBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/CustomBlock.java
@@ -1,7 +1,8 @@
 package org.commonmark.node;
 
 /**
- * A block that extensions can subclass to define custom blocks (not part of the core specification).
+ * A block that extensions can subclass to define custom blocks (not part of the core
+ * specification).
  */
 public abstract class CustomBlock extends Block {
 

--- a/commonmark/src/main/java/org/commonmark/node/DefinitionMap.java
+++ b/commonmark/src/main/java/org/commonmark/node/DefinitionMap.java
@@ -1,15 +1,14 @@
 package org.commonmark.node;
 
-import org.commonmark.internal.util.Escaping;
-
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import org.commonmark.internal.util.Escaping;
 
 /**
- * A map that can be used to store and look up reference definitions by a label. The labels are case-insensitive and
- * normalized, the same way as for {@link LinkReferenceDefinition} nodes.
+ * A map that can be used to store and look up reference definitions by a label. The labels are
+ * case-insensitive and normalized, the same way as for {@link LinkReferenceDefinition} nodes.
  *
  * @param <D> the type of value
  */
@@ -35,10 +34,10 @@ public class DefinitionMap<D> {
     }
 
     /**
-     * Store a new definition unless one is already in the map. If there is no definition for that label yet, return null.
-     * Otherwise, return the existing definition.
-     * <p>
-     * The label is normalized by the definition map before storing.
+     * Store a new definition unless one is already in the map. If there is no definition for that
+     * label yet, return null. Otherwise, return the existing definition.
+     *
+     * <p>The label is normalized by the definition map before storing.
      */
     public D putIfAbsent(String label, D definition) {
         String normalizedLabel = Escaping.normalizeLabelContent(label);

--- a/commonmark/src/main/java/org/commonmark/node/Delimited.java
+++ b/commonmark/src/main/java/org/commonmark/node/Delimited.java
@@ -1,8 +1,6 @@
 package org.commonmark.node;
 
-/**
- * A node that uses delimiters in the source form (e.g. <code>*bold*</code>).
- */
+/** A node that uses delimiters in the source form (e.g. <code>*bold*</code>). */
 public interface Delimited {
 
     /**

--- a/commonmark/src/main/java/org/commonmark/node/Document.java
+++ b/commonmark/src/main/java/org/commonmark/node/Document.java
@@ -1,8 +1,6 @@
 package org.commonmark.node;
 
-/**
- * The root block of a document, containing the top-level blocks.
- */
+/** The root block of a document, containing the top-level blocks. */
 public class Document extends Block {
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/node/Emphasis.java
+++ b/commonmark/src/main/java/org/commonmark/node/Emphasis.java
@@ -2,18 +2,19 @@ package org.commonmark.node;
 
 /**
  * Emphasis, e.g.:
+ *
  * <pre>
  * Some *emphasis* or _emphasis_
  * </pre>
  *
- * @see <a href="https://spec.commonmark.org/0.31.2/#emphasis-and-strong-emphasis">CommonMark Spec: Emphasis and strong emphasis</a>
+ * @see <a href="https://spec.commonmark.org/0.31.2/#emphasis-and-strong-emphasis">CommonMark Spec:
+ *     Emphasis and strong emphasis</a>
  */
 public class Emphasis extends Node implements Delimited {
 
     private String delimiter;
 
-    public Emphasis() {
-    }
+    public Emphasis() {}
 
     public Emphasis(String delimiter) {
         this.delimiter = delimiter;

--- a/commonmark/src/main/java/org/commonmark/node/FencedCodeBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/FencedCodeBlock.java
@@ -2,12 +2,14 @@ package org.commonmark.node;
 
 /**
  * A fenced code block, e.g.:
+ *
  * <pre>
  * ```
  * foo
  * bar
  * ```
  * </pre>
+ *
  * <p>
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#fenced-code-blocks">CommonMark Spec</a>
@@ -28,7 +30,8 @@ public class FencedCodeBlock extends Block {
     }
 
     /**
-     * @return the fence character that was used, e.g. {@code `} or {@code ~}, if available, or null otherwise
+     * @return the fence character that was used, e.g. {@code `} or {@code ~}, if available, or null
+     *     otherwise
      */
     public String getFenceCharacter() {
         return fenceCharacter;
@@ -39,8 +42,8 @@ public class FencedCodeBlock extends Block {
     }
 
     /**
-     * @return the length of the opening fence (how many of {{@link #getFenceCharacter()}} were used to start the code
-     * block) if available, or null otherwise
+     * @return the length of the opening fence (how many of {{@link #getFenceCharacter()}} were used
+     *     to start the code block) if available, or null otherwise
      */
     public Integer getOpeningFenceLength() {
         return openingFenceLength;
@@ -55,8 +58,8 @@ public class FencedCodeBlock extends Block {
     }
 
     /**
-     * @return the length of the closing fence (how many of {@link #getFenceCharacter()} were used to end the code
-     * block) if available, or null otherwise
+     * @return the length of the closing fence (how many of {@link #getFenceCharacter()} were used
+     *     to end the code block) if available, or null otherwise
      */
     public Integer getClosingFenceLength() {
         return closingFenceLength;
@@ -102,7 +105,9 @@ public class FencedCodeBlock extends Block {
      */
     @Deprecated
     public char getFenceChar() {
-        return fenceCharacter != null && !fenceCharacter.isEmpty() ? fenceCharacter.charAt(0) : '\0';
+        return fenceCharacter != null && !fenceCharacter.isEmpty()
+                ? fenceCharacter.charAt(0)
+                : '\0';
     }
 
     /**
@@ -132,7 +137,8 @@ public class FencedCodeBlock extends Block {
     private static void checkFenceLengths(Integer openingFenceLength, Integer closingFenceLength) {
         if (openingFenceLength != null && closingFenceLength != null) {
             if (closingFenceLength < openingFenceLength) {
-                throw new IllegalArgumentException("fence lengths required to be: closingFenceLength >= openingFenceLength");
+                throw new IllegalArgumentException(
+                        "fence lengths required to be: closingFenceLength >= openingFenceLength");
             }
         }
     }

--- a/commonmark/src/main/java/org/commonmark/node/HardLineBreak.java
+++ b/commonmark/src/main/java/org/commonmark/node/HardLineBreak.java
@@ -2,10 +2,12 @@ package org.commonmark.node;
 
 /**
  * A hard line break, e.g.:
+ *
  * <pre>
  * line\
  * break
  * </pre>
+ *
  * <p>
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#hard-line-breaks">CommonMark Spec</a>

--- a/commonmark/src/main/java/org/commonmark/node/Heading.java
+++ b/commonmark/src/main/java/org/commonmark/node/Heading.java
@@ -2,6 +2,7 @@ package org.commonmark.node;
 
 /**
  * A heading, e.g.:
+ *
  * <pre>
  * First heading
  * =============
@@ -10,7 +11,8 @@ package org.commonmark.node;
  * </pre>
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#atx-headings">CommonMark Spec: ATX headings</a>
- * @see <a href="https://spec.commonmark.org/0.31.2/#setext-headings">CommonMark Spec: Setext headings</a>
+ * @see <a href="https://spec.commonmark.org/0.31.2/#setext-headings">CommonMark Spec: Setext
+ *     headings</a>
  */
 public class Heading extends Block {
 

--- a/commonmark/src/main/java/org/commonmark/node/Image.java
+++ b/commonmark/src/main/java/org/commonmark/node/Image.java
@@ -2,6 +2,7 @@ package org.commonmark.node;
 
 /**
  * An image, e.g.:
+ *
  * <pre>
  * ![foo](/url "title")
  * </pre>
@@ -13,8 +14,7 @@ public class Image extends Node {
     private String destination;
     private String title;
 
-    public Image() {
-    }
+    public Image() {}
 
     public Image(String destination, String title) {
         this.destination = destination;

--- a/commonmark/src/main/java/org/commonmark/node/IndentedCodeBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/IndentedCodeBlock.java
@@ -2,12 +2,14 @@ package org.commonmark.node;
 
 /**
  * An indented code block, e.g.:
+ *
  * <pre><code>
  * Code follows:
  *
  *     foo
  *     bar
  * </code></pre>
+ *
  * <p>
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#indented-code-blocks">CommonMark Spec</a>

--- a/commonmark/src/main/java/org/commonmark/node/Link.java
+++ b/commonmark/src/main/java/org/commonmark/node/Link.java
@@ -2,21 +2,24 @@ package org.commonmark.node;
 
 /**
  * A link with a destination and an optional title; the link text is in child nodes.
- * <p>
- * Example for an inline link in a CommonMark document:
+ *
+ * <p>Example for an inline link in a CommonMark document:
+ *
  * <pre><code>
  * [link](/uri "title")
  * </code></pre>
- * <p>
- * The corresponding Link node would look like this:
+ *
+ * <p>The corresponding Link node would look like this:
+ *
  * <ul>
- * <li>{@link #getDestination()} returns {@code "/uri"}
- * <li>{@link #getTitle()} returns {@code "title"}
- * <li>A {@link Text} child node with {@link Text#getLiteral() getLiteral} that returns {@code "link"}</li>
+ *   <li>{@link #getDestination()} returns {@code "/uri"}
+ *   <li>{@link #getTitle()} returns {@code "title"}
+ *   <li>A {@link Text} child node with {@link Text#getLiteral() getLiteral} that returns {@code
+ *       "link"}
  * </ul>
- * <p>
- * Note that the text in the link can contain inline formatting, so it could also contain an {@link Image} or
- * {@link Emphasis}, etc.
+ *
+ * <p>Note that the text in the link can contain inline formatting, so it could also contain an
+ * {@link Image} or {@link Emphasis}, etc.
  *
  * @see <a href="http://spec.commonmark.org/0.31.2/#links">CommonMark Spec</a>
  */
@@ -25,8 +28,7 @@ public class Link extends Node {
     private String destination;
     private String title;
 
-    public Link() {
-    }
+    public Link() {}
 
     public Link(String destination, String title) {
         this.destination = destination;

--- a/commonmark/src/main/java/org/commonmark/node/LinkReferenceDefinition.java
+++ b/commonmark/src/main/java/org/commonmark/node/LinkReferenceDefinition.java
@@ -2,12 +2,13 @@ package org.commonmark.node;
 
 /**
  * A link reference definition, e.g.:
+ *
  * <pre><code>
  * [foo]: /url "title"
  * </code></pre>
- * <p>
- * They can be referenced anywhere else in the document to produce a link using <code>[foo]</code>. The definitions
- * themselves are usually not rendered in the final output.
+ *
+ * <p>They can be referenced anywhere else in the document to produce a link using <code>[foo]
+ * </code>. The definitions themselves are usually not rendered in the final output.
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#link-reference-definition">CommonMark Spec</a>
  */
@@ -17,8 +18,7 @@ public class LinkReferenceDefinition extends Block {
     private String destination;
     private String title;
 
-    public LinkReferenceDefinition() {
-    }
+    public LinkReferenceDefinition() {}
 
     public LinkReferenceDefinition(String label, String destination, String title) {
         this.label = label;

--- a/commonmark/src/main/java/org/commonmark/node/ListBlock.java
+++ b/commonmark/src/main/java/org/commonmark/node/ListBlock.java
@@ -1,8 +1,6 @@
 package org.commonmark.node;
 
-/**
- * A list block like {@link BulletList} or {@link OrderedList}.
- */
+/** A list block like {@link BulletList} or {@link OrderedList}. */
 public abstract class ListBlock extends Block {
 
     private boolean tight;
@@ -18,5 +16,4 @@ public abstract class ListBlock extends Block {
     public void setTight(boolean tight) {
         this.tight = tight;
     }
-
 }

--- a/commonmark/src/main/java/org/commonmark/node/ListItem.java
+++ b/commonmark/src/main/java/org/commonmark/node/ListItem.java
@@ -1,11 +1,12 @@
 package org.commonmark.node;
 
 /**
- * A child of a {@link ListBlock}, containing other blocks (e.g. {@link Paragraph}, other lists, etc).
- * <p>
- * Note that a list item can't directly contain {@link Text}, it needs to be:
- * {@link ListItem} : {@link Paragraph} : {@link Text}.
- * If you want a list that is rendered tightly, create a list with {@link ListBlock#setTight(boolean)}.
+ * A child of a {@link ListBlock}, containing other blocks (e.g. {@link Paragraph}, other lists,
+ * etc).
+ *
+ * <p>Note that a list item can't directly contain {@link Text}, it needs to be: {@link ListItem} :
+ * {@link Paragraph} : {@link Text}. If you want a list that is rendered tightly, create a list with
+ * {@link ListBlock#setTight(boolean)}.
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#list-items">CommonMark Spec: List items</a>
  */
@@ -20,15 +21,21 @@ public class ListItem extends Block {
     }
 
     /**
-     * Returns the indent of the marker such as "-" or "1." in columns (spaces or tab stop of 4) if available, or null
-     * otherwise.
-     * <p>
-     * Some examples and their marker indent:
+     * Returns the indent of the marker such as "-" or "1." in columns (spaces or tab stop of 4) if
+     * available, or null otherwise.
+     *
+     * <p>Some examples and their marker indent:
+     *
      * <pre>- Foo</pre>
+     *
      * Marker indent: 0
+     *
      * <pre> - Foo</pre>
+     *
      * Marker indent: 1
+     *
      * <pre>  1. Foo</pre>
+     *
      * Marker indent: 2
      */
     public Integer getMarkerIndent() {
@@ -40,19 +47,26 @@ public class ListItem extends Block {
     }
 
     /**
-     * Returns the indent of the content in columns (spaces or tab stop of 4) if available, or null otherwise.
-     * The content indent is counted from the beginning of the line and includes the marker on the first line.
-     * <p>
-     * Some examples and their content indent:
+     * Returns the indent of the content in columns (spaces or tab stop of 4) if available, or null
+     * otherwise. The content indent is counted from the beginning of the line and includes the
+     * marker on the first line.
+     *
+     * <p>Some examples and their content indent:
+     *
      * <pre>- Foo</pre>
+     *
      * Content indent: 2
+     *
      * <pre> - Foo</pre>
+     *
      * Content indent: 3
+     *
      * <pre>  1. Foo</pre>
+     *
      * Content indent: 5
-     * <p>
-     * Note that subsequent lines in the same list item need to be indented by at least the content indent to be counted
-     * as part of the list item.
+     *
+     * <p>Note that subsequent lines in the same list item need to be indented by at least the
+     * content indent to be counted as part of the list item.
      */
     public Integer getContentIndent() {
         return contentIndent;
@@ -63,8 +77,8 @@ public class ListItem extends Block {
     }
 
     /**
-     * @deprecated list items should only contain block nodes; if you're trying to create a list that is rendered
-     * without paragraphs, use {@link ListBlock#setTight(boolean)} instead.
+     * @deprecated list items should only contain block nodes; if you're trying to create a list
+     *     that is rendered without paragraphs, use {@link ListBlock#setTight(boolean)} instead.
      */
     @Override
     @Deprecated

--- a/commonmark/src/main/java/org/commonmark/node/Node.java
+++ b/commonmark/src/main/java/org/commonmark/node/Node.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 /**
  * The base class of all CommonMark AST nodes ({@link Block} and inlines).
- * <p>
- * A node can have multiple children, and a parent (except for the root node).
+ *
+ * <p>A node can have multiple children, and a parent (except for the root node).
  */
 public abstract class Node {
 
@@ -85,9 +85,7 @@ public abstract class Node {
         this.prev = null;
     }
 
-    /**
-     * Inserts the {@code sibling} node after {@code this} node.
-     */
+    /** Inserts the {@code sibling} node after {@code this} node. */
     public void insertAfter(Node sibling) {
         sibling.unlink();
         sibling.next = this.next;
@@ -102,9 +100,7 @@ public abstract class Node {
         }
     }
 
-    /**
-     * Inserts the {@code sibling} node before {@code this} node.
-     */
+    /** Inserts the {@code sibling} node before {@code this} node. */
     public void insertBefore(Node sibling) {
         sibling.unlink();
         sibling.prev = this.prev;

--- a/commonmark/src/main/java/org/commonmark/node/Nodes.java
+++ b/commonmark/src/main/java/org/commonmark/node/Nodes.java
@@ -9,12 +9,9 @@ import java.util.Iterator;
  */
 public class Nodes {
 
-    private Nodes() {
-    }
+    private Nodes() {}
 
-    /**
-     * The nodes between (not including) start and end.
-     */
+    /** The nodes between (not including) start and end. */
     public static Iterable<Node> between(Node start, Node end) {
         return new NodeIterable(start.getNext(), end);
     }
@@ -63,4 +60,3 @@ public class Nodes {
         }
     }
 }
-

--- a/commonmark/src/main/java/org/commonmark/node/OrderedList.java
+++ b/commonmark/src/main/java/org/commonmark/node/OrderedList.java
@@ -2,13 +2,14 @@ package org.commonmark.node;
 
 /**
  * An ordered list, e.g.:
+ *
  * <pre><code>
  * 1. One
  * 2. Two
  * 3. Three
  * </code></pre>
- * <p>
- * The children are {@link ListItem} blocks, which contain other blocks (or nested lists).
+ *
+ * <p>The children are {@link ListItem} blocks, which contain other blocks (or nested lists).
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#list-items">CommonMark Spec: List items</a>
  */
@@ -34,7 +35,8 @@ public class OrderedList extends ListBlock {
     }
 
     /**
-     * @return the delimiter used in the marker, e.g. {@code .} or {@code )}, if available, or null otherwise
+     * @return the delimiter used in the marker, e.g. {@code .} or {@code )}, if available, or null
+     *     otherwise
      */
     public String getMarkerDelimiter() {
         return markerDelimiter;
@@ -65,7 +67,9 @@ public class OrderedList extends ListBlock {
      */
     @Deprecated
     public char getDelimiter() {
-        return markerDelimiter != null && !markerDelimiter.isEmpty() ? markerDelimiter.charAt(0) : '\0';
+        return markerDelimiter != null && !markerDelimiter.isEmpty()
+                ? markerDelimiter.charAt(0)
+                : '\0';
     }
 
     /**

--- a/commonmark/src/main/java/org/commonmark/node/SoftLineBreak.java
+++ b/commonmark/src/main/java/org/commonmark/node/SoftLineBreak.java
@@ -2,6 +2,7 @@ package org.commonmark.node;
 
 /**
  * A soft line break (as opposed to a {@link HardLineBreak}), e.g. between:
+ *
  * <pre>
  * foo
  * bar

--- a/commonmark/src/main/java/org/commonmark/node/SourceSpan.java
+++ b/commonmark/src/main/java/org/commonmark/node/SourceSpan.java
@@ -4,22 +4,26 @@ import java.util.Objects;
 
 /**
  * A source span references a snippet of text from the source input.
- * <p>
- * It has a starting position (line and column index) and a length of how many characters it spans.
- * <p>
- * For example, this CommonMark source text:
+ *
+ * <p>It has a starting position (line and column index) and a length of how many characters it
+ * spans.
+ *
+ * <p>For example, this CommonMark source text:
+ *
  * <pre><code>
  * &gt; foo
  * </code></pre>
+ *
  * The {@link BlockQuote} node would have this source span: line 0, column 0, length 5.
- * <p>
- * The {@link Paragraph} node inside it would have: line 0, column 2, length 3.
- * <p>
- * If a block has multiple lines, it will have a source span for each line.
- * <p>
- * Note that the column index and length are measured in Java characters (UTF-16 code units). If you're outputting them
- * to be consumed by another programming language, e.g. one that uses UTF-8 strings, you will need to translate them,
- * otherwise characters such as emojis will result in incorrect positions.
+ *
+ * <p>The {@link Paragraph} node inside it would have: line 0, column 2, length 3.
+ *
+ * <p>If a block has multiple lines, it will have a source span for each line.
+ *
+ * <p>Note that the column index and length are measured in Java characters (UTF-16 code units). If
+ * you're outputting them to be consumed by another programming language, e.g. one that uses UTF-8
+ * strings, you will need to translate them, otherwise characters such as emojis will result in
+ * incorrect positions.
  *
  * @since 0.16.0
  */
@@ -35,8 +39,8 @@ public class SourceSpan {
     }
 
     /**
-     * @deprecated Use {{@link #of(int, int, int, int)}} instead to also specify input index. Using the deprecated one
-     * will set {@link #inputIndex} to 0.
+     * @deprecated Use {{@link #of(int, int, int, int)}} instead to also specify input index. Using
+     *     the deprecated one will set {@link #inputIndex} to 0.
      */
     @Deprecated
     public static SourceSpan of(int lineIndex, int columnIndex, int length) {
@@ -70,8 +74,8 @@ public class SourceSpan {
     }
 
     /**
-     * @return 0-based index of column (character on line) in source, e.g. 0 for the first character of a line, 1 for
-     * the second character, etc
+     * @return 0-based index of column (character on line) in source, e.g. 0 for the first character
+     *     of a line, 1 for the second character, etc
      */
     public int getColumnIndex() {
         return columnIndex;
@@ -101,21 +105,28 @@ public class SourceSpan {
             throw new IndexOutOfBoundsException("beginIndex " + beginIndex + " + must be >= 0");
         }
         if (beginIndex > length) {
-            throw new IndexOutOfBoundsException("beginIndex " + beginIndex + " must be <= length " + length);
+            throw new IndexOutOfBoundsException(
+                    "beginIndex " + beginIndex + " must be <= length " + length);
         }
         if (endIndex < 0) {
             throw new IndexOutOfBoundsException("endIndex " + endIndex + " + must be >= 0");
         }
         if (endIndex > length) {
-            throw new IndexOutOfBoundsException("endIndex " + endIndex + " must be <= length " + length);
+            throw new IndexOutOfBoundsException(
+                    "endIndex " + endIndex + " must be <= length " + length);
         }
         if (beginIndex > endIndex) {
-            throw new IndexOutOfBoundsException("beginIndex " + beginIndex + " must be <= endIndex " + endIndex);
+            throw new IndexOutOfBoundsException(
+                    "beginIndex " + beginIndex + " must be <= endIndex " + endIndex);
         }
         if (beginIndex == 0 && endIndex == length) {
             return this;
         }
-        return new SourceSpan(lineIndex, columnIndex + beginIndex, inputIndex + beginIndex, endIndex - beginIndex);
+        return new SourceSpan(
+                lineIndex,
+                columnIndex + beginIndex,
+                inputIndex + beginIndex,
+                endIndex - beginIndex);
     }
 
     @Override
@@ -127,10 +138,10 @@ public class SourceSpan {
             return false;
         }
         SourceSpan that = (SourceSpan) o;
-        return lineIndex == that.lineIndex &&
-                columnIndex == that.columnIndex &&
-                inputIndex == that.inputIndex &&
-                length == that.length;
+        return lineIndex == that.lineIndex
+                && columnIndex == that.columnIndex
+                && inputIndex == that.inputIndex
+                && length == that.length;
     }
 
     @Override
@@ -140,11 +151,15 @@ public class SourceSpan {
 
     @Override
     public String toString() {
-        return "SourceSpan{" +
-                "line=" + lineIndex +
-                ", column=" + columnIndex +
-                ", input=" + inputIndex +
-                ", length=" + length +
-                "}";
+        return "SourceSpan{"
+                + "line="
+                + lineIndex
+                + ", column="
+                + columnIndex
+                + ", input="
+                + inputIndex
+                + ", length="
+                + length
+                + "}";
     }
 }

--- a/commonmark/src/main/java/org/commonmark/node/SourceSpans.java
+++ b/commonmark/src/main/java/org/commonmark/node/SourceSpans.java
@@ -42,7 +42,13 @@ public class SourceSpans {
             SourceSpan a = sourceSpans.get(lastIndex);
             SourceSpan b = other.get(0);
             if (a.getInputIndex() + a.getLength() == b.getInputIndex()) {
-                sourceSpans.set(lastIndex, SourceSpan.of(a.getLineIndex(), a.getColumnIndex(), a.getInputIndex(), a.getLength() + b.getLength()));
+                sourceSpans.set(
+                        lastIndex,
+                        SourceSpan.of(
+                                a.getLineIndex(),
+                                a.getColumnIndex(),
+                                a.getInputIndex(),
+                                a.getLength() + b.getLength()));
                 sourceSpans.addAll(other.subList(1, other.size()));
             } else {
                 sourceSpans.addAll(other);

--- a/commonmark/src/main/java/org/commonmark/node/StrongEmphasis.java
+++ b/commonmark/src/main/java/org/commonmark/node/StrongEmphasis.java
@@ -2,18 +2,19 @@ package org.commonmark.node;
 
 /**
  * Strong emphasis, e.g.:
+ *
  * <pre><code>
  * Some **strong emphasis** or __strong emphasis__
  * </code></pre>
  *
- * @see <a href="https://spec.commonmark.org/0.31.2/#emphasis-and-strong-emphasis">CommonMark Spec: Emphasis and strong emphasis</a>
+ * @see <a href="https://spec.commonmark.org/0.31.2/#emphasis-and-strong-emphasis">CommonMark Spec:
+ *     Emphasis and strong emphasis</a>
  */
 public class StrongEmphasis extends Node implements Delimited {
 
     private String delimiter;
 
-    public StrongEmphasis() {
-    }
+    public StrongEmphasis() {}
 
     public StrongEmphasis(String delimiter) {
         this.delimiter = delimiter;

--- a/commonmark/src/main/java/org/commonmark/node/Text.java
+++ b/commonmark/src/main/java/org/commonmark/node/Text.java
@@ -2,11 +2,13 @@ package org.commonmark.node;
 
 /**
  * A text node, e.g. in:
+ *
  * <pre>
  * foo *bar*
  * </pre>
- * <p>
- * The <code>foo </code> is a text node, and the <code>bar</code> inside the emphasis is also a text node.
+ *
+ * <p>The <code>foo </code> is a text node, and the <code>bar</code> inside the emphasis is also a
+ * text node.
  *
  * @see <a href="https://spec.commonmark.org/0.31.2/#textual-content">CommonMark Spec</a>
  */
@@ -14,8 +16,7 @@ public class Text extends Node {
 
     private String literal;
 
-    public Text() {
-    }
+    public Text() {}
 
     public Text(String literal) {
         this.literal = literal;

--- a/commonmark/src/main/java/org/commonmark/node/ThematicBreak.java
+++ b/commonmark/src/main/java/org/commonmark/node/ThematicBreak.java
@@ -2,6 +2,7 @@ package org.commonmark.node;
 
 /**
  * A thematic break, e.g. between text:
+ *
  * <pre>
  * Some text
  *

--- a/commonmark/src/main/java/org/commonmark/node/Visitor.java
+++ b/commonmark/src/main/java/org/commonmark/node/Visitor.java
@@ -2,8 +2,8 @@ package org.commonmark.node;
 
 /**
  * Node visitor.
- * <p>
- * Implementations should subclass {@link AbstractVisitor} instead of implementing this directly.
+ *
+ * <p>Implementations should subclass {@link AbstractVisitor} instead of implementing this directly.
  */
 public interface Visitor {
 

--- a/commonmark/src/main/java/org/commonmark/node/package-info.java
+++ b/commonmark/src/main/java/org/commonmark/node/package-info.java
@@ -1,4 +1,5 @@
 /**
- * AST node types (see {@link org.commonmark.node.Node}) and visitors (see {@link org.commonmark.node.AbstractVisitor})
+ * AST node types (see {@link org.commonmark.node.Node}) and visitors (see {@link
+ * org.commonmark.node.AbstractVisitor})
  */
 package org.commonmark.node;

--- a/commonmark/src/main/java/org/commonmark/package-info.java
+++ b/commonmark/src/main/java/org/commonmark/package-info.java
@@ -1,10 +1,11 @@
 /**
  * Root package of commonmark-java
+ *
  * <ul>
- * <li>{@link org.commonmark.parser} for parsing input text to AST nodes</li>
- * <li>{@link org.commonmark.node} for AST node types and visitors</li>
- * <li>{@link org.commonmark.renderer.html} for HTML rendering</li>
- * <li>{@link org.commonmark.renderer.markdown} for Markdown rendering</li>
+ *   <li>{@link org.commonmark.parser} for parsing input text to AST nodes
+ *   <li>{@link org.commonmark.node} for AST node types and visitors
+ *   <li>{@link org.commonmark.renderer.html} for HTML rendering
+ *   <li>{@link org.commonmark.renderer.markdown} for Markdown rendering
  * </ul>
  */
 package org.commonmark;

--- a/commonmark/src/main/java/org/commonmark/parser/IncludeSourceSpans.java
+++ b/commonmark/src/main/java/org/commonmark/parser/IncludeSourceSpans.java
@@ -1,22 +1,16 @@
 package org.commonmark.parser;
 
 /**
- * Whether to include {@link org.commonmark.node.SourceSpan} or not while parsing,
- * see {@link Parser.Builder#includeSourceSpans(IncludeSourceSpans)}.
+ * Whether to include {@link org.commonmark.node.SourceSpan} or not while parsing, see {@link
+ * Parser.Builder#includeSourceSpans(IncludeSourceSpans)}.
  *
  * @since 0.16.0
  */
 public enum IncludeSourceSpans {
-    /**
-     * Do not include source spans.
-     */
+    /** Do not include source spans. */
     NONE,
-    /**
-     * Include source spans on {@link org.commonmark.node.Block} nodes.
-     */
+    /** Include source spans on {@link org.commonmark.node.Block} nodes. */
     BLOCKS,
-    /**
-     * Include source spans on block nodes and inline nodes.
-     */
+    /** Include source spans on block nodes and inline nodes. */
     BLOCKS_AND_INLINES,
 }

--- a/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/InlineParser.java
@@ -2,9 +2,7 @@ package org.commonmark.parser;
 
 import org.commonmark.node.Node;
 
-/**
- * Parser for inline content (text, links, emphasized text, etc).
- */
+/** Parser for inline content (text, links, emphasized text, etc). */
 public interface InlineParser {
 
     /**

--- a/commonmark/src/main/java/org/commonmark/parser/InlineParserContext.java
+++ b/commonmark/src/main/java/org/commonmark/parser/InlineParserContext.java
@@ -1,32 +1,30 @@
 package org.commonmark.parser;
 
-import org.commonmark.node.LinkReferenceDefinition;
-import org.commonmark.parser.beta.LinkProcessor;
-import org.commonmark.parser.beta.InlineContentParserFactory;
-import org.commonmark.parser.delimiter.DelimiterProcessor;
-
 import java.util.List;
 import java.util.Set;
+import org.commonmark.node.LinkReferenceDefinition;
+import org.commonmark.parser.beta.InlineContentParserFactory;
+import org.commonmark.parser.beta.LinkProcessor;
+import org.commonmark.parser.delimiter.DelimiterProcessor;
 
-/**
- * Context for inline parsing.
- */
+/** Context for inline parsing. */
 public interface InlineParserContext {
 
     /**
-     * @return custom inline content parsers that have been configured with
-     * {@link Parser.Builder#customInlineContentParserFactory(InlineContentParserFactory)}
+     * @return custom inline content parsers that have been configured with {@link
+     *     Parser.Builder#customInlineContentParserFactory(InlineContentParserFactory)}
      */
     List<InlineContentParserFactory> getCustomInlineContentParserFactories();
 
     /**
-     * @return custom delimiter processors that have been configured with
-     * {@link Parser.Builder#customDelimiterProcessor(DelimiterProcessor)}
+     * @return custom delimiter processors that have been configured with {@link
+     *     Parser.Builder#customDelimiterProcessor(DelimiterProcessor)}
      */
     List<DelimiterProcessor> getCustomDelimiterProcessors();
 
     /**
-     * @return custom link processors that have been configured with {@link Parser.Builder#linkProcessor}.
+     * @return custom link processors that have been configured with {@link
+     *     Parser.Builder#linkProcessor}.
      */
     List<LinkProcessor> getCustomLinkProcessors();
 
@@ -37,9 +35,9 @@ public interface InlineParserContext {
 
     /**
      * Look up a {@link LinkReferenceDefinition} for a given label.
-     * <p>
-     * Note that the passed in label does not need to be normalized; implementations are responsible for doing the
-     * normalization before lookup.
+     *
+     * <p>Note that the passed in label does not need to be normalized; implementations are
+     * responsible for doing the normalization before lookup.
      *
      * @param label the link label to look up
      * @return the definition if one exists, {@code null} otherwise
@@ -50,9 +48,9 @@ public interface InlineParserContext {
 
     /**
      * Look up a definition of a type for a given label.
-     * <p>
-     * Note that the passed in label does not need to be normalized; implementations are responsible for doing the
-     * normalization before lookup.
+     *
+     * <p>Note that the passed in label does not need to be normalized; implementations are
+     * responsible for doing the normalization before lookup.
      *
      * @return the definition if one exists, null otherwise
      */

--- a/commonmark/src/main/java/org/commonmark/parser/InlineParserFactory.java
+++ b/commonmark/src/main/java/org/commonmark/parser/InlineParserFactory.java
@@ -1,12 +1,11 @@
 package org.commonmark.parser;
 
-/**
- * Factory for custom inline parser.
- */
+/** Factory for custom inline parser. */
 public interface InlineParserFactory {
 
     /**
-     * Create an {@link InlineParser} to use for parsing inlines. This is called once per parsed document.
+     * Create an {@link InlineParser} to use for parsing inlines. This is called once per parsed
+     * document.
      */
     InlineParser create(InlineParserContext inlineParserContext);
 }

--- a/commonmark/src/main/java/org/commonmark/parser/Parser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/Parser.java
@@ -1,27 +1,26 @@
 package org.commonmark.parser;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.util.*;
 import org.commonmark.Extension;
 import org.commonmark.internal.Definitions;
 import org.commonmark.internal.DocumentParser;
 import org.commonmark.internal.InlineParserContextImpl;
 import org.commonmark.internal.InlineParserImpl;
 import org.commonmark.node.*;
+import org.commonmark.parser.beta.InlineContentParserFactory;
 import org.commonmark.parser.beta.LinkInfo;
 import org.commonmark.parser.beta.LinkProcessor;
-import org.commonmark.parser.beta.InlineContentParserFactory;
 import org.commonmark.parser.beta.LinkResult;
 import org.commonmark.parser.block.BlockParserFactory;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.util.*;
-
-
 /**
  * Parses input text to a tree of nodes.
- * <p>
- * Start with the {@link #builder} method, configure the parser and build it. Example:
+ *
+ * <p>Start with the {@link #builder} method, configure the parser and build it. Example:
+ *
  * <pre><code>
  * Parser parser = Parser.builder().build();
  * Node document = parser.parse("input text");
@@ -40,7 +39,9 @@ public class Parser {
     private final int maxOpenBlockParsers;
 
     private Parser(Builder builder) {
-        this.blockParserFactories = DocumentParser.calculateBlockParserFactories(builder.blockParserFactories, builder.enabledBlockTypes);
+        this.blockParserFactories =
+                DocumentParser.calculateBlockParserFactories(
+                        builder.blockParserFactories, builder.enabledBlockTypes);
         this.inlineParserFactory = builder.getInlineParserFactory();
         this.postProcessors = builder.postProcessors;
         this.inlineContentParserFactories = builder.inlineContentParserFactories;
@@ -50,10 +51,15 @@ public class Parser {
         this.includeSourceSpans = builder.includeSourceSpans;
         this.maxOpenBlockParsers = builder.maxOpenBlockParsers;
 
-        // Try to construct an inline parser. Invalid configuration might result in an exception, which we want to
-        // detect as soon as possible.
-        var context = new InlineParserContextImpl(
-                inlineContentParserFactories, delimiterProcessors, linkProcessors, linkMarkers, new Definitions());
+        // Try to construct an inline parser. Invalid configuration might result in an exception,
+        // which we want to detect as soon as possible.
+        var context =
+                new InlineParserContextImpl(
+                        inlineContentParserFactories,
+                        delimiterProcessors,
+                        linkProcessors,
+                        linkMarkers,
+                        new Definitions());
         this.inlineParserFactory.create(context);
     }
 
@@ -68,8 +74,8 @@ public class Parser {
 
     /**
      * Parse the specified input text into a tree of nodes.
-     * <p>
-     * This method is thread-safe (a new parser state is used for each invocation).
+     *
+     * <p>This method is thread-safe (a new parser state is used for each invocation).
      *
      * @param input the text to parse - must not be null
      * @return the root node
@@ -82,7 +88,9 @@ public class Parser {
     }
 
     /**
-     * Parse the specified reader into a tree of nodes. The caller is responsible for closing the reader.
+     * Parse the specified reader into a tree of nodes. The caller is responsible for closing the
+     * reader.
+     *
      * <pre><code>
      * Parser parser = Parser.builder().build();
      * try (InputStreamReader reader = new InputStreamReader(new FileInputStream("file.md"), StandardCharsets.UTF_8)) {
@@ -90,10 +98,12 @@ public class Parser {
      *     // ...
      * }
      * </code></pre>
-     * Note that if you have a file with a byte order mark (BOM), you need to skip it before handing the reader to this
-     * library. There's existing classes that do that, e.g. see {@code BOMInputStream} in Commons IO.
-     * <p>
-     * This method is thread-safe (a new parser state is used for each invocation).
+     *
+     * Note that if you have a file with a byte order mark (BOM), you need to skip it before handing
+     * the reader to this library. There's existing classes that do that, e.g. see {@code
+     * BOMInputStream} in Commons IO.
+     *
+     * <p>This method is thread-safe (a new parser state is used for each invocation).
      *
      * @param input the reader to parse - must not be null
      * @return the root node
@@ -107,8 +117,15 @@ public class Parser {
     }
 
     private DocumentParser createDocumentParser() {
-        return new DocumentParser(blockParserFactories, inlineParserFactory, inlineContentParserFactories,
-                delimiterProcessors, linkProcessors, linkMarkers, includeSourceSpans, maxOpenBlockParsers);
+        return new DocumentParser(
+                blockParserFactories,
+                inlineParserFactory,
+                inlineContentParserFactories,
+                delimiterProcessors,
+                linkProcessors,
+                linkMarkers,
+                includeSourceSpans,
+                maxOpenBlockParsers);
     }
 
     private Node postProcess(Node document) {
@@ -118,17 +135,17 @@ public class Parser {
         return document;
     }
 
-    /**
-     * Builder for configuring a {@link Parser}.
-     */
+    /** Builder for configuring a {@link Parser}. */
     public static class Builder {
         private final List<BlockParserFactory> blockParserFactories = new ArrayList<>();
-        private final List<InlineContentParserFactory> inlineContentParserFactories = new ArrayList<>();
+        private final List<InlineContentParserFactory> inlineContentParserFactories =
+                new ArrayList<>();
         private final List<DelimiterProcessor> delimiterProcessors = new ArrayList<>();
         private final List<LinkProcessor> linkProcessors = new ArrayList<>();
         private final List<PostProcessor> postProcessors = new ArrayList<>();
         private final Set<Character> linkMarkers = new HashSet<>();
-        private Set<Class<? extends Block>> enabledBlockTypes = DocumentParser.getDefaultBlockParserTypes();
+        private Set<Class<? extends Block>> enabledBlockTypes =
+                DocumentParser.getDefaultBlockParserTypes();
         private InlineParserFactory inlineParserFactory;
         private IncludeSourceSpans includeSourceSpans = IncludeSourceSpans.NONE;
         private int maxOpenBlockParsers = Integer.MAX_VALUE;
@@ -157,29 +174,31 @@ public class Parser {
 
         /**
          * Describe the list of markdown features the parser will recognize and parse.
-         * <p>
-         * By default, CommonMark will recognize and parse the following set of "block" elements:
-         * <ul>
-         * <li>{@link Heading} ({@code #})
-         * <li>{@link HtmlBlock} ({@code <html></html>})
-         * <li>{@link ThematicBreak} (Horizontal Rule) ({@code ---})
-         * <li>{@link FencedCodeBlock} ({@code ```})
-         * <li>{@link IndentedCodeBlock}
-         * <li>{@link BlockQuote} ({@code >})
-         * <li>{@link ListBlock} (Ordered / Unordered List) ({@code 1. / *})
-         * </ul>
-         * <p>
-         * To parse only a subset of the features listed above, pass a list of each feature's associated {@link Block} class.
-         * <p>
-         * E.g., to only parse headings and lists:
-         * <pre>
-         *     {@code
-         *     Parser.builder().enabledBlockTypes(Set.of(Heading.class, ListBlock.class));
-         *     }
-         * </pre>
          *
-         * @param enabledBlockTypes A list of block nodes the parser will parse.
-         *                          If this list is empty, the parser will not recognize any CommonMark core features.
+         * <p>By default, CommonMark will recognize and parse the following set of "block" elements:
+         *
+         * <ul>
+         *   <li>{@link Heading} ({@code #})
+         *   <li>{@link HtmlBlock} ({@code <html></html>})
+         *   <li>{@link ThematicBreak} (Horizontal Rule) ({@code ---})
+         *   <li>{@link FencedCodeBlock} ({@code ```})
+         *   <li>{@link IndentedCodeBlock}
+         *   <li>{@link BlockQuote} ({@code >})
+         *   <li>{@link ListBlock} (Ordered / Unordered List) ({@code 1. / *})
+         * </ul>
+         *
+         * <p>To parse only a subset of the features listed above, pass a list of each feature's
+         * associated {@link Block} class.
+         *
+         * <p>E.g., to only parse headings and lists:
+         *
+         * <pre>{@code
+         * Parser.builder().enabledBlockTypes(Set.of(Heading.class, ListBlock.class));
+         *
+         * }</pre>
+         *
+         * @param enabledBlockTypes A list of block nodes the parser will parse. If this list is
+         *     empty, the parser will not recognize any CommonMark core features.
          * @return {@code this}
          */
         public Builder enabledBlockTypes(Set<Class<? extends Block>> enabledBlockTypes) {
@@ -190,9 +209,10 @@ public class Parser {
         }
 
         /**
-         * Whether to calculate source positions for parsed {@link Node Nodes}, see {@link Node#getSourceSpans()}.
-         * <p>
-         * By default, source spans are disabled.
+         * Whether to calculate source positions for parsed {@link Node Nodes}, see {@link
+         * Node#getSourceSpans()}.
+         *
+         * <p>By default, source spans are disabled.
          *
          * @param includeSourceSpans which kind of source spans should be included
          * @return {@code this}
@@ -205,12 +225,12 @@ public class Parser {
 
         /**
          * Limit how many block parsers may be open at once while parsing.
-         * <p>
-         * Once the limit is reached, additional block starts are treated as plain text instead of
-         * creating deeper nested block structure.
-         * <p>
-         * The document root parser is not counted. The default is unlimited, so callers that keep
-         * using {@code Parser.builder().build()} preserve behavior.
+         *
+         * <p>Once the limit is reached, additional block starts are treated as plain text instead
+         * of creating deeper nested block structure.
+         *
+         * <p>The document root parser is not counted. The default is unlimited, so callers that
+         * keep using {@code Parser.builder().build()} preserve behavior.
          *
          * @param maxOpenBlockParsers maximum number of open non-document block parsers, must be
          *     zero or greater
@@ -226,10 +246,10 @@ public class Parser {
 
         /**
          * Add a custom block parser factory.
-         * <p>
-         * Note that custom factories are applied <em>before</em> the built-in factories. This is so that
-         * extensions can change how some syntax is parsed that would otherwise be handled by built-in factories.
-         * "With great power comes great responsibility."
+         *
+         * <p>Note that custom factories are applied <em>before</em> the built-in factories. This is
+         * so that extensions can change how some syntax is parsed that would otherwise be handled
+         * by built-in factories. "With great power comes great responsibility."
          *
          * @param blockParserFactory a block parser factory implementation
          * @return {@code this}
@@ -241,28 +261,33 @@ public class Parser {
         }
 
         /**
-         * Add a factory for a custom inline content parser, for extending inline parsing or overriding built-in parsing.
-         * <p>
-         * Note that parsers are triggered based on a special character as specified by
-         * {@link InlineContentParserFactory#getTriggerCharacters()}. It is possible to register multiple parsers for the same
-         * character, or even for some built-in special character such as {@code `}. The custom parsers are tried first
-         * in order in which they are registered, and then the built-in ones.
+         * Add a factory for a custom inline content parser, for extending inline parsing or
+         * overriding built-in parsing.
+         *
+         * <p>Note that parsers are triggered based on a special character as specified by {@link
+         * InlineContentParserFactory#getTriggerCharacters()}. It is possible to register multiple
+         * parsers for the same character, or even for some built-in special character such as
+         * {@code `}. The custom parsers are tried first in order in which they are registered, and
+         * then the built-in ones.
          */
-        public Builder customInlineContentParserFactory(InlineContentParserFactory inlineContentParserFactory) {
-            Objects.requireNonNull(inlineContentParserFactory, "inlineContentParser must not be null");
+        public Builder customInlineContentParserFactory(
+                InlineContentParserFactory inlineContentParserFactory) {
+            Objects.requireNonNull(
+                    inlineContentParserFactory, "inlineContentParser must not be null");
             inlineContentParserFactories.add(inlineContentParserFactory);
             return this;
         }
 
         /**
          * Add a custom delimiter processor for inline parsing.
-         * <p>
-         * Note that multiple delimiter processors with the same characters can be added, as long as they have a
-         * different minimum length. In that case, the processor with the shortest matching length is used. Adding more
-         * than one delimiter processor with the same character and minimum length is invalid.
-         * <p>
-         * If you want more control over how parsing is done, you might want to use
-         * {@link #customInlineContentParserFactory} instead.
+         *
+         * <p>Note that multiple delimiter processors with the same characters can be added, as long
+         * as they have a different minimum length. In that case, the processor with the shortest
+         * matching length is used. Adding more than one delimiter processor with the same character
+         * and minimum length is invalid.
+         *
+         * <p>If you want more control over how parsing is done, you might want to use {@link
+         * #customInlineContentParserFactory} instead.
          *
          * @param delimiterProcessor a delimiter processor implementation
          * @return {@code this}
@@ -275,9 +300,10 @@ public class Parser {
 
         /**
          * Add a custom link/image processor for inline parsing.
-         * <p>
-         * Multiple link processors can be added, and will be tried in order in which they were added. If no link
-         * processor applies, the normal behavior applies. That means these can override built-in link parsing.
+         *
+         * <p>Multiple link processors can be added, and will be tried in order in which they were
+         * added. If no link processor applies, the normal behavior applies. That means these can
+         * override built-in link parsing.
          *
          * @param linkProcessor a link processor implementation
          * @return {@code this}
@@ -289,12 +315,14 @@ public class Parser {
         }
 
         /**
-         * Add a custom link marker for link processing. A link marker is a character like {@code !} which, if it
-         * appears before the {@code [} of a link, changes the meaning of the link.
-         * <p>
-         * If a link marker followed by a valid link is parsed, the {@link org.commonmark.parser.beta.LinkInfo}
-         * that is passed to {@link LinkProcessor} will have its {@link LinkInfo#marker()} set. A link processor should
-         * check the {@link Text#getLiteral()} and then do any processing, and will probably want to use {@link LinkResult#includeMarker()}.
+         * Add a custom link marker for link processing. A link marker is a character like {@code !}
+         * which, if it appears before the {@code [} of a link, changes the meaning of the link.
+         *
+         * <p>If a link marker followed by a valid link is parsed, the {@link
+         * org.commonmark.parser.beta.LinkInfo} that is passed to {@link LinkProcessor} will have
+         * its {@link LinkInfo#marker()} set. A link processor should check the {@link
+         * Text#getLiteral()} and then do any processing, and will probably want to use {@link
+         * LinkResult#includeMarker()}.
          *
          * @param linkMarker a link marker character
          * @return {@code this}
@@ -313,18 +341,13 @@ public class Parser {
 
         /**
          * Overrides the parser used for inline markdown processing.
-         * <p>
-         * Provide an implementation of InlineParserFactory which provides a custom inline parser
-         * to modify how the following are parsed:
-         * bold (**)
-         * italic (*)
-         * strikethrough (~~)
-         * backtick quote (`)
-         * link ([title](http://))
-         * image (![alt](http://))
-         * <p>
-         * Note that if this method is not called or the inline parser factory is set to null, then the default
-         * implementation will be used.
+         *
+         * <p>Provide an implementation of InlineParserFactory which provides a custom inline parser
+         * to modify how the following are parsed: bold (**) italic (*) strikethrough (~~) backtick
+         * quote (`) link ([title](http://)) image (![alt](http://))
+         *
+         * <p>Note that if this method is not called or the inline parser factory is set to null,
+         * then the default implementation will be used.
          *
          * @param inlineParserFactory an inline parser factory implementation
          * @return {@code this}
@@ -343,9 +366,7 @@ public class Parser {
         }
     }
 
-    /**
-     * Extension for {@link Parser}.
-     */
+    /** Extension for {@link Parser}. */
     public interface ParserExtension extends Extension {
         void extend(Builder parserBuilder);
     }

--- a/commonmark/src/main/java/org/commonmark/parser/PostProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/parser/PostProcessor.java
@@ -9,5 +9,4 @@ public interface PostProcessor {
      * @return the result of post-processing, may be a modified {@code node} argument
      */
     Node process(Node node);
-
 }

--- a/commonmark/src/main/java/org/commonmark/parser/SourceLine.java
+++ b/commonmark/src/main/java/org/commonmark/parser/SourceLine.java
@@ -1,8 +1,7 @@
 package org.commonmark.parser;
 
-import org.commonmark.node.SourceSpan;
-
 import java.util.Objects;
+import org.commonmark.node.SourceSpan;
 
 /**
  * A line or part of a line from the input source.
@@ -39,7 +38,8 @@ public class SourceLine {
             if (length != 0) {
                 int columnIndex = sourceSpan.getColumnIndex() + beginIndex;
                 int inputIndex = sourceSpan.getInputIndex() + beginIndex;
-                newSourceSpan = SourceSpan.of(sourceSpan.getLineIndex(), columnIndex, inputIndex, length);
+                newSourceSpan =
+                        SourceSpan.of(sourceSpan.getLineIndex(), columnIndex, inputIndex, length);
             }
         }
         return SourceLine.of(newContent, newSourceSpan);

--- a/commonmark/src/main/java/org/commonmark/parser/SourceLines.java
+++ b/commonmark/src/main/java/org/commonmark/parser/SourceLines.java
@@ -1,9 +1,8 @@
 package org.commonmark.parser;
 
-import org.commonmark.node.SourceSpan;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.commonmark.node.SourceSpan;
 
 /**
  * A set of lines ({@link SourceLine}) from the input source.

--- a/commonmark/src/main/java/org/commonmark/parser/beta/InlineContentParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/InlineContentParser.java
@@ -1,21 +1,23 @@
 package org.commonmark.parser.beta;
 
 /**
- * Parser for a type of inline content. Registered via a {@link InlineContentParserFactory} and created by its
- * {@link InlineContentParserFactory#create() create} method. The lifetime of this is tied to each inline content
- * snippet that is parsed, as a new instance is created for each.
+ * Parser for a type of inline content. Registered via a {@link InlineContentParserFactory} and
+ * created by its {@link InlineContentParserFactory#create() create} method. The lifetime of this is
+ * tied to each inline content snippet that is parsed, as a new instance is created for each.
  */
 public interface InlineContentParser {
 
     /**
-     * Try to parse inline content starting from the current position. Note that the character at the current position
-     * is one of {@link InlineContentParserFactory#getTriggerCharacters()} of the factory that created this parser.
-     * <p>
-     * For a given inline content snippet that is being parsed, this method can be called multiple times: each time a
-     * trigger character is encountered.
+     * Try to parse inline content starting from the current position. Note that the character at
+     * the current position is one of {@link InlineContentParserFactory#getTriggerCharacters()} of
+     * the factory that created this parser.
+     *
+     * <p>For a given inline content snippet that is being parsed, this method can be called
+     * multiple times: each time a trigger character is encountered.
      *
      * @param inlineParserState the current state of the inline parser
-     * @return the result of parsing; can indicate that this parser is not interested, or that parsing was successful
+     * @return the result of parsing; can indicate that this parser is not interested, or that
+     *     parsing was successful
      */
     ParsedInline tryParse(InlineParserState inlineParserState);
 }

--- a/commonmark/src/main/java/org/commonmark/parser/beta/InlineContentParserFactory.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/InlineContentParserFactory.java
@@ -4,21 +4,24 @@ import java.util.Set;
 
 /**
  * A factory for extending inline content parsing.
- * <p>
- * See {@link org.commonmark.parser.Parser.Builder#customInlineContentParserFactory} for how to register it.
+ *
+ * <p>See {@link org.commonmark.parser.Parser.Builder#customInlineContentParserFactory} for how to
+ * register it.
  */
 public interface InlineContentParserFactory {
 
     /**
-     * An inline content parser needs to have a special "trigger" character which activates it. When this character is
-     * encountered during inline parsing, {@link InlineContentParser#tryParse} is called with the current parser state.
-     * It can also register for more than one trigger character.
+     * An inline content parser needs to have a special "trigger" character which activates it. When
+     * this character is encountered during inline parsing, {@link InlineContentParser#tryParse} is
+     * called with the current parser state. It can also register for more than one trigger
+     * character.
      */
     Set<Character> getTriggerCharacters();
 
     /**
-     * Create an {@link InlineContentParser} that will do the parsing. Create is called once per text snippet of inline
-     * content inside block structures, and then called each time a trigger character is encountered.
+     * Create an {@link InlineContentParser} that will do the parsing. Create is called once per
+     * text snippet of inline content inside block structures, and then called each time a trigger
+     * character is encountered.
      */
     InlineContentParser create();
 }

--- a/commonmark/src/main/java/org/commonmark/parser/beta/InlineParserState.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/InlineParserState.java
@@ -3,10 +3,10 @@ package org.commonmark.parser.beta;
 public interface InlineParserState {
 
     /**
-     * Return a scanner for the input for the current position (on the trigger character that the inline parser was
-     * added for).
-     * <p>
-     * Note that this always returns the same instance, if you want to backtrack you need to use
+     * Return a scanner for the input for the current position (on the trigger character that the
+     * inline parser was added for).
+     *
+     * <p>Note that this always returns the same instance, if you want to backtrack you need to use
      * {@link Scanner#position()} and {@link Scanner#setPosition(Position)}.
      */
     Scanner scanner();

--- a/commonmark/src/main/java/org/commonmark/parser/beta/LinkInfo.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/LinkInfo.java
@@ -4,62 +4,64 @@ import org.commonmark.node.Text;
 
 /**
  * A parsed link/image. There are different types of links.
- * <p>
- * Inline links:
+ *
+ * <p>Inline links:
+ *
  * <pre>
  * [text](destination)
  * [text](destination "title")
  * </pre>
- * <p>
- * Reference links, which have different subtypes. Full::
+ *
+ * <p>Reference links, which have different subtypes. Full::
+ *
  * <pre>
  * [text][label]
  * </pre>
+ *
  * Collapsed (label is ""):
+ *
  * <pre>
  * [text][]
  * </pre>
+ *
  * Shortcut (label is null):
+ *
  * <pre>
  * [text]
  * </pre>
- * Images use the same syntax as links but with a {@code !} {@link #marker()} front, e.g. {@code ![text](destination)}.
+ *
+ * Images use the same syntax as links but with a {@code !} {@link #marker()} front, e.g. {@code
+ * ![text](destination)}.
  */
 public interface LinkInfo {
 
     /**
-     * The marker if present, or null. A marker is e.g. {@code !} for an image, or a custom marker as specified in
-     * {@link org.commonmark.parser.Parser.Builder#linkMarker}.
+     * The marker if present, or null. A marker is e.g. {@code !} for an image, or a custom marker
+     * as specified in {@link org.commonmark.parser.Parser.Builder#linkMarker}.
      */
     Text marker();
 
-    /**
-     * The text node of the opening bracket {@code [}.
-     */
+    /** The text node of the opening bracket {@code [}. */
     Text openingBracket();
 
-    /**
-     * The text between the first brackets, e.g. `foo` in `[foo][bar]`.
-     */
+    /** The text between the first brackets, e.g. `foo` in `[foo][bar]`. */
     String text();
 
     /**
-     * The label, or null for inline links or for shortcut links (in which case {@link #text()} should be used as the label).
+     * The label, or null for inline links or for shortcut links (in which case {@link #text()}
+     * should be used as the label).
      */
     String label();
 
-    /**
-     * The destination if available, e.g. in `[foo](destination)`, or null
-     */
+    /** The destination if available, e.g. in `[foo](destination)`, or null */
     String destination();
 
-    /**
-     * The title if available, e.g. in `[foo](destination "title")`, or null
-     */
+    /** The title if available, e.g. in `[foo](destination "title")`, or null */
     String title();
 
     /**
      * The position after the closing text bracket, e.g.:
+     *
      * <pre>
      * [foo][bar]
      *      ^

--- a/commonmark/src/main/java/org/commonmark/parser/beta/LinkProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/LinkProcessor.java
@@ -4,37 +4,43 @@ import org.commonmark.parser.InlineParserContext;
 
 /**
  * An interface to decide how links/images are handled.
+ *
+ * <p>Implementations need to be registered with a parser via {@link
+ * org.commonmark.parser.Parser.Builder#linkProcessor}. Then, when inline parsing is run, each
+ * parsed link/image is passed to the processor. This includes links like these:
+ *
  * <p>
- * Implementations need to be registered with a parser via {@link org.commonmark.parser.Parser.Builder#linkProcessor}.
- * Then, when inline parsing is run, each parsed link/image is passed to the processor. This includes links like these:
- * <p>
+ *
  * <pre><code>
  * [text](destination)
  * [text]
  * [text][]
  * [text][label]
  * </code></pre>
+ *
  * And images:
+ *
  * <pre><code>
  * ![text](destination)
  * ![text]
  * ![text][]
  * ![text][label]
  * </code></pre>
+ *
  * See {@link LinkInfo} for accessing various parts of the parsed link/image.
- * <p>
- * The processor can then inspect the link/image and decide what to do with it by returning the appropriate
- * {@link LinkResult}. If it returns {@link LinkResult#none()}, the next registered processor is tried. If none of them
- * apply, the link is handled as it normally would.
+ *
+ * <p>The processor can then inspect the link/image and decide what to do with it by returning the
+ * appropriate {@link LinkResult}. If it returns {@link LinkResult#none()}, the next registered
+ * processor is tried. If none of them apply, the link is handled as it normally would.
  */
 public interface LinkProcessor {
 
     /**
      * @param linkInfo information about the parsed link/image
-     * @param scanner  the scanner at the current position after the parsed link/image
-     * @param context  context for inline parsing
-     * @return what to do with the link/image, e.g. do nothing (try the next processor), wrap the text in a node, or
-     * replace the link/image with a node
+     * @param scanner the scanner at the current position after the parsed link/image
+     * @param context context for inline parsing
+     * @return what to do with the link/image, e.g. do nothing (try the next processor), wrap the
+     *     text in a node, or replace the link/image with a node
      */
     LinkResult process(LinkInfo linkInfo, Scanner scanner, InlineParserContext context);
 }

--- a/commonmark/src/main/java/org/commonmark/parser/beta/LinkResult.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/LinkResult.java
@@ -3,26 +3,24 @@ package org.commonmark.parser.beta;
 import org.commonmark.internal.inline.LinkResultImpl;
 import org.commonmark.node.Node;
 
-/**
- * What to do with a link/image processed by {@link LinkProcessor}.
- */
+/** What to do with a link/image processed by {@link LinkProcessor}. */
 public interface LinkResult {
-    /**
-     * Link not handled by processor.
-     */
+    /** Link not handled by processor. */
     static LinkResult none() {
         return null;
     }
 
     /**
      * Wrap the link text in a node. This is the normal behavior for links, e.g. for this:
+     *
      * <pre><code>
      * [my *text*](destination)
      * </code></pre>
-     * The text is {@code my *text*}, a text node and emphasis. The text is wrapped in a
-     * {@link org.commonmark.node.Link} node, which means the text is added as child nodes to it.
      *
-     * @param node     the node to which the link text nodes will be added as child nodes
+     * The text is {@code my *text*}, a text node and emphasis. The text is wrapped in a {@link
+     * org.commonmark.node.Link} node, which means the text is added as child nodes to it.
+     *
+     * @param node the node to which the link text nodes will be added as child nodes
      * @param position the position to continue parsing from
      */
     static LinkResult wrapTextIn(Node node, Position position) {
@@ -31,12 +29,15 @@ public interface LinkResult {
 
     /**
      * Replace the link with a node. E.g. for this:
+     *
      * <pre><code>
      * [^foo]
      * </code></pre>
-     * The processor could decide to create a {@code FootnoteReference} node instead which replaces the link.
      *
-     * @param node     the node to replace the link with
+     * The processor could decide to create a {@code FootnoteReference} node instead which replaces
+     * the link.
+     *
+     * @param node the node to replace the link with
      * @param position the position to continue parsing from
      */
     static LinkResult replaceWith(Node node, Position position) {
@@ -44,7 +45,8 @@ public interface LinkResult {
     }
 
     /**
-     * If a {@link LinkInfo#marker()} is present, include it in processing (i.e. treat it the same way as the brackets).
+     * If a {@link LinkInfo#marker()} is present, include it in processing (i.e. treat it the same
+     * way as the brackets).
      */
     LinkResult includeMarker();
 }

--- a/commonmark/src/main/java/org/commonmark/parser/beta/ParsedInline.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/ParsedInline.java
@@ -1,14 +1,13 @@
 package org.commonmark.parser.beta;
 
+import java.util.Objects;
 import org.commonmark.internal.inline.ParsedInlineImpl;
 import org.commonmark.node.Node;
 
-import java.util.Objects;
-
 /**
  * The result of a single inline parser. Use the static methods to create instances.
- * <p>
- * <em>This interface is not intended to be implemented by clients.</em>
+ *
+ * <p><em>This interface is not intended to be implemented by clients.</em>
  */
 public interface ParsedInline {
 

--- a/commonmark/src/main/java/org/commonmark/parser/beta/Position.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/Position.java
@@ -1,8 +1,8 @@
 package org.commonmark.parser.beta;
 
 /**
- * Position within a {@link Scanner}. This is intentionally kept opaque so as not to expose the internal structure of
- * the Scanner.
+ * Position within a {@link Scanner}. This is intentionally kept opaque so as not to expose the
+ * internal structure of the Scanner.
  */
 public class Position {
 

--- a/commonmark/src/main/java/org/commonmark/parser/beta/Scanner.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/Scanner.java
@@ -1,29 +1,29 @@
 package org.commonmark.parser.beta;
 
+import java.util.List;
 import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.SourceLines;
 import org.commonmark.text.CharMatcher;
 
-import java.util.List;
-
 public class Scanner {
 
     /**
-     * Character representing the end of input source (or outside of the text in case of the "previous" methods).
-     * <p>
-     * Note that we can use NULL to represent this because CommonMark does not allow those in the input (we replace them
-     * in the beginning of parsing).
+     * Character representing the end of input source (or outside of the text in case of the
+     * "previous" methods).
+     *
+     * <p>Note that we can use NULL to represent this because CommonMark does not allow those in the
+     * input (we replace them in the beginning of parsing).
      */
     public static final char END = '\0';
 
-    // Lines without newlines at the end. The scanner will yield `\n` between lines because they're significant for
-    // parsing and the final output. There is no `\n` after the last line.
+    // Lines without newlines at the end. The scanner will yield `\n` between lines because they're
+    // significant for parsing and the final output. There is no `\n` after the last line.
     private final List<SourceLine> lines;
     // Which line we're at.
     private int lineIndex;
-    // The index within the line. If index == length(), we pretend that there's a `\n` and only advance after we yield
-    // that.
+    // The index within the line. If index == length(), we pretend that there's a `\n` and only
+    // advance after we yield that.
     private int index;
 
     // Current line or "" if at the end of the lines (using "" instead of null saves a null check)
@@ -135,8 +135,8 @@ public class Scanner {
     }
 
     /**
-     * Check if we have the specified content on the line and advanced the position. Note that if you want to match
-     * newline characters, use {@link #next(char)}.
+     * Check if we have the specified content on the line and advanced the position. Note that if
+     * you want to match newline characters, use {@link #next(char)}.
      *
      * @param content the text content to match on a single line (excluding newline characters)
      * @return true if matched and position was advanced, false otherwise
@@ -221,8 +221,8 @@ public class Scanner {
         }
     }
 
-    // Don't expose the int index, because it would be good if we could switch input to a List<String> of lines later
-    // instead of one contiguous String.
+    // Don't expose the int index, because it would be good if we could switch input to a
+    // List<String> of lines later instead of one contiguous String.
     public Position position() {
         return new Position(lineIndex, index);
     }
@@ -234,8 +234,8 @@ public class Scanner {
         setLine(lines.get(this.lineIndex));
     }
 
-    // For cases where the caller appends the result to a StringBuilder, we could offer another method to avoid some
-    // unnecessary copying.
+    // For cases where the caller appends the result to a StringBuilder, we could offer another
+    // method to avoid some unnecessary copying.
     public SourceLines getSource(Position begin, Position end) {
         if (begin.lineIndex == end.lineIndex) {
             // Shortcut for common case of text from a single line
@@ -271,11 +271,13 @@ public class Scanner {
 
     private void checkPosition(int lineIndex, int index) {
         if (lineIndex < 0 || lineIndex >= lines.size()) {
-            throw new IllegalArgumentException("Line index " + lineIndex + " out of range, number of lines: " + lines.size());
+            throw new IllegalArgumentException(
+                    "Line index " + lineIndex + " out of range, number of lines: " + lines.size());
         }
         SourceLine line = lines.get(lineIndex);
         if (index < 0 || index > line.getContent().length()) {
-            throw new IllegalArgumentException("Index " + index + " out of range, line length: " + line.getContent().length());
+            throw new IllegalArgumentException(
+                    "Index " + index + " out of range, line length: " + line.getContent().length());
         }
     }
 }

--- a/commonmark/src/main/java/org/commonmark/parser/beta/package-info.java
+++ b/commonmark/src/main/java/org/commonmark/parser/beta/package-info.java
@@ -1,4 +1,2 @@
-/**
- * Experimental APIs to use for extensions. APIs are subject to change if necessary.
- */
+/** Experimental APIs to use for extensions. APIs are subject to change if necessary. */
 package org.commonmark.parser.beta;

--- a/commonmark/src/main/java/org/commonmark/parser/block/AbstractBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/AbstractBlockParser.java
@@ -1,12 +1,11 @@
 package org.commonmark.parser.block;
 
+import java.util.List;
 import org.commonmark.node.Block;
 import org.commonmark.node.DefinitionMap;
 import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.SourceLine;
-
-import java.util.List;
 
 public abstract class AbstractBlockParser implements BlockParser {
 
@@ -26,8 +25,7 @@ public abstract class AbstractBlockParser implements BlockParser {
     }
 
     @Override
-    public void addLine(SourceLine line) {
-    }
+    public void addLine(SourceLine line) {}
 
     @Override
     public void addSourceSpan(SourceSpan sourceSpan) {
@@ -40,11 +38,8 @@ public abstract class AbstractBlockParser implements BlockParser {
     }
 
     @Override
-    public void closeBlock() {
-    }
+    public void closeBlock() {}
 
     @Override
-    public void parseInlines(InlineParser inlineParser) {
-    }
-
+    public void parseInlines(InlineParser inlineParser) {}
 }

--- a/commonmark/src/main/java/org/commonmark/parser/block/AbstractBlockParserFactory.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/AbstractBlockParserFactory.java
@@ -1,4 +1,3 @@
 package org.commonmark.parser.block;
 
-public abstract class AbstractBlockParserFactory implements BlockParserFactory {
-}
+public abstract class AbstractBlockParserFactory implements BlockParserFactory {}

--- a/commonmark/src/main/java/org/commonmark/parser/block/BlockContinue.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/BlockContinue.java
@@ -2,13 +2,10 @@ package org.commonmark.parser.block;
 
 import org.commonmark.internal.BlockContinueImpl;
 
-/**
- * Result object for continuing parsing of a block, see static methods for constructors.
- */
+/** Result object for continuing parsing of a block, see static methods for constructors. */
 public class BlockContinue {
 
-    protected BlockContinue() {
-    }
+    protected BlockContinue() {}
 
     public static BlockContinue none() {
         return null;
@@ -25,5 +22,4 @@ public class BlockContinue {
     public static BlockContinue finished() {
         return new BlockContinueImpl(-1, -1, true);
     }
-
 }

--- a/commonmark/src/main/java/org/commonmark/parser/block/BlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/BlockParser.java
@@ -1,33 +1,34 @@
 package org.commonmark.parser.block;
 
+import java.util.List;
 import org.commonmark.node.Block;
 import org.commonmark.node.DefinitionMap;
 import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.SourceLine;
 
-import java.util.List;
-
 /**
  * Parser for a specific block node.
- * <p>
- * Implementations should subclass {@link AbstractBlockParser} instead of implementing this directly.
+ *
+ * <p>Implementations should subclass {@link AbstractBlockParser} instead of implementing this
+ * directly.
  */
 public interface BlockParser {
 
     /**
-     * Return true if the block that is parsed is a container (contains other blocks), or false if it's a leaf.
+     * Return true if the block that is parsed is a container (contains other blocks), or false if
+     * it's a leaf.
      */
     boolean isContainer();
 
     /**
      * Return true if the block can have lazy continuation lines.
-     * <p>
-     * Lazy continuation lines are lines that were rejected by this {@link #tryContinue(ParserState)} but didn't match
-     * any other block parsers either.
-     * <p>
-     * If true is returned here, those lines will get added via {@link #addLine(SourceLine)}. For false, the block is
-     * closed instead.
+     *
+     * <p>Lazy continuation lines are lines that were rejected by this {@link
+     * #tryContinue(ParserState)} but didn't match any other block parsers either.
+     *
+     * <p>If true is returned here, those lines will get added via {@link #addLine(SourceLine)}. For
+     * false, the block is closed instead.
      */
     boolean canHaveLazyContinuationLines();
 
@@ -38,28 +39,28 @@ public interface BlockParser {
     BlockContinue tryContinue(ParserState parserState);
 
     /**
-     * Add the part of a line that belongs to this block parser to parse (i.e. without any container block markers).
-     * Note that the line will only include a {@link SourceLine#getSourceSpan()} if source spans are enabled for inlines.
+     * Add the part of a line that belongs to this block parser to parse (i.e. without any container
+     * block markers). Note that the line will only include a {@link SourceLine#getSourceSpan()} if
+     * source spans are enabled for inlines.
      */
     void addLine(SourceLine line);
 
     /**
-     * Add a source span of the currently parsed block. The default implementation in {@link AbstractBlockParser} adds
-     * it to the block. Unless you have some complicated parsing where you need to check source positions, you don't
-     * need to override this.
+     * Add a source span of the currently parsed block. The default implementation in {@link
+     * AbstractBlockParser} adds it to the block. Unless you have some complicated parsing where you
+     * need to check source positions, you don't need to override this.
      *
      * @since 0.16.0
      */
     void addSourceSpan(SourceSpan sourceSpan);
 
     /**
-     * Return definitions parsed by this parser. The definitions returned here can later be accessed during inline
-     * parsing via {@link org.commonmark.parser.InlineParserContext#getDefinition}.
+     * Return definitions parsed by this parser. The definitions returned here can later be accessed
+     * during inline parsing via {@link org.commonmark.parser.InlineParserContext#getDefinition}.
      */
     List<DefinitionMap<?>> getDefinitions();
 
     void closeBlock();
 
     void parseInlines(InlineParser inlineParser);
-
 }

--- a/commonmark/src/main/java/org/commonmark/parser/block/BlockParserFactory.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/BlockParserFactory.java
@@ -2,11 +2,11 @@ package org.commonmark.parser.block;
 
 /**
  * Parser factory for a block node for determining when a block starts.
- * <p>
- * Implementations should subclass {@link AbstractBlockParserFactory} instead of implementing this directly.
+ *
+ * <p>Implementations should subclass {@link AbstractBlockParserFactory} instead of implementing
+ * this directly.
  */
 public interface BlockParserFactory {
 
     BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser);
-
 }

--- a/commonmark/src/main/java/org/commonmark/parser/block/BlockStart.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/BlockStart.java
@@ -2,24 +2,17 @@ package org.commonmark.parser.block;
 
 import org.commonmark.internal.BlockStartImpl;
 
-/**
- * Result object for starting parsing of a block, see static methods for constructors.
- */
+/** Result object for starting parsing of a block, see static methods for constructors. */
 public abstract class BlockStart {
 
-    protected BlockStart() {
-    }
+    protected BlockStart() {}
 
-    /**
-     * Result for when there is no block start.
-     */
+    /** Result for when there is no block start. */
     public static BlockStart none() {
         return null;
     }
 
-    /**
-     * Start block(s) with the specified parser(s).
-     */
+    /** Start block(s) with the specified parser(s). */
     public static BlockStart of(BlockParser... blockParsers) {
         return new BlockStartImpl(blockParsers);
     }
@@ -39,30 +32,32 @@ public abstract class BlockStart {
     public abstract BlockStart atColumn(int newColumn);
 
     /**
-     * @deprecated use {@link #replaceParagraphLines(int)} instead; please raise an issue if that doesn't work for you
-     * for some reason.
+     * @deprecated use {@link #replaceParagraphLines(int)} instead; please raise an issue if that
+     *     doesn't work for you for some reason.
      */
     @Deprecated
     public abstract BlockStart replaceActiveBlockParser();
 
     /**
-     * Replace a number of lines from the current paragraph (as returned by
-     * {@link MatchedBlockParser#getParagraphLines()}) with the new block.
-     * <p>
-     * This is useful for parsing blocks that start with normal paragraphs and only have special marker syntax in later
-     * lines, e.g. in this:
+     * Replace a number of lines from the current paragraph (as returned by {@link
+     * MatchedBlockParser#getParagraphLines()}) with the new block.
+     *
+     * <p>This is useful for parsing blocks that start with normal paragraphs and only have special
+     * marker syntax in later lines, e.g. in this:
+     *
      * <pre>
      * Foo
      * ===
      * </pre>
-     * The <code>Foo</code> line is initially parsed as a normal paragraph, then <code>===</code> is parsed as a heading
-     * marker, replacing the 1 paragraph line before. The end result is a single Heading block.
-     * <p>
-     * Note that source spans from the replaced lines are automatically added to the new block.
      *
-     * @param lines the number of lines to replace (at least 1); use {@link Integer#MAX_VALUE} to replace the whole
-     *              paragraph
+     * The <code>Foo</code> line is initially parsed as a normal paragraph, then <code>===</code> is
+     * parsed as a heading marker, replacing the 1 paragraph line before. The end result is a single
+     * Heading block.
+     *
+     * <p>Note that source spans from the replaced lines are automatically added to the new block.
+     *
+     * @param lines the number of lines to replace (at least 1); use {@link Integer#MAX_VALUE} to
+     *     replace the whole paragraph
      */
     public abstract BlockStart replaceParagraphLines(int lines);
-
 }

--- a/commonmark/src/main/java/org/commonmark/parser/block/MatchedBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/MatchedBlockParser.java
@@ -3,20 +3,21 @@ package org.commonmark.parser.block;
 import org.commonmark.parser.SourceLines;
 
 /**
- * Open block parser that was last matched during the continue phase. This is different from the currently active
- * block parser, as an unmatched block is only closed when a new block is started.
- * <p><em>This interface is not intended to be implemented by clients.</em></p>
+ * Open block parser that was last matched during the continue phase. This is different from the
+ * currently active block parser, as an unmatched block is only closed when a new block is started.
+ *
+ * <p><em>This interface is not intended to be implemented by clients.</em>
  */
 public interface MatchedBlockParser {
 
     BlockParser getMatchedBlockParser();
 
     /**
-     * Returns the current paragraph lines if the matched block is a paragraph. If you want to use some or all of the
-     * lines for starting a new block instead, use {@link BlockStart#replaceParagraphLines(int)}.
+     * Returns the current paragraph lines if the matched block is a paragraph. If you want to use
+     * some or all of the lines for starting a new block instead, use {@link
+     * BlockStart#replaceParagraphLines(int)}.
      *
      * @return paragraph content or an empty list
      */
     SourceLines getParagraphLines();
-
 }

--- a/commonmark/src/main/java/org/commonmark/parser/block/ParserState.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/ParserState.java
@@ -4,7 +4,8 @@ import org.commonmark.parser.SourceLine;
 
 /**
  * State of the parser that is used in block parsers.
- * <p><em>This interface is not intended to be implemented by clients.</em></p>
+ *
+ * <p><em>This interface is not intended to be implemented by clients.</em>
  */
 public interface ParserState {
 
@@ -19,21 +20,24 @@ public interface ParserState {
     int getIndex();
 
     /**
-     * @return the index of the next non-space character starting from {@link #getIndex()} (may be the same) (0-based)
+     * @return the index of the next non-space character starting from {@link #getIndex()} (may be
+     *     the same) (0-based)
      */
     int getNextNonSpaceIndex();
 
     /**
-     * The column is the position within the line after tab characters have been processed as 4-space tab stops.
-     * If the line doesn't contain any tabs, it's the same as the {@link #getIndex()}. If the line starts with a tab,
-     * followed by text, then the column for the first character of the text is 4 (the index is 1).
+     * The column is the position within the line after tab characters have been processed as
+     * 4-space tab stops. If the line doesn't contain any tabs, it's the same as the {@link
+     * #getIndex()}. If the line starts with a tab, followed by text, then the column for the first
+     * character of the text is 4 (the index is 1).
      *
      * @return the current column within the line (0-based)
      */
     int getColumn();
 
     /**
-     * @return the indentation in columns (either by spaces or tab stop of 4), starting from {@link #getColumn()}
+     * @return the indentation in columns (either by spaces or tab stop of 4), starting from {@link
+     *     #getColumn()}
      */
     int getIndent();
 
@@ -46,5 +50,4 @@ public interface ParserState {
      * @return the deepest open block parser
      */
     BlockParser getActiveBlockParser();
-
 }

--- a/commonmark/src/main/java/org/commonmark/parser/block/package-info.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/package-info.java
@@ -1,4 +1,2 @@
-/**
- * Types for extending block parsing
- */
+/** Types for extending block parsing */
 package org.commonmark.parser.block;

--- a/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterProcessor.java
@@ -4,22 +4,24 @@ import org.commonmark.node.Text;
 
 /**
  * Custom delimiter processor for additional delimiters besides {@code _} and {@code *}.
- * <p>
- * Note that implementations of this need to be thread-safe, the same instance may be used by multiple parsers.
+ *
+ * <p>Note that implementations of this need to be thread-safe, the same instance may be used by
+ * multiple parsers.
  *
  * @see org.commonmark.parser.beta.InlineContentParserFactory
  */
 public interface DelimiterProcessor {
 
     /**
-     * @return the character that marks the beginning of a delimited node, must not clash with any built-in special
-     * characters
+     * @return the character that marks the beginning of a delimited node, must not clash with any
+     *     built-in special characters
      */
     char getOpeningCharacter();
 
     /**
-     * @return the character that marks the the ending of a delimited node, must not clash with any built-in special
-     * characters. Note that for a symmetric delimiter such as "*", this is the same as the opening.
+     * @return the character that marks the the ending of a delimited node, must not clash with any
+     *     built-in special characters. Note that for a symmetric delimiter such as "*", this is the
+     *     same as the opening.
      */
     char getClosingCharacter();
 
@@ -30,17 +32,18 @@ public interface DelimiterProcessor {
 
     /**
      * Process the delimiter runs.
-     * <p>
-     * The processor can examine the runs and the nodes and decide if it wants to process or not. If not, it should not
-     * change any nodes and return 0. If yes, it should do the processing (wrapping nodes, etc) and then return how many
-     * delimiters were used.
-     * <p>
-     * Note that removal (unlinking) of the used delimiter {@link Text} nodes is done by the caller.
+     *
+     * <p>The processor can examine the runs and the nodes and decide if it wants to process or not.
+     * If not, it should not change any nodes and return 0. If yes, it should do the processing
+     * (wrapping nodes, etc) and then return how many delimiters were used.
+     *
+     * <p>Note that removal (unlinking) of the used delimiter {@link Text} nodes is done by the
+     * caller.
      *
      * @param openingRun the opening delimiter run
      * @param closingRun the closing delimiter run
-     * @return how many delimiters were used; must not be greater than length of either opener or closer
+     * @return how many delimiters were used; must not be greater than length of either opener or
+     *     closer
      */
     int process(DelimiterRun openingRun, DelimiterRun closingRun);
-
 }

--- a/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterRun.java
+++ b/commonmark/src/main/java/org/commonmark/parser/delimiter/DelimiterRun.java
@@ -2,9 +2,7 @@ package org.commonmark.parser.delimiter;
 
 import org.commonmark.node.Text;
 
-/**
- * A delimiter run is one or more of the same delimiter character, e.g. {@code ***}.
- */
+/** A delimiter run is one or more of the same delimiter character, e.g. {@code ***}. */
 public interface DelimiterRun {
 
     /**
@@ -23,8 +21,8 @@ public interface DelimiterRun {
     int length();
 
     /**
-     * @return the number of characters originally in this delimiter run; at the start of processing, this is the same
-     * as {{@link #length()}}
+     * @return the number of characters originally in this delimiter run; at the start of
+     *     processing, this is the same as {{@link #length()}}
      */
     int originalLength();
 
@@ -39,20 +37,20 @@ public interface DelimiterRun {
     Text getCloser();
 
     /**
-     * Get the opening delimiter nodes for the specified length of delimiters. Length must be between 1 and
-     * {@link #length()}.
-     * <p>
-     * For example, for a delimiter run {@code ***}, calling this with 1 would return the last {@code *}.
-     * Calling it with 2 would return the second last {@code *} and the last {@code *}.
+     * Get the opening delimiter nodes for the specified length of delimiters. Length must be
+     * between 1 and {@link #length()}.
+     *
+     * <p>For example, for a delimiter run {@code ***}, calling this with 1 would return the last
+     * {@code *}. Calling it with 2 would return the second last {@code *} and the last {@code *}.
      */
     Iterable<Text> getOpeners(int length);
 
     /**
-     * Get the closing delimiter nodes for the specified length of delimiters. Length must be between 1 and
-     * {@link #length()}.
-     * <p>
-     * For example, for a delimiter run {@code ***}, calling this with 1 would return the first {@code *}.
-     * Calling it with 2 would return the first {@code *} and the second {@code *}.
+     * Get the closing delimiter nodes for the specified length of delimiters. Length must be
+     * between 1 and {@link #length()}.
+     *
+     * <p>For example, for a delimiter run {@code ***}, calling this with 1 would return the first
+     * {@code *}. Calling it with 2 would return the first {@code *} and the second {@code *}.
      */
     Iterable<Text> getClosers(int length);
 }

--- a/commonmark/src/main/java/org/commonmark/parser/package-info.java
+++ b/commonmark/src/main/java/org/commonmark/parser/package-info.java
@@ -1,4 +1,2 @@
-/**
- * Parsing input text to AST nodes (see {@link org.commonmark.parser.Parser})
- */
+/** Parsing input text to AST nodes (see {@link org.commonmark.parser.Parser}) */
 package org.commonmark.parser;

--- a/commonmark/src/main/java/org/commonmark/renderer/NodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/NodeRenderer.java
@@ -1,12 +1,9 @@
 package org.commonmark.renderer;
 
+import java.util.Set;
 import org.commonmark.node.Node;
 
-import java.util.Set;
-
-/**
- * A renderer for a set of node types.
- */
+/** A renderer for a set of node types. */
 public interface NodeRenderer {
 
     /**
@@ -26,14 +23,12 @@ public interface NodeRenderer {
      *
      * @param rootNode the root (top-level) node
      */
-    default void beforeRoot(Node rootNode) {
-    }
+    default void beforeRoot(Node rootNode) {}
 
     /**
      * Called after the root node is rendered, to do any final processing at the end.
      *
      * @param rootNode the root (top-level) node
      */
-    default void afterRoot(Node rootNode) {
-    }
+    default void afterRoot(Node rootNode) {}
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/html/AttributeProvider.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/AttributeProvider.java
@@ -1,29 +1,27 @@
 package org.commonmark.renderer.html;
 
+import java.util.Map;
 import org.commonmark.node.Node;
 
-import java.util.Map;
-
-/**
- * Extension point for adding/changing attributes on HTML tags for a node.
- */
+/** Extension point for adding/changing attributes on HTML tags for a node. */
 public interface AttributeProvider {
 
     /**
      * Set the attributes for a HTML tag of the specified node by modifying the provided map.
-     * <p>
-     * This allows to change or even remove default attributes. With great power comes great responsibility.
-     * <p>
-     * The attribute key and values will be escaped (preserving character entities), so don't escape them here,
-     * otherwise they will be double-escaped.
-     * <p>
-     * This method may be called multiple times for the same node, if the node is rendered using multiple nested
-     * tags (e.g. code blocks).
+     *
+     * <p>This allows to change or even remove default attributes. With great power comes great
+     * responsibility.
+     *
+     * <p>The attribute key and values will be escaped (preserving character entities), so don't
+     * escape them here, otherwise they will be double-escaped.
+     *
+     * <p>This method may be called multiple times for the same node, if the node is rendered using
+     * multiple nested tags (e.g. code blocks).
      *
      * @param node the node to set attributes for
-     * @param tagName the HTML tag name that these attributes are for (e.g. {@code h1}, {@code pre}, {@code code}).
+     * @param tagName the HTML tag name that these attributes are for (e.g. {@code h1}, {@code pre},
+     *     {@code code}).
      * @param attributes the attributes, with any default attributes already set in the map
      */
     void setAttributes(Node node, String tagName, Map<String, String> attributes);
-
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/html/AttributeProviderContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/AttributeProviderContext.java
@@ -2,8 +2,9 @@ package org.commonmark.renderer.html;
 
 /**
  * The context for attribute providers.
- * <p>Note: There are currently no methods here, this is for future extensibility.</p>
- * <p><em>This interface is not intended to be implemented by clients.</em></p>
+ *
+ * <p>Note: There are currently no methods here, this is for future extensibility.
+ *
+ * <p><em>This interface is not intended to be implemented by clients.</em>
  */
-public interface AttributeProviderContext {
-}
+public interface AttributeProviderContext {}

--- a/commonmark/src/main/java/org/commonmark/renderer/html/AttributeProviderFactory.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/AttributeProviderFactory.java
@@ -1,8 +1,6 @@
 package org.commonmark.renderer.html;
 
-/**
- * Factory for instantiating new attribute providers when rendering is done.
- */
+/** Factory for instantiating new attribute providers when rendering is done. */
 public interface AttributeProviderFactory {
 
     /**

--- a/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/CoreHtmlNodeRenderer.java
@@ -1,11 +1,10 @@
 package org.commonmark.renderer.html;
 
-import org.commonmark.node.*;
-import org.commonmark.renderer.NodeRenderer;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import org.commonmark.node.*;
+import org.commonmark.renderer.NodeRenderer;
 
 /**
  * The node renderer that renders all the core nodes (comes last in the order of node renderers).
@@ -42,8 +41,7 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
                 Code.class,
                 HtmlInline.class,
                 SoftLineBreak.class,
-                HardLineBreak.class
-        );
+                HardLineBreak.class);
     }
 
     @Override
@@ -69,9 +67,12 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
 
     @Override
     public void visit(Paragraph paragraph) {
-        boolean omitP = isInTightList(paragraph) || //
-                (context.shouldOmitSingleParagraphP() && paragraph.getParent() instanceof Document && //
-                        paragraph.getPrevious() == null && paragraph.getNext() == null);
+        boolean omitP =
+                isInTightList(paragraph)
+                        || (context.shouldOmitSingleParagraphP()
+                                && paragraph.getParent() instanceof Document
+                                && paragraph.getPrevious() == null
+                                && paragraph.getNext() == null);
         if (!omitP) {
             html.line();
             html.tag("p", getAttrs(paragraph, "p"));
@@ -172,7 +173,8 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
 
     @Override
     public void visit(OrderedList orderedList) {
-        int start = orderedList.getMarkerStartNumber() != null ? orderedList.getMarkerStartNumber() : 1;
+        int start =
+                orderedList.getMarkerStartNumber() != null ? orderedList.getMarkerStartNumber() : 1;
         Map<String, String> attrs = new LinkedHashMap<>();
         if (start != 1) {
             attrs.put("start", String.valueOf(start));
@@ -268,7 +270,8 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
         html.line();
     }
 
-    private void renderListBlock(ListBlock listBlock, String tagName, Map<String, String> attributes) {
+    private void renderListBlock(
+            ListBlock listBlock, String tagName, Map<String, String> attributes) {
         html.line();
         html.tag(tagName, attributes);
         html.line();
@@ -294,7 +297,8 @@ public class CoreHtmlNodeRenderer extends AbstractVisitor implements NodeRendere
         return getAttrs(node, tagName, Map.of());
     }
 
-    private Map<String, String> getAttrs(Node node, String tagName, Map<String, String> defaultAttributes) {
+    private Map<String, String> getAttrs(
+            Node node, String tagName, Map<String, String> defaultAttributes) {
         return context.extendAttributes(node, tagName, defaultAttributes);
     }
 

--- a/commonmark/src/main/java/org/commonmark/renderer/html/DefaultUrlSanitizer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/DefaultUrlSanitizer.java
@@ -3,10 +3,9 @@ package org.commonmark.renderer.html;
 import java.util.*;
 
 /**
- *
- * Allows http, https, mailto, and data protocols for url.
- * Also allows protocol relative urls, and relative urls.
- * Implementation based on https://github.com/OWASP/java-html-sanitizer/blob/f07e44b034a45d94d6fd010279073c38b6933072/src/main/java/org/owasp/html/FilterUrlByProtocolAttributePolicy.java
+ * Allows http, https, mailto, and data protocols for url. Also allows protocol relative urls, and
+ * relative urls. Implementation based on
+ * https://github.com/OWASP/java-html-sanitizer/blob/f07e44b034a45d94d6fd010279073c38b6933072/src/main/java/org/owasp/html/FilterUrlByProtocolAttributePolicy.java
  */
 public class DefaultUrlSanitizer implements UrlSanitizer {
     private Set<String> protocols;
@@ -27,7 +26,7 @@ public class DefaultUrlSanitizer implements UrlSanitizer {
             switch (url.charAt(i)) {
                 case '/':
                 case '#':
-                case '?':  // No protocol.
+                case '?': // No protocol.
                     break protocol_loop;
                 case ':':
                     String protocol = url.substring(0, i).toLowerCase();
@@ -39,7 +38,6 @@ public class DefaultUrlSanitizer implements UrlSanitizer {
         }
         return url;
     }
-
 
     @Override
     public String sanitizeImageUrl(String url) {
@@ -74,7 +72,6 @@ public class DefaultUrlSanitizer implements UrlSanitizer {
                 return true;
             default:
                 return false;
-
         }
     }
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlNodeRendererContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlNodeRendererContext.java
@@ -1,10 +1,9 @@
 package org.commonmark.renderer.html;
 
+import java.util.Map;
 import org.commonmark.node.Image;
 import org.commonmark.node.Link;
 import org.commonmark.node.Node;
-
-import java.util.Map;
 
 public interface HtmlNodeRendererContext {
 
@@ -17,8 +16,9 @@ public interface HtmlNodeRendererContext {
     /**
      * Let extensions modify the HTML tag attributes.
      *
-     * @param node       the node for which the attributes are applied
-     * @param tagName    the HTML tag name that these attributes are for (e.g. {@code h1}, {@code pre}, {@code code}).
+     * @param node the node for which the attributes are applied
+     * @param tagName the HTML tag name that these attributes are for (e.g. {@code h1}, {@code pre},
+     *     {@code code}).
      * @param attributes the attributes that were calculated by the renderer
      * @return the extended attributes with added/updated/removed entries
      */
@@ -35,8 +35,9 @@ public interface HtmlNodeRendererContext {
     String getSoftbreak();
 
     /**
-     * Render the specified node and its children using the configured renderers. This should be used to render child
-     * nodes; be careful not to pass the node that is being rendered, that would result in an endless loop.
+     * Render the specified node and its children using the configured renderers. This should be
+     * used to render child nodes; be careful not to pass the node that is being rendered, that
+     * would result in an endless loop.
      *
      * @param node the node to render
      */
@@ -48,7 +49,8 @@ public interface HtmlNodeRendererContext {
     boolean shouldEscapeHtml();
 
     /**
-     * @return whether documents that only contain a single paragraph should be rendered without the {@code <p>} tag
+     * @return whether documents that only contain a single paragraph should be rendered without the
+     *     {@code <p>} tag
      */
     boolean shouldOmitSingleParagraphP();
 
@@ -59,7 +61,8 @@ public interface HtmlNodeRendererContext {
     boolean shouldSanitizeUrls();
 
     /**
-     * @return Sanitizer to use for securing {@link Link} href and {@link Image} src if {@link #shouldSanitizeUrls()} is true.
+     * @return Sanitizer to use for securing {@link Link} href and {@link Image} src if {@link
+     *     #shouldSanitizeUrls()} is true.
      * @since 0.14.0
      */
     UrlSanitizer urlSanitizer();

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlNodeRendererFactory.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlNodeRendererFactory.java
@@ -2,9 +2,7 @@ package org.commonmark.renderer.html;
 
 import org.commonmark.renderer.NodeRenderer;
 
-/**
- * Factory for instantiating new node renderers when rendering is done.
- */
+/** Factory for instantiating new node renderers when rendering is done. */
 public interface HtmlNodeRendererFactory {
 
     /**

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
@@ -1,17 +1,17 @@
 package org.commonmark.renderer.html;
 
+import java.util.*;
 import org.commonmark.Extension;
 import org.commonmark.internal.renderer.NodeRendererMap;
 import org.commonmark.internal.util.Escaping;
 import org.commonmark.node.*;
 import org.commonmark.renderer.Renderer;
 
-import java.util.*;
-
 /**
  * Renders a tree of nodes to HTML.
- * <p>
- * Start with the {@link #builder} method to configure the renderer. Example:
+ *
+ * <p>Start with the {@link #builder} method to configure the renderer. Example:
+ *
  * <pre><code>
  * HtmlRenderer renderer = HtmlRenderer.builder().escapeHtml(true).build();
  * renderer.render(node);
@@ -69,9 +69,7 @@ public class HtmlRenderer implements Renderer {
         return sb.toString();
     }
 
-    /**
-     * Builder for configuring an {@link HtmlRenderer}. See methods for default configuration.
-     */
+    /** Builder for configuring an {@link HtmlRenderer}. See methods for default configuration. */
     public static class Builder {
 
         private String softbreak = "\n";
@@ -91,12 +89,12 @@ public class HtmlRenderer implements Renderer {
         }
 
         /**
-         * The HTML to use for rendering a softbreak, defaults to {@code "\n"} (meaning the rendered result doesn't have
-         * a line break).
-         * <p>
-         * Set it to {@code "<br>"} (or {@code "<br />"} to make them hard breaks.
-         * <p>
-         * Set it to {@code " "} to ignore line wrapping in the source.
+         * The HTML to use for rendering a softbreak, defaults to {@code "\n"} (meaning the rendered
+         * result doesn't have a line break).
+         *
+         * <p>Set it to {@code "<br>"} (or {@code "<br />"} to make them hard breaks.
+         *
+         * <p>Set it to {@code " "} to ignore line wrapping in the source.
          *
          * @param softbreak HTML for softbreak
          * @return {@code this}
@@ -107,10 +105,12 @@ public class HtmlRenderer implements Renderer {
         }
 
         /**
-         * Whether {@link HtmlInline} and {@link HtmlBlock} should be escaped, defaults to {@code false}.
-         * <p>
-         * Note that {@link HtmlInline} is only a tag itself, not the text between an opening tag and a closing tag. So
-         * markup in the text will be parsed as normal and is not affected by this option.
+         * Whether {@link HtmlInline} and {@link HtmlBlock} should be escaped, defaults to {@code
+         * false}.
+         *
+         * <p>Note that {@link HtmlInline} is only a tag itself, not the text between an opening tag
+         * and a closing tag. So markup in the text will be parsed as normal and is not affected by
+         * this option.
          *
          * @param escapeHtml true for escaping, false for preserving raw HTML
          * @return {@code this}
@@ -121,7 +121,8 @@ public class HtmlRenderer implements Renderer {
         }
 
         /**
-         * Whether {@link Image} src and {@link Link} href should be sanitized, defaults to {@code false}.
+         * Whether {@link Image} src and {@link Link} href should be sanitized, defaults to {@code
+         * false}.
          *
          * @param sanitizeUrls true for sanitization, false for preserving raw attribute
          * @return {@code this}
@@ -146,13 +147,15 @@ public class HtmlRenderer implements Renderer {
 
         /**
          * Whether URLs of link or images should be percent-encoded, defaults to {@code false}.
-         * <p>
-         * If enabled, the following is done:
+         *
+         * <p>If enabled, the following is done:
+         *
          * <ul>
-         * <li>Existing percent-encoded parts are preserved (e.g. "%20" is kept as "%20")</li>
-         * <li>Reserved characters such as "/" are preserved, except for "[" and "]" (see encodeURI in JS)</li>
-         * <li>Unreserved characters such as "a" are preserved</li>
-         * <li>Other characters such umlauts are percent-encoded</li>
+         *   <li>Existing percent-encoded parts are preserved (e.g. "%20" is kept as "%20")
+         *   <li>Reserved characters such as "/" are preserved, except for "[" and "]" (see
+         *       encodeURI in JS)
+         *   <li>Unreserved characters such as "a" are preserved
+         *   <li>Other characters such umlauts are percent-encoded
          * </ul>
          *
          * @param percentEncodeUrls true to percent-encode, false for leaving as-is
@@ -164,8 +167,9 @@ public class HtmlRenderer implements Renderer {
         }
 
         /**
-         * Whether documents that only contain a single paragraph should be rendered without the {@code <p>} tag. Set to
-         * {@code true} to render without the tag; the default of {@code false} always renders the tag.
+         * Whether documents that only contain a single paragraph should be rendered without the
+         * {@code <p>} tag. Set to {@code true} to render without the tag; the default of {@code
+         * false} always renders the tag.
          *
          * @return {@code this}
          */
@@ -175,23 +179,26 @@ public class HtmlRenderer implements Renderer {
         }
 
         /**
-         * Add a factory for an attribute provider for adding/changing HTML attributes to the rendered tags.
+         * Add a factory for an attribute provider for adding/changing HTML attributes to the
+         * rendered tags.
          *
          * @param attributeProviderFactory the attribute provider factory to add
          * @return {@code this}
          */
         public Builder attributeProviderFactory(AttributeProviderFactory attributeProviderFactory) {
-            Objects.requireNonNull(attributeProviderFactory, "attributeProviderFactory must not be null");
+            Objects.requireNonNull(
+                    attributeProviderFactory, "attributeProviderFactory must not be null");
             this.attributeProviderFactories.add(attributeProviderFactory);
             return this;
         }
 
         /**
-         * Add a factory for instantiating a node renderer (done when rendering). This allows to override the rendering
-         * of node types or define rendering for custom node types.
-         * <p>
-         * If multiple node renderers for the same node type are created, the one from the factory that was added first
-         * "wins". (This is how the rendering for core node types can be overridden; the default rendering comes last.)
+         * Add a factory for instantiating a node renderer (done when rendering). This allows to
+         * override the rendering of node types or define rendering for custom node types.
+         *
+         * <p>If multiple node renderers for the same node type are created, the one from the
+         * factory that was added first "wins". (This is how the rendering for core node types can
+         * be overridden; the default rendering comes last.)
          *
          * @param nodeRendererFactory the factory for creating a node renderer
          * @return {@code this}
@@ -218,9 +225,7 @@ public class HtmlRenderer implements Renderer {
         }
     }
 
-    /**
-     * Extension for {@link HtmlRenderer}.
-     */
+    /** Extension for {@link HtmlRenderer}. */
     public interface HtmlRendererExtension extends Extension {
         void extend(Builder rendererBuilder);
     }
@@ -275,7 +280,8 @@ public class HtmlRenderer implements Renderer {
         }
 
         @Override
-        public Map<String, String> extendAttributes(Node node, String tagName, Map<String, String> attributes) {
+        public Map<String, String> extendAttributes(
+                Node node, String tagName, Map<String, String> attributes) {
             Map<String, String> attrs = new LinkedHashMap<>(attributes);
             setCustomAttributes(node, tagName, attrs);
             return attrs;

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlWriter.java
@@ -1,10 +1,9 @@
 package org.commonmark.renderer.html;
 
-import org.commonmark.internal.util.Escaping;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import org.commonmark.internal.util.Escaping;
 
 public class HtmlWriter {
 

--- a/commonmark/src/main/java/org/commonmark/renderer/html/UrlSanitizer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/UrlSanitizer.java
@@ -4,10 +4,11 @@ import org.commonmark.node.Image;
 import org.commonmark.node.Link;
 
 /**
- * Sanitizes urls for img and a elements by whitelisting protocols.
- * This is intended to prevent XSS payloads like [Click this totally safe url](javascript:document.xss=true;)
- * <p>
- * Implementation based on https://github.com/OWASP/java-html-sanitizer/blob/f07e44b034a45d94d6fd010279073c38b6933072/src/main/java/org/owasp/html/FilterUrlByProtocolAttributePolicy.java
+ * Sanitizes urls for img and a elements by whitelisting protocols. This is intended to prevent XSS
+ * payloads like [Click this totally safe url](javascript:document.xss=true;)
+ *
+ * <p>Implementation based on
+ * https://github.com/OWASP/java-html-sanitizer/blob/f07e44b034a45d94d6fd010279073c38b6933072/src/main/java/org/owasp/html/FilterUrlByProtocolAttributePolicy.java
  *
  * @since 0.14.0
  */

--- a/commonmark/src/main/java/org/commonmark/renderer/html/package-info.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/package-info.java
@@ -1,4 +1,2 @@
-/**
- * HTML rendering (see {@link org.commonmark.renderer.html.HtmlRenderer})
- */
+/** HTML rendering (see {@link org.commonmark.renderer.html.HtmlRenderer}) */
 package org.commonmark.renderer.html;

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/CoreMarkdownNodeRenderer.java
@@ -1,22 +1,22 @@
 package org.commonmark.renderer.markdown;
 
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.commonmark.node.*;
 import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.text.AsciiMatcher;
 import org.commonmark.text.CharMatcher;
 import org.commonmark.text.Characters;
 
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * The node renderer that renders all the core nodes (comes last in the order of node renderers).
- * <p>
- * Note that while sometimes it would be easier to record what kind of syntax was used on parsing (e.g. ATX vs Setext
- * heading), this renderer is intended to also work for documents that were created by directly creating
- * {@link Node Nodes} instead. So in order to support that, it sometimes needs to do a bit more work.
+ *
+ * <p>Note that while sometimes it would be easier to record what kind of syntax was used on parsing
+ * (e.g. ATX vs Setext heading), this renderer is intended to also work for documents that were
+ * created by directly creating {@link Node Nodes} instead. So in order to support that, it
+ * sometimes needs to do a bit more work.
  */
 public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRenderer {
 
@@ -33,9 +33,10 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     protected final MarkdownNodeRendererContext context;
     private final MarkdownWriter writer;
+
     /**
-     * If we're currently within a {@link BulletList} or {@link OrderedList}, this keeps the context of that list.
-     * It has a parent field so that it can represent a stack (for nested lists).
+     * If we're currently within a {@link BulletList} or {@link OrderedList}, this keeps the context
+     * of that list. It has a parent field so that it can represent a stack (for nested lists).
      */
     private ListHolder listHolder;
 
@@ -43,7 +44,11 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
         this.context = context;
         this.writer = context.getWriter();
 
-        textEscape = AsciiMatcher.builder().anyOf("[]<>`*_&\n\\").anyOf(context.getSpecialCharacters()).build();
+        textEscape =
+                AsciiMatcher.builder()
+                        .anyOf("[]<>`*_&\n\\")
+                        .anyOf(context.getSpecialCharacters())
+                        .build();
         textEscapeInHeading = AsciiMatcher.builder(textEscape).anyOf("#").build();
     }
 
@@ -69,8 +74,7 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
                 SoftLineBreak.class,
                 StrongEmphasis.class,
                 Text.class,
-                ThematicBreak.class
-        );
+                ThematicBreak.class);
     }
 
     @Override
@@ -108,8 +112,8 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
                 visitChildren(heading);
                 writer.line();
                 if (heading.getLevel() == 1) {
-                    // Note that it would be nice to match the length of the contents instead of just using 3, but that's
-                    // not easy.
+                    // Note that it would be nice to match the length of the contents instead of
+                    // just using 3, but that's not easy.
                     writer.raw("===");
                 } else {
                     writer.raw("---");
@@ -132,8 +136,8 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
     @Override
     public void visit(IndentedCodeBlock indentedCodeBlock) {
         String literal = indentedCodeBlock.getLiteral();
-        // We need to respect line prefixes which is why we need to write it line by line (e.g. an indented code block
-        // within a block quote)
+        // We need to respect line prefixes which is why we need to write it line by line (e.g. an
+        // indented code block within a block quote)
         writer.writePrefix("    ");
         writer.pushPrefix("    ");
         List<String> lines = getLines(literal);
@@ -151,19 +155,24 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
     @Override
     public void visit(FencedCodeBlock codeBlock) {
         String literal = codeBlock.getLiteral();
-        String fenceChar = codeBlock.getFenceCharacter() != null ? codeBlock.getFenceCharacter() : "`";
+        String fenceChar =
+                codeBlock.getFenceCharacter() != null ? codeBlock.getFenceCharacter() : "`";
         int openingFenceLength;
         if (codeBlock.getOpeningFenceLength() != null) {
             // If we have a known fence length, use it
             openingFenceLength = codeBlock.getOpeningFenceLength();
         } else {
-            // Otherwise, calculate the closing fence length pessimistically, e.g. if the code block itself contains a
-            // line with ```, we need to use a fence of length 4. If ``` occurs with non-whitespace characters on a
+            // Otherwise, calculate the closing fence length pessimistically, e.g. if the code block
+            // itself contains a line with ```, we need to use a fence of length 4. If ``` occurs
+            // with non-whitespace characters on a
             // line, we technically don't need a longer fence, but it's not incorrect to do so.
             int fenceCharsInLiteral = findMaxRunLength(fenceChar, literal);
             openingFenceLength = Math.max(fenceCharsInLiteral + 1, 3);
         }
-        int closingFenceLength = codeBlock.getClosingFenceLength() != null ? codeBlock.getClosingFenceLength() : openingFenceLength;
+        int closingFenceLength =
+                codeBlock.getClosingFenceLength() != null
+                        ? codeBlock.getClosingFenceLength()
+                        : openingFenceLength;
 
         String openingFence = repeat(fenceChar, openingFenceLength);
         String closingFence = repeat(fenceChar, closingFenceLength);
@@ -251,13 +260,19 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             marker = repeat(" ", markerIndent) + bulletListHolder.marker;
         } else if (listHolder instanceof OrderedListHolder) {
             OrderedListHolder orderedListHolder = (OrderedListHolder) listHolder;
-            marker = repeat(" ", markerIndent) + orderedListHolder.number + orderedListHolder.delimiter;
+            marker =
+                    repeat(" ", markerIndent)
+                            + orderedListHolder.number
+                            + orderedListHolder.delimiter;
             orderedListHolder.number++;
         } else {
             throw new IllegalStateException("Unknown list holder type: " + listHolder);
         }
         Integer contentIndent = listItem.getContentIndent();
-        String spaces = contentIndent != null ? repeat(" ", Math.max(contentIndent - marker.length(), 1)) : " ";
+        String spaces =
+                contentIndent != null
+                        ? repeat(" ", Math.max(contentIndent - marker.length(), 1))
+                        : " ";
         writer.writePrefix(marker);
         writer.writePrefix(spaces);
         writer.pushPrefix(repeat(" ", marker.length() + spaces.length()));
@@ -281,10 +296,14 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
             writer.raw('`');
         }
         // If the literal starts or ends with a backtick, surround it with a single space.
-        // If it starts and ends with a space (but is not only spaces), add an additional space (otherwise they would
-        // get removed on parsing).
-        boolean addSpace = literal.startsWith("`") || literal.endsWith("`") ||
-                (literal.startsWith(" ") && literal.endsWith(" ") && Characters.hasNonSpace(literal));
+        // If it starts and ends with a space (but is not only spaces), add an additional space
+        // (otherwise they would get removed on parsing).
+        boolean addSpace =
+                literal.startsWith("`")
+                        || literal.endsWith("`")
+                        || (literal.startsWith(" ")
+                                && literal.endsWith(" ")
+                                && Characters.hasNonSpace(literal));
         if (addSpace) {
             writer.raw(' ');
         }
@@ -345,38 +364,47 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
     @Override
     public void visit(Text text) {
-        // Text is tricky. In Markdown special characters (`-`, `#` etc.) can be escaped (`\-`, `\#` etc.) so that
-        // they're parsed as plain text. Currently, whether a character was escaped or not is not recorded in the Node,
-        // so here we don't know. If we just wrote out those characters unescaped, the resulting Markdown would change
-        // meaning (turn into a list item, heading, etc.).
-        // You might say "Why not store that in the Node when parsing", but that wouldn't work for the use case where
-        // nodes are constructed directly instead of via parsing. This renderer needs to work for that too.
-        // So currently, when in doubt, we escape. For special characters only occurring at the beginning of a line,
-        // we only escape them then (we wouldn't want to escape every `.` for example).
+        // Text is tricky. In Markdown special characters (`-`, `#` etc.) can be escaped (`\-`, `\#`
+        // etc.) so that they're parsed as plain text. Currently, whether a character was escaped or
+        // not is not recorded in the Node, so here we don't know. If we just wrote out those
+        // characters unescaped, the resulting Markdown would change meaning (turn into a list item,
+        // heading, etc.).
+        //
+        // You might say "Why not store that in the Node when parsing", but that wouldn't work for
+        // the use case where nodes are constructed directly instead of via parsing. This renderer
+        // needs to work for that too.
+        //
+        // So currently, when in doubt, we escape. For special characters only occurring at the
+        // beginning of a line, we only escape them then (we wouldn't want to escape every `.` for
+        // example).
         String literal = text.getLiteral();
         if (writer.isAtLineStart() && !literal.isEmpty()) {
             char c = literal.charAt(0);
             switch (c) {
-                case '-': {
-                    // Would be ambiguous with a bullet list marker, escape
-                    writer.raw("\\-");
-                    literal = literal.substring(1);
-                    break;
-                }
-                case '#': {
-                    // Would be ambiguous with an ATX heading, escape
-                    writer.raw("\\#");
-                    literal = literal.substring(1);
-                    break;
-                }
-                case '=': {
-                    // Would be ambiguous with a Setext heading, escape unless it's the first line in the block
-                    if (text.getPrevious() != null) {
-                        writer.raw("\\=");
+                case '-':
+                    {
+                        // Would be ambiguous with a bullet list marker, escape
+                        writer.raw("\\-");
                         literal = literal.substring(1);
+                        break;
                     }
-                    break;
-                }
+                case '#':
+                    {
+                        // Would be ambiguous with an ATX heading, escape
+                        writer.raw("\\#");
+                        literal = literal.substring(1);
+                        break;
+                    }
+                case '=':
+                    {
+                        // Would be ambiguous with a Setext heading, escape unless it's the first
+                        // line in the block
+                        if (text.getPrevious() != null) {
+                            writer.raw("\\=");
+                            literal = literal.substring(1);
+                        }
+                        break;
+                    }
                 case '0':
                 case '1':
                 case '2':
@@ -386,26 +414,29 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
                 case '6':
                 case '7':
                 case '8':
-                case '9': {
-                    // Check for ordered list marker
-                    Matcher m = orderedListMarkerPattern.matcher(literal);
-                    if (m.find()) {
-                        writer.raw(m.group(1));
-                        writer.raw("\\" + m.group(2));
-                        literal = literal.substring(m.end());
+                case '9':
+                    {
+                        // Check for ordered list marker
+                        Matcher m = orderedListMarkerPattern.matcher(literal);
+                        if (m.find()) {
+                            writer.raw(m.group(1));
+                            writer.raw("\\" + m.group(2));
+                            literal = literal.substring(m.end());
+                        }
+                        break;
                     }
-                    break;
-                }
-                case '\t': {
-                    writer.raw("&#9;");
-                    literal = literal.substring(1);
-                    break;
-                }
-                case ' ': {
-                    writer.raw("&#32;");
-                    literal = literal.substring(1);
-                    break;
-                }
+                case '\t':
+                    {
+                        writer.raw("&#9;");
+                        literal = literal.substring(1);
+                        break;
+                    }
+                case ' ':
+                    {
+                        writer.raw("&#32;");
+                        literal = literal.substring(1);
+                        break;
+                    }
             }
         }
 
@@ -467,13 +498,13 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
     }
 
     private static List<String> getLines(String literal) {
-        // Without -1, split would discard all trailing empty strings, which is not what we want, e.g. it would
-        // return the same result for "abc", "abc\n" and "abc\n\n".
+        // Without -1, split would discard all trailing empty strings, which is not what we want,
+        // e.g. it would return the same result for "abc", "abc\n" and "abc\n\n".
         // With -1, it returns ["abc"], ["abc", ""] and ["abc", "", ""].
         String[] parts = literal.split("\n", -1);
         if (parts[parts.length - 1].isEmpty()) {
-            // But we don't want the last empty string, as "\n" is used as a line terminator (not a separator),
-            // so return without the last element.
+            // But we don't want the last empty string, as "\n" is used as a line terminator (not a
+            // separator), so return without the last element.
             return List.of(parts).subList(0, parts.length - 1);
         } else {
             return List.of(parts);
@@ -524,14 +555,18 @@ public class CoreMarkdownNodeRenderer extends AbstractVisitor implements NodeRen
 
         protected OrderedListHolder(ListHolder parent, OrderedList orderedList) {
             super(parent);
-            delimiter = orderedList.getMarkerDelimiter() != null ? orderedList.getMarkerDelimiter() : ".";
-            number = orderedList.getMarkerStartNumber() != null ? orderedList.getMarkerStartNumber() : 1;
+            delimiter =
+                    orderedList.getMarkerDelimiter() != null
+                            ? orderedList.getMarkerDelimiter()
+                            : ".";
+            number =
+                    orderedList.getMarkerStartNumber() != null
+                            ? orderedList.getMarkerStartNumber()
+                            : 1;
         }
     }
 
-    /**
-     * Visits nodes to check if there are any soft or hard line breaks.
-     */
+    /** Visits nodes to check if there are any soft or hard line breaks. */
     private static class LineBreakVisitor extends AbstractVisitor {
         private boolean lineBreak = false;
 

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererContext.java
@@ -1,8 +1,7 @@
 package org.commonmark.renderer.markdown;
 
-import org.commonmark.node.Node;
-
 import java.util.Set;
+import org.commonmark.node.Node;
 
 /**
  * Context that is passed to custom node renderers, see {@link MarkdownNodeRendererFactory#create}.
@@ -15,16 +14,17 @@ public interface MarkdownNodeRendererContext {
     MarkdownWriter getWriter();
 
     /**
-     * Render the specified node and its children using the configured renderers. This should be used to render child
-     * nodes; be careful not to pass the node that is being rendered, that would result in an endless loop.
+     * Render the specified node and its children using the configured renderers. This should be
+     * used to render child nodes; be careful not to pass the node that is being rendered, that
+     * would result in an endless loop.
      *
      * @param node the node to render
      */
     void render(Node node);
 
     /**
-     * @return additional special characters that need to be escaped if they occur in normal text; currently only ASCII
-     * characters are allowed
+     * @return additional special characters that need to be escaped if they occur in normal text;
+     *     currently only ASCII characters are allowed
      */
     Set<Character> getSpecialCharacters();
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererFactory.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownNodeRendererFactory.java
@@ -1,12 +1,9 @@
 package org.commonmark.renderer.markdown;
 
+import java.util.Set;
 import org.commonmark.renderer.NodeRenderer;
 
-import java.util.Set;
-
-/**
- * Factory for instantiating new node renderers for rendering custom nodes.
- */
+/** Factory for instantiating new node renderers for rendering custom nodes. */
 public interface MarkdownNodeRendererFactory {
 
     /**
@@ -18,8 +15,8 @@ public interface MarkdownNodeRendererFactory {
     NodeRenderer create(MarkdownNodeRendererContext context);
 
     /**
-     * @return the additional special characters that this factory would like to have escaped in normal text; currently
-     * only ASCII characters are allowed
+     * @return the additional special characters that this factory would like to have escaped in
+     *     normal text; currently only ASCII characters are allowed
      */
     Set<Character> getSpecialCharacters();
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownRenderer.java
@@ -1,26 +1,29 @@
 package org.commonmark.renderer.markdown;
 
+import java.util.*;
 import org.commonmark.Extension;
 import org.commonmark.internal.renderer.NodeRendererMap;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.Renderer;
 
-import java.util.*;
-
 /**
  * Renders nodes to Markdown (CommonMark syntax); use {@link #builder()} to create a renderer.
- * <p>
- * Note that it doesn't currently preserve the exact syntax of the original input Markdown (if any):
+ *
+ * <p>Note that it doesn't currently preserve the exact syntax of the original input Markdown (if
+ * any):
+ *
  * <ul>
- *     <li>Headings are output as ATX headings if possible (multi-line headings need Setext headings)</li>
- *     <li>Links are always rendered as inline links (no support for reference links yet)</li>
- *     <li>Escaping might be over-eager, e.g. a plain {@code *} might be escaped
- *     even though it doesn't need to be in that particular context</li>
- *     <li>Leading whitespace in paragraphs is not preserved</li>
+ *   <li>Headings are output as ATX headings if possible (multi-line headings need Setext headings)
+ *   <li>Links are always rendered as inline links (no support for reference links yet)
+ *   <li>Escaping might be over-eager, e.g. a plain {@code *} might be escaped even though it
+ *       doesn't need to be in that particular context
+ *   <li>Leading whitespace in paragraphs is not preserved
  * </ul>
- * However, it should produce Markdown that is semantically equivalent to the input, i.e. if the Markdown was parsed
- * again and compared against the original AST, it should be the same (minus bugs).
+ *
+ * However, it should produce Markdown that is semantically equivalent to the input, i.e. if the
+ * Markdown was parsed again and compared against the original AST, it should be the same (minus
+ * bugs).
  */
 public class MarkdownRenderer implements Renderer {
 
@@ -30,17 +33,18 @@ public class MarkdownRenderer implements Renderer {
         this.nodeRendererFactories = new ArrayList<>(builder.nodeRendererFactories.size() + 1);
         this.nodeRendererFactories.addAll(builder.nodeRendererFactories);
         // Add as last. This means clients can override the rendering of core nodes if they want.
-        this.nodeRendererFactories.add(new MarkdownNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(MarkdownNodeRendererContext context) {
-                return new CoreMarkdownNodeRenderer(context);
-            }
+        this.nodeRendererFactories.add(
+                new MarkdownNodeRendererFactory() {
+                    @Override
+                    public NodeRenderer create(MarkdownNodeRendererContext context) {
+                        return new CoreMarkdownNodeRenderer(context);
+                    }
 
-            @Override
-            public Set<Character> getSpecialCharacters() {
-                return Set.of();
-            }
-        });
+                    @Override
+                    public Set<Character> getSpecialCharacters() {
+                        return Set.of();
+                    }
+                });
     }
 
     /**
@@ -80,11 +84,12 @@ public class MarkdownRenderer implements Renderer {
         }
 
         /**
-         * Add a factory for instantiating a node renderer (done when rendering). This allows to override the rendering
-         * of node types or define rendering for custom node types.
-         * <p>
-         * If multiple node renderers for the same node type are created, the one from the factory that was added first
-         * "wins". (This is how the rendering for core node types can be overridden; the default rendering comes last.)
+         * Add a factory for instantiating a node renderer (done when rendering). This allows to
+         * override the rendering of node types or define rendering for custom node types.
+         *
+         * <p>If multiple node renderers for the same node type are created, the one from the
+         * factory that was added first "wins". (This is how the rendering for core node types can
+         * be overridden; the default rendering comes last.)
          *
          * @param nodeRendererFactory the factory for creating a node renderer
          * @return {@code this}
@@ -101,7 +106,8 @@ public class MarkdownRenderer implements Renderer {
         public Builder extensions(Iterable<? extends Extension> extensions) {
             for (Extension extension : extensions) {
                 if (extension instanceof MarkdownRendererExtension) {
-                    MarkdownRendererExtension markdownRendererExtension = (MarkdownRendererExtension) extension;
+                    MarkdownRendererExtension markdownRendererExtension =
+                            (MarkdownRendererExtension) extension;
                     markdownRendererExtension.extend(this);
                 }
             }
@@ -109,13 +115,12 @@ public class MarkdownRenderer implements Renderer {
         }
     }
 
-    /**
-     * Extension for {@link MarkdownRenderer} for rendering custom nodes.
-     */
+    /** Extension for {@link MarkdownRenderer} for rendering custom nodes. */
     public interface MarkdownRendererExtension extends Extension {
 
         /**
-         * Extend Markdown rendering, usually by registering custom node renderers using {@link Builder#nodeRendererFactory}.
+         * Extend Markdown rendering, usually by registering custom node renderers using {@link
+         * Builder#nodeRendererFactory}.
          *
          * @param rendererBuilder the renderer builder to extend
          */

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/MarkdownWriter.java
@@ -1,13 +1,10 @@
 package org.commonmark.renderer.markdown;
 
-import org.commonmark.text.CharMatcher;
-
 import java.io.IOException;
 import java.util.LinkedList;
+import org.commonmark.text.CharMatcher;
 
-/**
- * Writer for Markdown (CommonMark) text.
- */
+/** Writer for Markdown (CommonMark) text. */
 public class MarkdownWriter {
 
     private final Appendable buffer;
@@ -16,8 +13,9 @@ public class MarkdownWriter {
     private char lastChar;
     private boolean atLineStart = true;
 
-    // Stacks of settings that affect various rendering behaviors. The common pattern here is that callers use "push" to
-    // change a setting, render some nodes, and then "pop" the setting off the stack again to restore previous state.
+    // Stacks of settings that affect various rendering behaviors. The common pattern here is that
+    // callers use "push" to change a setting, render some nodes, and then "pop" the setting off the
+    // stack again to restore previous state.
     private final LinkedList<String> prefixes = new LinkedList<>();
     private final LinkedList<Boolean> tight = new LinkedList<>();
     private final LinkedList<CharMatcher> rawEscapes = new LinkedList<>();
@@ -26,17 +24,13 @@ public class MarkdownWriter {
         buffer = out;
     }
 
-    /**
-     * Write the supplied string (raw/unescaped except if {@link #pushRawEscape} was used).
-     */
+    /** Write the supplied string (raw/unescaped except if {@link #pushRawEscape} was used). */
     public void raw(String s) {
         flushBlockSeparator();
         write(s, null);
     }
 
-    /**
-     * Write the supplied character (raw/unescaped except if {@link #pushRawEscape} was used).
-     */
+    /** Write the supplied character (raw/unescaped except if {@link #pushRawEscape} was used). */
     public void raw(char c) {
         flushBlockSeparator();
         write(c);
@@ -45,7 +39,7 @@ public class MarkdownWriter {
     /**
      * Write the supplied string with escaping.
      *
-     * @param s      the string to write
+     * @param s the string to write
      * @param escape which characters to escape
      */
     public void text(String s, CharMatcher escape) {
@@ -59,9 +53,7 @@ public class MarkdownWriter {
         atLineStart = false;
     }
 
-    /**
-     * Write a newline (line terminator).
-     */
+    /** Write a newline (line terminator). */
     public void line() {
         write('\n');
         writePrefixes();
@@ -69,19 +61,20 @@ public class MarkdownWriter {
     }
 
     /**
-     * Enqueue a block separator to be written before the next text is written. Block separators are not written
-     * straight away because if there are no more blocks to write we don't want a separator (at the end of the document).
+     * Enqueue a block separator to be written before the next text is written. Block separators are
+     * not written straight away because if there are no more blocks to write we don't want a
+     * separator (at the end of the document).
      */
     public void block() {
-        // Remember whether this should be a tight or loose separator now because tight could get changed in between
-        // this and the next flush.
+        // Remember whether this should be a tight or loose separator now because tight could get
+        // changed in between this and the next flush.
         blockSeparator = isTight() ? 1 : 2;
         atLineStart = true;
     }
 
     /**
-     * Push a prefix onto the top of the stack. All prefixes are written at the beginning of each line, until the
-     * prefix is popped again.
+     * Push a prefix onto the top of the stack. All prefixes are written at the beginning of each
+     * line, until the prefix is popped again.
      *
      * @param prefix the raw prefix string
      */
@@ -100,36 +93,32 @@ public class MarkdownWriter {
         atLineStart = tmp;
     }
 
-    /**
-     * Remove the last prefix from the top of the stack.
-     */
+    /** Remove the last prefix from the top of the stack. */
     public void popPrefix() {
         prefixes.removeLast();
     }
 
     /**
-     * Change whether blocks are tight or loose. Loose is the default where blocks are separated by a blank line. Tight
-     * is where blocks are not separated by a blank line. Tight blocks are used in lists, if there are no blank lines
-     * within the list.
-     * <p>
-     * Note that changing this does not affect block separators that have already been enqueued with {@link #block()},
-     * only future ones.
+     * Change whether blocks are tight or loose. Loose is the default where blocks are separated by
+     * a blank line. Tight is where blocks are not separated by a blank line. Tight blocks are used
+     * in lists, if there are no blank lines within the list.
+     *
+     * <p>Note that changing this does not affect block separators that have already been enqueued
+     * with {@link #block()}, only future ones.
      */
     public void pushTight(boolean tight) {
         this.tight.addLast(tight);
     }
 
-    /**
-     * Remove the last "tight" setting from the top of the stack.
-     */
+    /** Remove the last "tight" setting from the top of the stack. */
     public void popTight() {
         this.tight.removeLast();
     }
 
     /**
-     * Escape the characters matching the supplied matcher, in all text (text and raw). This might be useful to
-     * extensions that add another layer of syntax, e.g. the tables extension that uses `|` to separate cells and needs
-     * all `|` characters to be escaped (even in code spans).
+     * Escape the characters matching the supplied matcher, in all text (text and raw). This might
+     * be useful to extensions that add another layer of syntax, e.g. the tables extension that uses
+     * `|` to separate cells and needs all `|` characters to be escaped (even in code spans).
      *
      * @param rawEscape the characters to escape in raw text
      */
@@ -137,9 +126,7 @@ public class MarkdownWriter {
         rawEscapes.add(rawEscape);
     }
 
-    /**
-     * Remove the last raw escape from the top of the stack.
-     */
+    /** Remove the last raw escape from the top of the stack. */
     public void popRawEscape() {
         rawEscapes.removeLast();
     }
@@ -152,7 +139,8 @@ public class MarkdownWriter {
     }
 
     /**
-     * @return whether we're at the line start (not counting any prefixes), i.e. after a {@link #line} or {@link #block}.
+     * @return whether we're at the line start (not counting any prefixes), i.e. after a {@link
+     *     #line} or {@link #block}.
      */
     public boolean isAtLineStart() {
         return atLineStart;
@@ -199,7 +187,8 @@ public class MarkdownWriter {
     }
 
     /**
-     * If a block separator has been enqueued with {@link #block()} but not yet written, write it now.
+     * If a block separator has been enqueued with {@link #block()} but not yet written, write it
+     * now.
      */
     private void flushBlockSeparator() {
         if (blockSeparator != 0) {

--- a/commonmark/src/main/java/org/commonmark/renderer/markdown/package-info.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/markdown/package-info.java
@@ -1,4 +1,2 @@
-/**
- * Markdown rendering (see {@link org.commonmark.renderer.markdown.MarkdownRenderer})
- */
+/** Markdown rendering (see {@link org.commonmark.renderer.markdown.MarkdownRenderer}) */
 package org.commonmark.renderer.markdown;

--- a/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
@@ -1,9 +1,8 @@
 package org.commonmark.renderer.text;
 
+import java.util.Set;
 import org.commonmark.node.*;
 import org.commonmark.renderer.NodeRenderer;
-
-import java.util.Set;
 
 /**
  * The node renderer that renders all the core nodes (comes last in the order of node renderers).
@@ -42,8 +41,7 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
                 Code.class,
                 HtmlInline.class,
                 SoftLineBreak.class,
-                HardLineBreak.class
-        );
+                HardLineBreak.class);
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/renderer/text/LineBreakRendering.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/LineBreakRendering.java
@@ -1,19 +1,14 @@
 package org.commonmark.renderer.text;
 
-/**
- * Control how line breaks are rendered.
- */
+/** Control how line breaks are rendered. */
 public enum LineBreakRendering {
     /**
-     * Strip all line breaks within blocks and between blocks, resulting in all the text in a single line.
+     * Strip all line breaks within blocks and between blocks, resulting in all the text in a single
+     * line.
      */
     STRIP,
-    /**
-     * Use single line breaks between blocks, not a blank line (also render all lists as tight).
-     */
+    /** Use single line breaks between blocks, not a blank line (also render all lists as tight). */
     COMPACT,
-    /**
-     * Separate blocks by a blank line (and respect tight vs loose lists).
-     */
+    /** Separate blocks by a blank line (and respect tight vs loose lists). */
     SEPARATE_BLOCKS,
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentNodeRendererContext.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentNodeRendererContext.java
@@ -4,14 +4,12 @@ import org.commonmark.node.Node;
 
 public interface TextContentNodeRendererContext {
 
-    /**
-     * Controls how line breaks should be rendered, see {@link LineBreakRendering}.
-     */
+    /** Controls how line breaks should be rendered, see {@link LineBreakRendering}. */
     LineBreakRendering lineBreakRendering();
 
     /**
-     * @return true for stripping new lines and render text as "single line",
-     * false for keeping all line breaks.
+     * @return true for stripping new lines and render text as "single line", false for keeping all
+     *     line breaks.
      * @deprecated Use {@link #lineBreakRendering()} instead
      */
     @Deprecated
@@ -23,8 +21,9 @@ public interface TextContentNodeRendererContext {
     TextContentWriter getWriter();
 
     /**
-     * Render the specified node and its children using the configured renderers. This should be used to render child
-     * nodes; be careful not to pass the node that is being rendered, that would result in an endless loop.
+     * Render the specified node and its children using the configured renderers. This should be
+     * used to render child nodes; be careful not to pass the node that is being rendered, that
+     * would result in an endless loop.
      *
      * @param node the node to render
      */

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentNodeRendererFactory.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentNodeRendererFactory.java
@@ -2,9 +2,7 @@ package org.commonmark.renderer.text;
 
 import org.commonmark.renderer.NodeRenderer;
 
-/**
- * Factory for instantiating new node renderers when rendering is done.
- */
+/** Factory for instantiating new node renderers when rendering is done. */
 public interface TextContentNodeRendererFactory {
 
     /**

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
@@ -1,16 +1,13 @@
 package org.commonmark.renderer.text;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.commonmark.Extension;
 import org.commonmark.internal.renderer.NodeRendererMap;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.Renderer;
 
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- * Renders nodes to plain text content with minimal markup-like additions.
- */
+/** Renders nodes to plain text content with minimal markup-like additions. */
 public class TextContentRenderer implements Renderer {
 
     private final LineBreakRendering lineBreakRendering;
@@ -37,7 +34,8 @@ public class TextContentRenderer implements Renderer {
 
     @Override
     public void render(Node node, Appendable output) {
-        RendererContext context = new RendererContext(new TextContentWriter(output, lineBreakRendering));
+        RendererContext context =
+                new RendererContext(new TextContentWriter(output, lineBreakRendering));
         context.render(node);
     }
 
@@ -64,8 +62,8 @@ public class TextContentRenderer implements Renderer {
         }
 
         /**
-         * Configure how line breaks (newlines) are rendered, see {@link LineBreakRendering}.
-         * The default is {@link LineBreakRendering#COMPACT}.
+         * Configure how line breaks (newlines) are rendered, see {@link LineBreakRendering}. The
+         * default is {@link LineBreakRendering#COMPACT}.
          *
          * @param lineBreakRendering the mode to use
          * @return {@code this}
@@ -78,23 +76,26 @@ public class TextContentRenderer implements Renderer {
         /**
          * Set the value of flag for stripping new lines.
          *
-         * @param stripNewlines true for stripping new lines and render text as "single line",
-         *                      false for keeping all line breaks
+         * @param stripNewlines true for stripping new lines and render text as "single line", false
+         *     for keeping all line breaks
          * @return {@code this}
-         * @deprecated Use {@link #lineBreakRendering(LineBreakRendering)} with {@link LineBreakRendering#STRIP} instead
+         * @deprecated Use {@link #lineBreakRendering(LineBreakRendering)} with {@link
+         *     LineBreakRendering#STRIP} instead
          */
         @Deprecated
         public Builder stripNewlines(boolean stripNewlines) {
-            this.lineBreakRendering = stripNewlines ? LineBreakRendering.STRIP : LineBreakRendering.COMPACT;
+            this.lineBreakRendering =
+                    stripNewlines ? LineBreakRendering.STRIP : LineBreakRendering.COMPACT;
             return this;
         }
 
         /**
-         * Add a factory for instantiating a node renderer (done when rendering). This allows to override the rendering
-         * of node types or define rendering for custom node types.
-         * <p>
-         * If multiple node renderers for the same node type are created, the one from the factory that was added first
-         * "wins". (This is how the rendering for core node types can be overridden; the default rendering comes last.)
+         * Add a factory for instantiating a node renderer (done when rendering). This allows to
+         * override the rendering of node types or define rendering for custom node types.
+         *
+         * <p>If multiple node renderers for the same node type are created, the one from the
+         * factory that was added first "wins". (This is how the rendering for core node types can
+         * be overridden; the default rendering comes last.)
          *
          * @param nodeRendererFactory the factory for creating a node renderer
          * @return {@code this}
@@ -120,9 +121,7 @@ public class TextContentRenderer implements Renderer {
         }
     }
 
-    /**
-     * Extension for {@link TextContentRenderer}.
-     */
+    /** Extension for {@link TextContentRenderer}. */
     public interface TextContentRendererExtension extends Extension {
         void extend(TextContentRenderer.Builder rendererBuilder);
     }

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentWriter.java
@@ -41,8 +41,13 @@ public class TextContentWriter {
     }
 
     public void block() {
-        blockSeparator = lineBreakRendering == LineBreakRendering.STRIP ? " " : //
-                lineBreakRendering == LineBreakRendering.COMPACT || isTight() ? "\n" : "\n\n";
+        blockSeparator =
+                lineBreakRendering == LineBreakRendering.STRIP
+                        ? " "
+                        : //
+                        lineBreakRendering == LineBreakRendering.COMPACT || isTight()
+                                ? "\n"
+                                : "\n\n";
     }
 
     public void resetBlock() {
@@ -64,8 +69,8 @@ public class TextContentWriter {
     }
 
     /**
-     * Push a prefix onto the top of the stack. All prefixes are written at the beginning of each line, until the
-     * prefix is popped again.
+     * Push a prefix onto the top of the stack. All prefixes are written at the beginning of each
+     * line, until the prefix is popped again.
      *
      * @param prefix the raw prefix string
      */
@@ -82,28 +87,24 @@ public class TextContentWriter {
         write(prefix);
     }
 
-    /**
-     * Remove the last prefix from the top of the stack.
-     */
+    /** Remove the last prefix from the top of the stack. */
     public void popPrefix() {
         prefixes.removeLast();
     }
 
     /**
-     * Change whether blocks are tight or loose. Loose is the default where blocks are separated by a blank line. Tight
-     * is where blocks are not separated by a blank line. Tight blocks are used in lists, if there are no blank lines
-     * within the list.
-     * <p>
-     * Note that changing this does not affect block separators that have already been enqueued with {@link #block()},
-     * only future ones.
+     * Change whether blocks are tight or loose. Loose is the default where blocks are separated by
+     * a blank line. Tight is where blocks are not separated by a blank line. Tight blocks are used
+     * in lists, if there are no blank lines within the list.
+     *
+     * <p>Note that changing this does not affect block separators that have already been enqueued
+     * with {@link #block()}, only future ones.
      */
     public void pushTight(boolean tight) {
         this.tight.addLast(tight);
     }
 
-    /**
-     * Remove the last "tight" setting from the top of the stack.
-     */
+    /** Remove the last "tight" setting from the top of the stack. */
     public void popTight() {
         this.tight.removeLast();
     }
@@ -119,7 +120,8 @@ public class TextContentWriter {
     }
 
     /**
-     * If a block separator has been enqueued with {@link #block()} but not yet written, write it now.
+     * If a block separator has been enqueued with {@link #block()} but not yet written, write it
+     * now.
      */
     private void flushBlockSeparator() {
         if (blockSeparator != null) {

--- a/commonmark/src/main/java/org/commonmark/renderer/text/package-info.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/package-info.java
@@ -1,4 +1,5 @@
 /**
- * Plain text rendering with minimal markup (see {@link org.commonmark.renderer.text.TextContentRenderer})
+ * Plain text rendering with minimal markup (see {@link
+ * org.commonmark.renderer.text.TextContentRenderer})
  */
 package org.commonmark.renderer.text;

--- a/commonmark/src/main/java/org/commonmark/text/AsciiMatcher.java
+++ b/commonmark/src/main/java/org/commonmark/text/AsciiMatcher.java
@@ -3,9 +3,7 @@ package org.commonmark.text;
 import java.util.BitSet;
 import java.util.Set;
 
-/**
- * Char matcher that can match ASCII characters efficiently.
- */
+/** Char matcher that can match ASCII characters efficiently. */
 public class AsciiMatcher implements CharMatcher {
     private final BitSet set;
 

--- a/commonmark/src/main/java/org/commonmark/text/CharMatcher.java
+++ b/commonmark/src/main/java/org/commonmark/text/CharMatcher.java
@@ -2,10 +2,10 @@ package org.commonmark.text;
 
 /**
  * Matcher interface for {@code char} values.
- * <p>
- * Note that because this matches on {@code char} values only (as opposed to {@code int} code points),
- * this only operates on the level of code units and doesn't support supplementary characters
- * (see {@link Character#isSupplementaryCodePoint(int)}).
+ *
+ * <p>Note that because this matches on {@code char} values only (as opposed to {@code int} code
+ * points), this only operates on the level of code units and doesn't support supplementary
+ * characters (see {@link Character#isSupplementaryCodePoint(int)}).
  */
 public interface CharMatcher {
 

--- a/commonmark/src/main/java/org/commonmark/text/Characters.java
+++ b/commonmark/src/main/java/org/commonmark/text/Characters.java
@@ -1,8 +1,6 @@
 package org.commonmark.text;
 
-/**
- * Functions for finding characters in strings or checking characters.
- */
+/** Functions for finding characters in strings or checking characters. */
 public class Characters {
 
     public static int find(char c, CharSequence s, int startIndex) {
@@ -57,7 +55,8 @@ public class Characters {
     }
 
     /**
-     * @see <a href="https://spec.commonmark.org/0.31.2/#unicode-punctuation-character">Unicode punctuation character</a>
+     * @see <a href="https://spec.commonmark.org/0.31.2/#unicode-punctuation-character">Unicode
+     *     punctuation character</a>
      */
     public static boolean isPunctuationCodePoint(int codePoint) {
         switch (Character.getType(codePoint)) {
@@ -69,7 +68,7 @@ public class Characters {
             case Character.OTHER_PUNCTUATION:
             case Character.INITIAL_QUOTE_PUNCTUATION:
             case Character.FINAL_QUOTE_PUNCTUATION:
-                // General category "S" (symbol)
+            // General category "S" (symbol)
             case Character.MATH_SYMBOL:
             case Character.CURRENCY_SYMBOL:
             case Character.MODIFIER_SYMBOL:
@@ -94,9 +93,11 @@ public class Characters {
     }
 
     /**
-     * Check whether the provided code point is a Unicode whitespace character as defined in the spec.
+     * Check whether the provided code point is a Unicode whitespace character as defined in the
+     * spec.
      *
-     * @see <a href="https://spec.commonmark.org/0.31.2/#unicode-whitespace-character">Unicode whitespace character</a>
+     * @see <a href="https://spec.commonmark.org/0.31.2/#unicode-whitespace-character">Unicode
+     *     whitespace character</a>
      */
     public static boolean isWhitespaceCodePoint(int codePoint) {
         switch (codePoint) {

--- a/commonmark/src/main/java/org/commonmark/text/package-info.java
+++ b/commonmark/src/main/java/org/commonmark/text/package-info.java
@@ -1,4 +1,2 @@
-/**
- * Text processing utilities for parsing and rendering, exported for use by extensions
- */
+/** Text processing utilities for parsing and rendering, exported for use by extensions */
 package org.commonmark.text;

--- a/commonmark/src/test/java/org/commonmark/ProfilingMain.java
+++ b/commonmark/src/test/java/org/commonmark/ProfilingMain.java
@@ -1,17 +1,17 @@
 package org.commonmark;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.TestResources;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class ProfilingMain {
 
     private static final String SPEC = TestResources.readAsString(TestResources.getSpec());
-    //    private static final List<String> SPEC_EXAMPLES = ExampleReader.readExampleSources(TestResources.getSpec());
+    //    private static final List<String> SPEC_EXAMPLES =
+    // ExampleReader.readExampleSources(TestResources.getSpec());
     private static final Parser PARSER = Parser.builder().build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().build();
 

--- a/commonmark/src/test/java/org/commonmark/internal/DocumentParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/internal/DocumentParserTest.java
@@ -1,31 +1,41 @@
 package org.commonmark.internal;
 
-import org.commonmark.node.*;
-import org.commonmark.parser.block.BlockParserFactory;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.commonmark.node.*;
+import org.commonmark.parser.block.BlockParserFactory;
+import org.junit.jupiter.api.Test;
 
 class DocumentParserTest {
-    private static final List<BlockParserFactory> CORE_FACTORIES = List.of(
-            new BlockQuoteParser.Factory(),
-            new HeadingParser.Factory(),
-            new FencedCodeBlockParser.Factory(),
-            new HtmlBlockParser.Factory(),
-            new ThematicBreakParser.Factory(),
-            new ListBlockParser.Factory(),
-            new IndentedCodeBlockParser.Factory());
+    private static final List<BlockParserFactory> CORE_FACTORIES =
+            List.of(
+                    new BlockQuoteParser.Factory(),
+                    new HeadingParser.Factory(),
+                    new FencedCodeBlockParser.Factory(),
+                    new HtmlBlockParser.Factory(),
+                    new ThematicBreakParser.Factory(),
+                    new ListBlockParser.Factory(),
+                    new IndentedCodeBlockParser.Factory());
 
     @Test
     void calculateBlockParserFactories_givenAFullListOfAllowedNodes_includesAllCoreFactories() {
         List<BlockParserFactory> customParserFactories = List.of();
-        var enabledBlockTypes = Set.of(BlockQuote.class, Heading.class, FencedCodeBlock.class, HtmlBlock.class, ThematicBreak.class, ListBlock.class, IndentedCodeBlock.class);
+        var enabledBlockTypes =
+                Set.of(
+                        BlockQuote.class,
+                        Heading.class,
+                        FencedCodeBlock.class,
+                        HtmlBlock.class,
+                        ThematicBreak.class,
+                        ListBlock.class,
+                        IndentedCodeBlock.class);
 
-        List<BlockParserFactory> blockParserFactories = DocumentParser.calculateBlockParserFactories(customParserFactories, enabledBlockTypes);
+        List<BlockParserFactory> blockParserFactories =
+                DocumentParser.calculateBlockParserFactories(
+                        customParserFactories, enabledBlockTypes);
         assertThat(blockParserFactories).hasSameSizeAs(CORE_FACTORIES);
 
         for (BlockParserFactory factory : CORE_FACTORIES) {
@@ -39,13 +49,17 @@ class DocumentParserTest {
         Set<Class<? extends Block>> nodes = new HashSet<>();
         nodes.add(IndentedCodeBlock.class);
 
-        List<BlockParserFactory> blockParserFactories = DocumentParser.calculateBlockParserFactories(customParserFactories, nodes);
+        List<BlockParserFactory> blockParserFactories =
+                DocumentParser.calculateBlockParserFactories(customParserFactories, nodes);
 
         assertThat(blockParserFactories).hasSize(1);
-        assertThat(hasInstance(blockParserFactories, IndentedCodeBlockParser.Factory.class)).isTrue();
+        assertThat(hasInstance(blockParserFactories, IndentedCodeBlockParser.Factory.class))
+                .isTrue();
     }
 
-    private boolean hasInstance(List<BlockParserFactory> blockParserFactories, Class<? extends BlockParserFactory> factoryClass) {
+    private boolean hasInstance(
+            List<BlockParserFactory> blockParserFactories,
+            Class<? extends BlockParserFactory> factoryClass) {
         for (BlockParserFactory factory : blockParserFactories) {
             if (factory.getClass().equals(factoryClass)) {
                 return true;
@@ -53,5 +67,4 @@ class DocumentParserTest {
         }
         return false;
     }
-
 }

--- a/commonmark/src/test/java/org/commonmark/internal/LinkReferenceDefinitionParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/internal/LinkReferenceDefinitionParserTest.java
@@ -1,11 +1,11 @@
 package org.commonmark.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.commonmark.internal.LinkReferenceDefinitionParser.State;
 import org.commonmark.node.LinkReferenceDefinition;
 import org.commonmark.parser.SourceLine;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class LinkReferenceDefinitionParserTest {
 
@@ -149,8 +149,8 @@ class LinkReferenceDefinitionParserTest {
     void testTitleMultiline3() {
         parse("[foo]: /url");
         assertThat(parser.getState()).isEqualTo(State.START_TITLE);
-        // Note that this looks like a valid title until we parse "bad", at which point we need to treat the whole line
-        // as a paragraph line and discard any already parsed title.
+        // Note that this looks like a valid title until we parse "bad", at which point we need to
+        // treat the whole line as a paragraph line and discard any already parsed title.
         parse("\"title\" bad");
         assertThat(parser.getState()).isEqualTo(State.PARAGRAPH);
 
@@ -192,13 +192,15 @@ class LinkReferenceDefinitionParserTest {
         assertParagraphLines(paragraphContent, parser);
     }
 
-    private static void assertDef(LinkReferenceDefinition def, String label, String destination, String title) {
+    private static void assertDef(
+            LinkReferenceDefinition def, String label, String destination, String title) {
         assertThat(def.getLabel()).isEqualTo(label);
         assertThat(def.getDestination()).isEqualTo(destination);
         assertThat(def.getTitle()).isEqualTo(title);
     }
 
-    private static void assertParagraphLines(String expectedContent, LinkReferenceDefinitionParser parser) {
+    private static void assertParagraphLines(
+            String expectedContent, LinkReferenceDefinitionParser parser) {
         String actual = parser.getParagraphLines().getContent();
         assertThat(actual).isEqualTo(expectedContent);
     }

--- a/commonmark/src/test/java/org/commonmark/internal/util/EscapingTest.java
+++ b/commonmark/src/test/java/org/commonmark/internal/util/EscapingTest.java
@@ -1,8 +1,8 @@
 package org.commonmark.internal.util;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 class EscapingTest {
 

--- a/commonmark/src/test/java/org/commonmark/internal/util/LineReaderTest.java
+++ b/commonmark/src/test/java/org/commonmark/internal/util/LineReaderTest.java
@@ -1,17 +1,16 @@
 package org.commonmark.internal.util;
 
-import org.junit.jupiter.api.Test;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.commonmark.internal.util.LineReader.CHAR_BUFFER_SIZE;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Objects;
-
-import static java.util.stream.Collectors.joining;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.commonmark.internal.util.LineReader.CHAR_BUFFER_SIZE;
+import org.junit.jupiter.api.Test;
 
 class LineReaderTest {
 
@@ -45,12 +44,16 @@ class LineReaderTest {
         assertLines(repeat("a", CHAR_BUFFER_SIZE) + "b", "\r");
 
         assertLines("", "\n", "", "\r", "", "\r\n", "", "\n");
-        assertLines("what", "\r", "are", "\r", "", "\r", "you", "\r\n", "", "\r\n", "even", "\n", "doing", null);
+        assertLines(
+                "what", "\r", "are", "\r", "", "\r", "you", "\r\n", "", "\r\n", "even", "\n",
+                "doing", null);
     }
 
     @Test
     void testClose() throws IOException {
-        var reader = new InputStreamReader(new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)));
+        var reader =
+                new InputStreamReader(
+                        new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)));
         var lineReader = new LineReader(reader);
         lineReader.close();
         lineReader.close();
@@ -58,7 +61,9 @@ class LineReaderTest {
     }
 
     private void assertLines(String... s) throws IOException {
-        assertThat(s.length).as("Expected parts needs to be even (pairs of content and terminator)").isEven();
+        assertThat(s.length)
+                .as("Expected parts needs to be even (pairs of content and terminator)")
+                .isEven();
         var input = Arrays.stream(s).filter(Objects::nonNull).collect(joining(""));
 
         assertLines(new StringReader(input), s);
@@ -86,9 +91,7 @@ class LineReaderTest {
         return sb.toString();
     }
 
-    /**
-     * Reader that only reads 0 or 1 chars at a time to test the corner cases.
-     */
+    /** Reader that only reads 0 or 1 chars at a time to test the corner cases. */
     private static class SlowStringReader extends Reader {
 
         private final String s;
@@ -118,7 +121,6 @@ class LineReaderTest {
         }
 
         @Override
-        public void close() {
-        }
+        public void close() {}
     }
 }

--- a/commonmark/src/test/java/org/commonmark/parser/InlineContentParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/parser/InlineContentParserTest.java
@@ -1,5 +1,8 @@
 package org.commonmark.parser;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
 import org.commonmark.node.*;
 import org.commonmark.parser.beta.InlineContentParser;
 import org.commonmark.parser.beta.InlineContentParserFactory;
@@ -8,15 +11,14 @@ import org.commonmark.parser.beta.ParsedInline;
 import org.commonmark.test.Nodes;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 class InlineContentParserTest {
 
     @Test
     void customInlineContentParser() {
-        var parser = Parser.builder().customInlineContentParserFactory(new DollarInlineParser.Factory()).build();
+        var parser =
+                Parser.builder()
+                        .customInlineContentParserFactory(new DollarInlineParser.Factory())
+                        .build();
         var doc = parser.parse("Test: $hey *there*$ $you$\n\n# Heading $heading$\n");
         var inline1 = Nodes.find(doc, DollarInline.class);
         assertThat(inline1.getLiteral()).isEqualTo("hey *there*");
@@ -28,7 +30,8 @@ class InlineContentParserTest {
         var inline3 = (DollarInline) heading.getLastChild();
         assertThat(inline3.getLiteral()).isEqualTo("heading");
 
-        // Parser is created for each inline snippet, which is why the index resets for the second snippet.
+        // Parser is created for each inline snippet, which is why the index resets for the second
+        // snippet.
         assertThat(inline1.getIndex()).isEqualTo(0);
         assertThat(inline2.getIndex()).isEqualTo(1);
         assertThat(inline3.getIndex()).isEqualTo(0);
@@ -37,8 +40,12 @@ class InlineContentParserTest {
     @Test
     void bangInlineContentParser() {
         // See if using ! for a custom inline content parser works.
-        // ![] is used for images, but if it's not followed by a [, it should be possible to parse it differently.
-        var parser = Parser.builder().customInlineContentParserFactory(new BangInlineParser.Factory()).build();
+        // ![] is used for images, but if it's not followed by a [, it should be possible to parse
+        // it differently.
+        var parser =
+                Parser.builder()
+                        .customInlineContentParserFactory(new BangInlineParser.Factory())
+                        .build();
         var doc = parser.parse("![image](url) !notimage");
         var image = Nodes.find(doc, Image.class);
         assertThat(image.getDestination()).isEqualTo("url");
@@ -98,8 +105,7 @@ class InlineContentParserTest {
         }
     }
 
-    private static class BangInline extends CustomNode {
-    }
+    private static class BangInline extends CustomNode {}
 
     private static class BangInlineParser implements InlineContentParser {
 

--- a/commonmark/src/test/java/org/commonmark/parser/beta/LinkProcessorTest.java
+++ b/commonmark/src/test/java/org/commonmark/parser/beta/LinkProcessorTest.java
@@ -1,21 +1,23 @@
 package org.commonmark.parser.beta;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.commonmark.node.Link;
 import org.commonmark.node.Text;
 import org.commonmark.parser.Parser;
 import org.commonmark.test.Nodes;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 class LinkProcessorTest {
 
     @Test
     void testLinkMarkerShouldNotBeIncludedByDefault() {
-        // If a link marker is registered but is not processed, the built-in link processor shouldn't consume it.
-        // And I think by default, other processors shouldn't consume it either (by accident).
-        // So requiring processors to opt into including the marker is better than requiring them to opt out,
-        // because processors that look for a marker already need to write some code to deal with the marker anyway,
+        // If a link marker is registered but is not processed, the built-in link processor
+        // shouldn't consume it. And I think by default, other processors shouldn't consume it
+        // either (by accident).
+        // So requiring processors to opt into including the marker is better
+        // than requiring them to opt out, because processors that look for a marker already need to
+        // write some code to deal with the marker anyway,
         // and will have tests ensuring that the marker is part of the parsed node, not the text.
         var parser = Parser.builder().linkMarker('^').build();
         var doc = parser.parse("^[test](url)");

--- a/commonmark/src/test/java/org/commonmark/parser/beta/ScannerTest.java
+++ b/commonmark/src/test/java/org/commonmark/parser/beta/ScannerTest.java
@@ -1,21 +1,18 @@
 package org.commonmark.parser.beta;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.SourceLines;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 class ScannerTest {
 
     @Test
     void testNext() {
-        Scanner scanner = new Scanner(List.of(
-                SourceLine.of("foo bar", null)),
-                0, 4);
+        Scanner scanner = new Scanner(List.of(SourceLine.of("foo bar", null)), 0, 4);
         assertThat(scanner.peek()).isEqualTo('b');
         scanner.next();
         assertThat(scanner.peek()).isEqualTo('a');
@@ -27,10 +24,8 @@ class ScannerTest {
 
     @Test
     void testMultipleLines() {
-        Scanner scanner = new Scanner(List.of(
-                SourceLine.of("ab", null),
-                SourceLine.of("cde", null)),
-                0, 0);
+        Scanner scanner =
+                new Scanner(List.of(SourceLine.of("ab", null), SourceLine.of("cde", null)), 0, 0);
         assertThat(scanner.hasNext()).isTrue();
         assertThat(scanner.peekPreviousCodePoint()).isEqualTo('\0');
         assertThat(scanner.peek()).isEqualTo('a');
@@ -84,70 +79,77 @@ class ScannerTest {
 
     @Test
     void testTextBetween() {
-        Scanner scanner = new Scanner(List.of(
-                SourceLine.of("ab", SourceSpan.of(10, 3, 13, 2)),
-                SourceLine.of("cde", SourceSpan.of(11, 4, 20, 3))),
-                0, 0);
+        Scanner scanner =
+                new Scanner(
+                        List.of(
+                                SourceLine.of("ab", SourceSpan.of(10, 3, 13, 2)),
+                                SourceLine.of("cde", SourceSpan.of(11, 4, 20, 3))),
+                        0,
+                        0);
 
         Position start = scanner.position();
 
         scanner.next();
-        assertSourceLines(scanner.getSource(start, scanner.position()),
-                "a",
-                SourceSpan.of(10, 3, 13, 1));
+        assertSourceLines(
+                scanner.getSource(start, scanner.position()), "a", SourceSpan.of(10, 3, 13, 1));
 
         Position afterA = scanner.position();
 
         scanner.next();
-        assertSourceLines(scanner.getSource(start, scanner.position()),
-                "ab",
-                SourceSpan.of(10, 3, 13, 2));
+        assertSourceLines(
+                scanner.getSource(start, scanner.position()), "ab", SourceSpan.of(10, 3, 13, 2));
 
         Position afterB = scanner.position();
 
         scanner.next();
-        assertSourceLines(scanner.getSource(start, scanner.position()),
-                "ab\n",
-                SourceSpan.of(10, 3, 13, 2));
+        assertSourceLines(
+                scanner.getSource(start, scanner.position()), "ab\n", SourceSpan.of(10, 3, 13, 2));
 
         scanner.next();
-        assertSourceLines(scanner.getSource(start, scanner.position()),
+        assertSourceLines(
+                scanner.getSource(start, scanner.position()),
                 "ab\nc",
                 SourceSpan.of(10, 3, 13, 2),
                 SourceSpan.of(11, 4, 20, 1));
 
         scanner.next();
-        assertSourceLines(scanner.getSource(start, scanner.position()),
+        assertSourceLines(
+                scanner.getSource(start, scanner.position()),
                 "ab\ncd",
                 SourceSpan.of(10, 3, 13, 2),
                 SourceSpan.of(11, 4, 20, 2));
 
         scanner.next();
-        assertSourceLines(scanner.getSource(start, scanner.position()),
+        assertSourceLines(
+                scanner.getSource(start, scanner.position()),
                 "ab\ncde",
                 SourceSpan.of(10, 3, 13, 2),
                 SourceSpan.of(11, 4, 20, 3));
 
-        assertSourceLines(scanner.getSource(afterA, scanner.position()),
+        assertSourceLines(
+                scanner.getSource(afterA, scanner.position()),
                 "b\ncde",
                 SourceSpan.of(10, 4, 14, 1),
                 SourceSpan.of(11, 4, 20, 3));
 
-        assertSourceLines(scanner.getSource(afterB, scanner.position()),
+        assertSourceLines(
+                scanner.getSource(afterB, scanner.position()),
                 "\ncde",
                 SourceSpan.of(11, 4, 20, 3));
     }
 
-    private void assertSourceLines(SourceLines sourceLines, String expectedContent, SourceSpan... expectedSourceSpans) {
+    private void assertSourceLines(
+            SourceLines sourceLines, String expectedContent, SourceSpan... expectedSourceSpans) {
         assertThat(sourceLines.getContent()).isEqualTo(expectedContent);
         assertThat(sourceLines.getSourceSpans()).isEqualTo(List.of(expectedSourceSpans));
     }
 
     @Test
     void nextString() {
-        Scanner scanner = Scanner.of(SourceLines.of(List.of(
-                SourceLine.of("hey ya", null),
-                SourceLine.of("hi", null))));
+        Scanner scanner =
+                Scanner.of(
+                        SourceLines.of(
+                                List.of(SourceLine.of("hey ya", null), SourceLine.of("hi", null))));
         assertThat(scanner.next("hoy")).isFalse();
         assertThat(scanner.next("hey")).isTrue();
         assertThat(scanner.next(' ')).isTrue();

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/MarkdownRendererTest.java
@@ -1,14 +1,13 @@
 package org.commonmark.renderer.markdown;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.commonmark.testutil.Asserts.assertRendering;
+
+import java.util.Set;
 import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.NodeRenderer;
 import org.junit.jupiter.api.Test;
-
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.commonmark.testutil.Asserts.assertRendering;
 
 public class MarkdownRendererTest {
 
@@ -120,12 +119,14 @@ public class MarkdownRendererTest {
         // Tight list where the second item contains a loose list
         assertRoundTrip("- Foo\n  - Bar\n  \n  - Baz\n");
 
-        // List item indent. This is a tricky one, but here the amount of space between the list marker and "one"
-        // determines whether "two" is part of the list item or an indented code block.
-        // In this case, it's an indented code block because it's not indented enough to be part of the list item.
-        // If the renderer would just use "- one", then "two" would change from being an indented code block to being
-        // a paragraph in the list item! So it is important for the renderer to preserve the content indent of the list
-        // item.
+        // List item indent. This is a tricky one, but here the amount of space between the list
+        // marker and "one" determines whether "two" is part of the list item or an indented code
+        // block.
+        // In this case, it's an indented code block because it's not indented enough to be part of
+        // the list item.
+        // If the renderer would just use "- one", then "two" would change from being an indented
+        // code block to being a paragraph in the list item! So it is important for the renderer to
+        // preserve the content indent of the list item.
         assertRoundTrip(" -    one\n\n     two\n");
 
         // Empty list
@@ -192,8 +193,8 @@ public class MarkdownRendererTest {
 
     @Test
     public void testEscaping() {
-        // These are a bit tricky. We always escape some characters, even though they only need escaping if they would
-        // otherwise result in a different parse result (e.g. a link):
+        // These are a bit tricky. We always escape some characters, even though they only need
+        // escaping if they would otherwise result in a different parse result (e.g. a link):
         assertRoundTrip("\\[a\\](/uri)\n");
         assertRoundTrip("\\`abc\\`\n");
 
@@ -250,7 +251,8 @@ public class MarkdownRendererTest {
         // Not emphasis (needs * inside words)
         assertRoundTrip("foo\\_bar\\_\n");
 
-        // Even when rendering a manually constructed tree, the emphasis delimiter needs to be chosen correctly.
+        // Even when rendering a manually constructed tree, the emphasis delimiter needs to be
+        // chosen correctly.
         Document doc = new Document();
         Paragraph p = new Paragraph();
         doc.appendChild(p);
@@ -312,29 +314,31 @@ public class MarkdownRendererTest {
 
     @Test
     public void overrideNodeRender() {
-        var nodeRendererFactory = new MarkdownNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(MarkdownNodeRendererContext context) {
-                return new NodeRenderer() {
+        var nodeRendererFactory =
+                new MarkdownNodeRendererFactory() {
                     @Override
-                    public Set<Class<? extends Node>> getNodeTypes() {
-                        return Set.of(Heading.class);
+                    public NodeRenderer create(MarkdownNodeRendererContext context) {
+                        return new NodeRenderer() {
+                            @Override
+                            public Set<Class<? extends Node>> getNodeTypes() {
+                                return Set.of(Heading.class);
+                            }
+
+                            @Override
+                            public void render(Node node) {
+                                context.getWriter().raw("# Custom heading");
+                            }
+                        };
                     }
 
                     @Override
-                    public void render(Node node) {
-                        context.getWriter().raw("# Custom heading");
+                    public Set<Character> getSpecialCharacters() {
+                        return Set.of();
                     }
                 };
-            }
 
-            @Override
-            public Set<Character> getSpecialCharacters() {
-                return Set.of();
-            }
-        };
-
-        MarkdownRenderer renderer = MarkdownRenderer.builder().nodeRendererFactory(nodeRendererFactory).build();
+        MarkdownRenderer renderer =
+                MarkdownRenderer.builder().nodeRendererFactory(nodeRendererFactory).build();
         String rendered = renderer.render(parse("# Hello"));
         assertThat(rendered).isEqualTo("# Custom heading\n");
     }

--- a/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/renderer/markdown/SpecMarkdownRendererTest.java
@@ -1,5 +1,11 @@
 package org.commonmark.renderer.markdown;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -8,27 +14,22 @@ import org.commonmark.testutil.example.Example;
 import org.commonmark.testutil.example.ExampleReader;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * Tests Markdown rendering using the examples in the spec like this:
+ *
  * <ol>
- * <li>Parses the source to an AST and then renders it back to Markdown</li>
- * <li>Parses that to an AST and then renders it to HTML</li>
- * <li>Compares that HTML to the expected HTML of the example:
- * If it's the same, then the expected elements were preserved in the Markdown rendering</li>
+ *   <li>Parses the source to an AST and then renders it back to Markdown
+ *   <li>Parses that to an AST and then renders it to HTML
+ *   <li>Compares that HTML to the expected HTML of the example: If it's the same, then the expected
+ *       elements were preserved in the Markdown rendering
  * </ol>
  */
 public class SpecMarkdownRendererTest {
 
     public static final MarkdownRenderer MARKDOWN_RENDERER = MarkdownRenderer.builder().build();
     // The spec says URL-escaping is optional, but the examples assume that it's enabled.
-    public static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().percentEncodeUrls(true).build();
+    public static final HtmlRenderer HTML_RENDERER =
+            HtmlRenderer.builder().percentEncodeUrls(true).build();
 
     @Test
     public void testCoverage() {

--- a/commonmark/src/test/java/org/commonmark/test/AbstractVisitorTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/AbstractVisitorTest.java
@@ -1,21 +1,22 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.commonmark.node.*;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class AbstractVisitorTest {
 
     @Test
     public void replacingNodeInVisitorShouldNotDestroyVisitOrder() {
-        Visitor visitor = new AbstractVisitor() {
-            @Override
-            public void visit(Text text) {
-                text.insertAfter(new Code(text.getLiteral()));
-                text.unlink();
-            }
-        };
+        Visitor visitor =
+                new AbstractVisitor() {
+                    @Override
+                    public void visit(Text text) {
+                        text.insertAfter(new Code(text.getLiteral()));
+                        text.unlink();
+                    }
+                };
 
         Paragraph paragraph = new Paragraph();
         paragraph.appendChild(new Text("foo"));

--- a/commonmark/src/test/java/org/commonmark/test/BlockParserFactoryTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/BlockParserFactoryTest.java
@@ -1,5 +1,8 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.commonmark.node.*;
 import org.commonmark.parser.IncludeSourceSpans;
 import org.commonmark.parser.InlineParser;
@@ -8,15 +11,12 @@ import org.commonmark.parser.SourceLines;
 import org.commonmark.parser.block.*;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class BlockParserFactoryTest {
 
     @Test
     public void customBlockParserFactory() {
-        var parser = Parser.builder().customBlockParserFactory(new DashBlockParser.Factory()).build();
+        var parser =
+                Parser.builder().customBlockParserFactory(new DashBlockParser.Factory()).build();
 
         // The dashes would normally be a ThematicBreak
         var doc = parser.parse("hey\n\n---\n");
@@ -28,10 +28,11 @@ public class BlockParserFactoryTest {
 
     @Test
     public void replaceActiveBlockParser() {
-        var parser = Parser.builder()
-                .customBlockParserFactory(new StarHeadingBlockParser.Factory())
-                .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
-                .build();
+        var parser =
+                Parser.builder()
+                        .customBlockParserFactory(new StarHeadingBlockParser.Factory())
+                        .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
+                        .build();
 
         var doc = parser.parse("a\nbc\n***\n");
 
@@ -46,16 +47,17 @@ public class BlockParserFactoryTest {
         assertThat(((Text) bc).getLiteral()).isEqualTo("bc");
         assertThat(bc.getNext()).isNull();
 
-        assertThat(heading.getSourceSpans()).isEqualTo(List.of(
-                SourceSpan.of(0, 0, 0, 1),
-                SourceSpan.of(1, 0, 2, 2),
-                SourceSpan.of(2, 0, 5, 3)));
+        assertThat(heading.getSourceSpans())
+                .isEqualTo(
+                        List.of(
+                                SourceSpan.of(0, 0, 0, 1),
+                                SourceSpan.of(1, 0, 2, 2),
+                                SourceSpan.of(2, 0, 5, 3)));
         assertThat(a.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 1)));
         assertThat(bc.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(1, 0, 2, 2)));
     }
 
-    private static class DashBlock extends CustomBlock {
-    }
+    private static class DashBlock extends CustomBlock {}
 
     private static class DashBlockParser extends AbstractBlockParser {
 
@@ -83,8 +85,7 @@ public class BlockParserFactoryTest {
         }
     }
 
-    private static class StarHeading extends CustomBlock {
-    }
+    private static class StarHeading extends CustomBlock {}
 
     private static class StarHeadingBlockParser extends AbstractBlockParser {
 

--- a/commonmark/src/test/java/org/commonmark/test/DelimitedTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/DelimitedTest.java
@@ -1,38 +1,36 @@
 package org.commonmark.test;
 
-import org.commonmark.node.*;
-import org.commonmark.parser.Parser;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.commonmark.node.*;
+import org.commonmark.parser.Parser;
+import org.junit.jupiter.api.Test;
 
 public class DelimitedTest {
 
     @Test
     public void emphasisDelimiters() {
-        String input = "* *emphasis* \n"
-                + "* **strong** \n"
-                + "* _important_ \n"
-                + "* __CRITICAL__ \n";
+        String input =
+                "* *emphasis* \n" + "* **strong** \n" + "* _important_ \n" + "* __CRITICAL__ \n";
 
         Parser parser = Parser.builder().build();
         Node document = parser.parse(input);
 
         final List<Delimited> list = new ArrayList<>();
-        Visitor visitor = new AbstractVisitor() {
-            @Override
-            public void visit(Emphasis node) {
-                list.add(node);
-            }
+        Visitor visitor =
+                new AbstractVisitor() {
+                    @Override
+                    public void visit(Emphasis node) {
+                        list.add(node);
+                    }
 
-            @Override
-            public void visit(StrongEmphasis node) {
-                list.add(node);
-            }
-        };
+                    @Override
+                    public void visit(StrongEmphasis node) {
+                        list.add(node);
+                    }
+                };
         document.accept(visitor);
 
         assertThat(list).hasSize(4);

--- a/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
@@ -1,5 +1,10 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Locale;
+import java.util.Set;
 import org.commonmark.node.CustomNode;
 import org.commonmark.node.Node;
 import org.commonmark.node.Text;
@@ -13,23 +18,20 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
 
-import java.util.Locale;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 public class DelimiterProcessorTest extends RenderingTestCase {
 
-    private static final Parser PARSER = Parser.builder().customDelimiterProcessor(new AsymmetricDelimiterProcessor()).build();
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().nodeRendererFactory(new UpperCaseNodeRendererFactory()).build();
+    private static final Parser PARSER =
+            Parser.builder().customDelimiterProcessor(new AsymmetricDelimiterProcessor()).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().nodeRendererFactory(new UpperCaseNodeRendererFactory()).build();
 
     @Test
     public void delimiterProcessorWithInvalidDelimiterUse() {
-        Parser parser = Parser.builder()
-                .customDelimiterProcessor(new CustomDelimiterProcessor(':', 0))
-                .customDelimiterProcessor(new CustomDelimiterProcessor(';', -1))
-                .build();
+        Parser parser =
+                Parser.builder()
+                        .customDelimiterProcessor(new CustomDelimiterProcessor(':', 0))
+                        .customDelimiterProcessor(new CustomDelimiterProcessor(';', -1))
+                        .build();
         assertThat(RENDERER.render(parser.parse(":test:"))).isEqualTo("<p>:test:</p>\n");
         assertThat(RENDERER.render(parser.parse(";test;"))).isEqualTo("<p>;test;</p>\n");
     }
@@ -51,21 +53,26 @@ public class DelimiterProcessorTest extends RenderingTestCase {
 
     @Test
     public void multipleDelimitersWithDifferentLengths() {
-        Parser parser = Parser.builder()
-                .customDelimiterProcessor(new OneDelimiterProcessor())
-                .customDelimiterProcessor(new TwoDelimiterProcessor())
-                .build();
-        assertThat(RENDERER.render(parser.parse("+one+ ++two++"))).isEqualTo("<p>(1)one(/1) (2)two(/2)</p>\n");
-        assertThat(RENDERER.render(parser.parse("+++both+++"))).isEqualTo("<p>(1)(2)both(/2)(/1)</p>\n");
+        Parser parser =
+                Parser.builder()
+                        .customDelimiterProcessor(new OneDelimiterProcessor())
+                        .customDelimiterProcessor(new TwoDelimiterProcessor())
+                        .build();
+        assertThat(RENDERER.render(parser.parse("+one+ ++two++")))
+                .isEqualTo("<p>(1)one(/1) (2)two(/2)</p>\n");
+        assertThat(RENDERER.render(parser.parse("+++both+++")))
+                .isEqualTo("<p>(1)(2)both(/2)(/1)</p>\n");
     }
 
     @Test
     public void multipleDelimitersWithSameLengthConflict() {
-        assertThatThrownBy(() ->
-                Parser.builder()
-                        .customDelimiterProcessor(new OneDelimiterProcessor())
-                        .customDelimiterProcessor(new OneDelimiterProcessor())
-                        .build()).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(
+                        () ->
+                                Parser.builder()
+                                        .customDelimiterProcessor(new OneDelimiterProcessor())
+                                        .customDelimiterProcessor(new OneDelimiterProcessor())
+                                        .build())
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Override
@@ -139,8 +146,7 @@ public class DelimiterProcessorTest extends RenderingTestCase {
         }
     }
 
-    private static class UpperCaseNode extends CustomNode {
-    }
+    private static class UpperCaseNode extends CustomNode {}
 
     private static class UpperCaseNodeRendererFactory implements HtmlNodeRendererFactory {
 
@@ -166,7 +172,9 @@ public class DelimiterProcessorTest extends RenderingTestCase {
         @Override
         public void render(Node node) {
             UpperCaseNode upperCaseNode = (UpperCaseNode) node;
-            for (Node child = upperCaseNode.getFirstChild(); child != null; child = child.getNext()) {
+            for (Node child = upperCaseNode.getFirstChild();
+                    child != null;
+                    child = child.getNext()) {
                 if (child instanceof Text) {
                     Text text = (Text) child;
                     text.setLiteral(text.getLiteral().toUpperCase(Locale.ENGLISH));

--- a/commonmark/src/test/java/org/commonmark/test/FencedCodeBlockParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/FencedCodeBlockParserTest.java
@@ -1,13 +1,13 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.commonmark.node.FencedCodeBlock;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FencedCodeBlockParserTest extends RenderingTestCase {
 
@@ -24,36 +24,35 @@ public class FencedCodeBlockParserTest extends RenderingTestCase {
 
     @Test
     public void backtickInfoDoesntAllowBacktick() {
-        assertRendering("```info ` test\ncode\n```",
+        assertRendering(
+                "```info ` test\ncode\n```",
                 "<p>```info ` test\ncode</p>\n<pre><code></code></pre>\n");
     }
 
     @Test
     public void backtickAndTildeCantBeMixed() {
-        assertRendering("``~`\ncode\n``~`",
-                "<p><code>~` code </code>~`</p>\n");
+        assertRendering("``~`\ncode\n``~`", "<p><code>~` code </code>~`</p>\n");
     }
 
     @Test
     public void closingCanHaveSpacesAfter() {
-        assertRendering("```\ncode\n```   ",
-                "<pre><code>code\n</code></pre>\n");
+        assertRendering("```\ncode\n```   ", "<pre><code>code\n</code></pre>\n");
     }
 
     @Test
     public void closingCanNotHaveNonSpaces() {
-        assertRendering("```\ncode\n``` a",
-                "<pre><code>code\n``` a\n</code></pre>\n");
+        assertRendering("```\ncode\n``` a", "<pre><code>code\n``` a\n</code></pre>\n");
     }
 
     @Test
     public void issue151() {
-        assertRendering("```\nthis code\n\nshould not have BRs or paragraphs in it\nok\n```",
-                "<pre><code>this code\n" +
-                        "\n" +
-                        "should not have BRs or paragraphs in it\n" +
-                        "ok\n" +
-                        "</code></pre>\n");
+        assertRendering(
+                "```\nthis code\n\nshould not have BRs or paragraphs in it\nok\n```",
+                "<pre><code>this code\n"
+                        + "\n"
+                        + "should not have BRs or paragraphs in it\n"
+                        + "ok\n"
+                        + "</code></pre>\n");
     }
 
     @Override

--- a/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
@@ -1,5 +1,12 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.NodeRenderer;
@@ -7,39 +14,49 @@ import org.commonmark.renderer.html.*;
 import org.commonmark.testutil.TestResources;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class HtmlRendererTest {
 
     @Test
     public void htmlAllowingShouldNotEscapeInlineHtml() {
-        String rendered = htmlAllowingRenderer().render(parse("paragraph with <span id='foo' class=\"bar\">inline &amp; html</span>"));
-        assertThat(rendered).isEqualTo("<p>paragraph with <span id='foo' class=\"bar\">inline &amp; html</span></p>\n");
+        String rendered =
+                htmlAllowingRenderer()
+                        .render(
+                                parse(
+                                        "paragraph with <span id='foo' class=\"bar\">inline &amp; html</span>"));
+        assertThat(rendered)
+                .isEqualTo(
+                        "<p>paragraph with <span id='foo' class=\"bar\">inline &amp; html</span></p>\n");
     }
 
     @Test
     public void htmlAllowingShouldNotEscapeBlockHtml() {
-        String rendered = htmlAllowingRenderer().render(parse("<div id='foo' class=\"bar\">block &amp;</div>"));
+        String rendered =
+                htmlAllowingRenderer()
+                        .render(parse("<div id='foo' class=\"bar\">block &amp;</div>"));
         assertThat(rendered).isEqualTo("<div id='foo' class=\"bar\">block &amp;</div>\n");
     }
 
     @Test
     public void htmlEscapingShouldEscapeInlineHtml() {
-        String rendered = htmlEscapingRenderer().render(parse("paragraph with <span id='foo' class=\"bar\">inline &amp; html</span>"));
+        String rendered =
+                htmlEscapingRenderer()
+                        .render(
+                                parse(
+                                        "paragraph with <span id='foo' class=\"bar\">inline &amp; html</span>"));
         // Note that &amp; is not escaped, as it's a normal text node, not part of the inline HTML.
-        assertThat(rendered).isEqualTo("<p>paragraph with &lt;span id='foo' class=&quot;bar&quot;&gt;inline &amp; html&lt;/span&gt;</p>\n");
+        assertThat(rendered)
+                .isEqualTo(
+                        "<p>paragraph with &lt;span id='foo' class=&quot;bar&quot;&gt;inline &amp; html&lt;/span&gt;</p>\n");
     }
 
     @Test
     public void htmlEscapingShouldEscapeHtmlBlocks() {
-        String rendered = htmlEscapingRenderer().render(parse("<div id='foo' class=\"bar\">block &amp;</div>"));
-        assertThat(rendered).isEqualTo("<p>&lt;div id='foo' class=&quot;bar&quot;&gt;block &amp;amp;&lt;/div&gt;</p>\n");
+        String rendered =
+                htmlEscapingRenderer()
+                        .render(parse("<div id='foo' class=\"bar\">block &amp;</div>"));
+        assertThat(rendered)
+                .isEqualTo(
+                        "<p>&lt;div id='foo' class=&quot;bar&quot;&gt;block &amp;amp;&lt;/div&gt;</p>\n");
     }
 
     @Test
@@ -50,9 +67,12 @@ public class HtmlRendererTest {
 
     @Test
     public void characterReferencesWithoutSemicolonsShouldNotBeParsedShouldBeEscaped() {
-        String input = "[example](&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29)";
+        String input =
+                "[example](&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29)";
         String rendered = defaultRenderer().render(parse(input));
-        assertThat(rendered).isEqualTo("<p><a href=\"&amp;#x6A&amp;#x61&amp;#x76&amp;#x61&amp;#x73&amp;#x63&amp;#x72&amp;#x69&amp;#x70&amp;#x74&amp;#x3A&amp;#x61&amp;#x6C&amp;#x65&amp;#x72&amp;#x74&amp;#x28&amp;#x27&amp;#x58&amp;#x53&amp;#x53&amp;#x27&amp;#x29\">example</a></p>\n");
+        assertThat(rendered)
+                .isEqualTo(
+                        "<p><a href=\"&amp;#x6A&amp;#x61&amp;#x76&amp;#x61&amp;#x73&amp;#x63&amp;#x72&amp;#x69&amp;#x70&amp;#x74&amp;#x3A&amp;#x61&amp;#x6C&amp;#x65&amp;#x72&amp;#x74&amp;#x28&amp;#x27&amp;#x58&amp;#x53&amp;#x53&amp;#x27&amp;#x29\">example</a></p>\n");
     }
 
     @Test
@@ -61,7 +81,8 @@ public class HtmlRendererTest {
         Link link = new Link();
         link.setDestination("&colon;");
         paragraph.appendChild(link);
-        assertThat(defaultRenderer().render(paragraph)).isEqualTo("<p><a href=\"&amp;colon;\"></a></p>\n");
+        assertThat(defaultRenderer().render(paragraph))
+                .isEqualTo("<p><a href=\"&amp;colon;\"></a></p>\n");
     }
 
     @Test
@@ -70,7 +91,8 @@ public class HtmlRendererTest {
         Link link = new Link();
         link.setDestination("javascript:alert(5);");
         paragraph.appendChild(link);
-        assertThat(rawUrlsRenderer().render(paragraph)).isEqualTo("<p><a href=\"javascript:alert(5);\"></a></p>\n");
+        assertThat(rawUrlsRenderer().render(paragraph))
+                .isEqualTo("<p><a href=\"javascript:alert(5);\"></a></p>\n");
     }
 
     @Test
@@ -79,13 +101,15 @@ public class HtmlRendererTest {
         Link link = new Link();
         link.setDestination("/exampleUrl");
         paragraph.appendChild(link);
-        assertThat(sanitizeUrlsRenderer().render(paragraph)).isEqualTo("<p><a rel=\"nofollow\" href=\"/exampleUrl\"></a></p>\n");
+        assertThat(sanitizeUrlsRenderer().render(paragraph))
+                .isEqualTo("<p><a rel=\"nofollow\" href=\"/exampleUrl\"></a></p>\n");
 
         paragraph = new Paragraph();
         link = new Link();
         link.setDestination("https://google.com");
         paragraph.appendChild(link);
-        assertThat(sanitizeUrlsRenderer().render(paragraph)).isEqualTo("<p><a rel=\"nofollow\" href=\"https://google.com\"></a></p>\n");
+        assertThat(sanitizeUrlsRenderer().render(paragraph))
+                .isEqualTo("<p><a rel=\"nofollow\" href=\"https://google.com\"></a></p>\n");
     }
 
     @Test
@@ -94,26 +118,31 @@ public class HtmlRendererTest {
         Link link = new Link();
         link.setDestination("http://google.com");
         paragraph.appendChild(link);
-        assertThat(sanitizeUrlsRenderer().render(paragraph)).isEqualTo("<p><a rel=\"nofollow\" href=\"http://google.com\"></a></p>\n");
+        assertThat(sanitizeUrlsRenderer().render(paragraph))
+                .isEqualTo("<p><a rel=\"nofollow\" href=\"http://google.com\"></a></p>\n");
 
         paragraph = new Paragraph();
         link = new Link();
         link.setDestination("https://google.com");
         paragraph.appendChild(link);
-        assertThat(sanitizeUrlsRenderer().render(paragraph)).isEqualTo("<p><a rel=\"nofollow\" href=\"https://google.com\"></a></p>\n");
+        assertThat(sanitizeUrlsRenderer().render(paragraph))
+                .isEqualTo("<p><a rel=\"nofollow\" href=\"https://google.com\"></a></p>\n");
 
         paragraph = new Paragraph();
         link = new Link();
         link.setDestination("mailto:foo@bar.example.com");
         paragraph.appendChild(link);
-        assertThat(sanitizeUrlsRenderer().render(paragraph)).isEqualTo("<p><a rel=\"nofollow\" href=\"mailto:foo@bar.example.com\"></a></p>\n");
+        assertThat(sanitizeUrlsRenderer().render(paragraph))
+                .isEqualTo("<p><a rel=\"nofollow\" href=\"mailto:foo@bar.example.com\"></a></p>\n");
 
-        String image = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAAQSURBVBhXY/iPBVBf8P9/AG8TY51nJdgkAAAAAElFTkSuQmCC";
+        String image =
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAAQSURBVBhXY/iPBVBf8P9/AG8TY51nJdgkAAAAAElFTkSuQmCC";
         paragraph = new Paragraph();
         link = new Link();
         link.setDestination(image);
         paragraph.appendChild(link);
-        assertThat(sanitizeUrlsRenderer().render(paragraph)).isEqualTo("<p><a rel=\"nofollow\" href=\"" + image + "\"></a></p>\n");
+        assertThat(sanitizeUrlsRenderer().render(paragraph))
+                .isEqualTo("<p><a rel=\"nofollow\" href=\"" + image + "\"></a></p>\n");
     }
 
     @Test
@@ -122,74 +151,103 @@ public class HtmlRendererTest {
         Link link = new Link();
         link.setDestination("javascript:alert(5);");
         paragraph.appendChild(link);
-        assertThat(sanitizeUrlsRenderer().render(paragraph)).isEqualTo("<p><a rel=\"nofollow\" href=\"\"></a></p>\n");
+        assertThat(sanitizeUrlsRenderer().render(paragraph))
+                .isEqualTo("<p><a rel=\"nofollow\" href=\"\"></a></p>\n");
 
         paragraph = new Paragraph();
         link = new Link();
         link.setDestination("ftp://google.com");
         paragraph.appendChild(link);
-        assertThat(sanitizeUrlsRenderer().render(paragraph)).isEqualTo("<p><a rel=\"nofollow\" href=\"\"></a></p>\n");
+        assertThat(sanitizeUrlsRenderer().render(paragraph))
+                .isEqualTo("<p><a rel=\"nofollow\" href=\"\"></a></p>\n");
     }
 
     @Test
     public void percentEncodeUrlDisabled() {
-        assertThat(defaultRenderer().render(parse("[a](foo&amp;bar)"))).isEqualTo("<p><a href=\"foo&amp;bar\">a</a></p>\n");
-        assertThat(defaultRenderer().render(parse("[a](ä)"))).isEqualTo("<p><a href=\"ä\">a</a></p>\n");
-        assertThat(defaultRenderer().render(parse("[a](foo%20bar)"))).isEqualTo("<p><a href=\"foo%20bar\">a</a></p>\n");
+        assertThat(defaultRenderer().render(parse("[a](foo&amp;bar)")))
+                .isEqualTo("<p><a href=\"foo&amp;bar\">a</a></p>\n");
+        assertThat(defaultRenderer().render(parse("[a](ä)")))
+                .isEqualTo("<p><a href=\"ä\">a</a></p>\n");
+        assertThat(defaultRenderer().render(parse("[a](foo%20bar)")))
+                .isEqualTo("<p><a href=\"foo%20bar\">a</a></p>\n");
     }
 
     @Test
     public void percentEncodeUrl() {
         // Entities are escaped anyway
-        assertThat(percentEncodingRenderer().render(parse("[a](foo&amp;bar)"))).isEqualTo("<p><a href=\"foo&amp;bar\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](foo&amp;bar)")))
+                .isEqualTo("<p><a href=\"foo&amp;bar\">a</a></p>\n");
         // Existing encoding is preserved
-        assertThat(percentEncodingRenderer().render(parse("[a](foo%20bar)"))).isEqualTo("<p><a href=\"foo%20bar\">a</a></p>\n");
-        assertThat(percentEncodingRenderer().render(parse("[a](foo%61)"))).isEqualTo("<p><a href=\"foo%61\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](foo%20bar)")))
+                .isEqualTo("<p><a href=\"foo%20bar\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](foo%61)")))
+                .isEqualTo("<p><a href=\"foo%61\">a</a></p>\n");
         // Invalid encoding is escaped
-        assertThat(percentEncodingRenderer().render(parse("[a](foo%)"))).isEqualTo("<p><a href=\"foo%25\">a</a></p>\n");
-        assertThat(percentEncodingRenderer().render(parse("[a](foo%a)"))).isEqualTo("<p><a href=\"foo%25a\">a</a></p>\n");
-        assertThat(percentEncodingRenderer().render(parse("[a](foo%a_)"))).isEqualTo("<p><a href=\"foo%25a_\">a</a></p>\n");
-        assertThat(percentEncodingRenderer().render(parse("[a](foo%xx)"))).isEqualTo("<p><a href=\"foo%25xx\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](foo%)")))
+                .isEqualTo("<p><a href=\"foo%25\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](foo%a)")))
+                .isEqualTo("<p><a href=\"foo%25a\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](foo%a_)")))
+                .isEqualTo("<p><a href=\"foo%25a_\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](foo%xx)")))
+                .isEqualTo("<p><a href=\"foo%25xx\">a</a></p>\n");
         // Reserved characters are preserved, except for '[' and ']'
-        assertThat(percentEncodingRenderer().render(parse("[a](!*'();:@&=+$,/?#[])"))).isEqualTo("<p><a href=\"!*'();:@&amp;=+$,/?#%5B%5D\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](!*'();:@&=+$,/?#[])")))
+                .isEqualTo("<p><a href=\"!*'();:@&amp;=+$,/?#%5B%5D\">a</a></p>\n");
         // Unreserved characters are preserved
-        assertThat(percentEncodingRenderer().render(parse("[a](ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~)"))).isEqualTo("<p><a href=\"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~\">a</a></p>\n");
+        assertThat(
+                        percentEncodingRenderer()
+                                .render(
+                                        parse(
+                                                "[a](ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~)")))
+                .isEqualTo(
+                        "<p><a href=\"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~\">a</a></p>\n");
         // Other characters are percent-encoded (LATIN SMALL LETTER A WITH DIAERESIS)
-        assertThat(percentEncodingRenderer().render(parse("[a](ä)"))).isEqualTo("<p><a href=\"%C3%A4\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](ä)")))
+                .isEqualTo("<p><a href=\"%C3%A4\">a</a></p>\n");
         // Other characters are percent-encoded (MUSICAL SYMBOL G CLEF, surrogate pair in UTF-16)
-        assertThat(percentEncodingRenderer().render(parse("[a](\uD834\uDD1E)"))).isEqualTo("<p><a href=\"%F0%9D%84%9E\">a</a></p>\n");
+        assertThat(percentEncodingRenderer().render(parse("[a](\uD834\uDD1E)")))
+                .isEqualTo("<p><a href=\"%F0%9D%84%9E\">a</a></p>\n");
     }
 
     @Test
     public void attributeProviderForCodeBlock() {
-        AttributeProviderFactory custom = context -> (node, tagName, attributes) -> {
-            if (node instanceof FencedCodeBlock && tagName.equals("code")) {
-                FencedCodeBlock fencedCodeBlock = (FencedCodeBlock) node;
-                // Remove the default attribute for info
-                attributes.remove("class");
-                // Put info in custom attribute instead
-                attributes.put("data-custom", fencedCodeBlock.getInfo());
-            } else if (node instanceof FencedCodeBlock && tagName.equals("pre")) {
-                attributes.put("data-code-block", "fenced");
-            }
-        };
+        AttributeProviderFactory custom =
+                context ->
+                        (node, tagName, attributes) -> {
+                            if (node instanceof FencedCodeBlock && tagName.equals("code")) {
+                                FencedCodeBlock fencedCodeBlock = (FencedCodeBlock) node;
+                                // Remove the default attribute for info
+                                attributes.remove("class");
+                                // Put info in custom attribute instead
+                                attributes.put("data-custom", fencedCodeBlock.getInfo());
+                            } else if (node instanceof FencedCodeBlock && tagName.equals("pre")) {
+                                attributes.put("data-code-block", "fenced");
+                            }
+                        };
 
         HtmlRenderer renderer = HtmlRenderer.builder().attributeProviderFactory(custom).build();
         String rendered = renderer.render(parse("```info\ncontent\n```"));
-        assertThat(rendered).isEqualTo("<pre data-code-block=\"fenced\"><code data-custom=\"info\">content\n</code></pre>\n");
+        assertThat(rendered)
+                .isEqualTo(
+                        "<pre data-code-block=\"fenced\"><code data-custom=\"info\">content\n</code></pre>\n");
 
         String rendered2 = renderer.render(parse("```evil\"\ncontent\n```"));
-        assertThat(rendered2).isEqualTo("<pre data-code-block=\"fenced\"><code data-custom=\"evil&quot;\">content\n</code></pre>\n");
+        assertThat(rendered2)
+                .isEqualTo(
+                        "<pre data-code-block=\"fenced\"><code data-custom=\"evil&quot;\">content\n</code></pre>\n");
     }
 
     @Test
     public void attributeProviderForImage() {
-        AttributeProviderFactory custom = context -> (node, tagName, attributes) -> {
-            if (node instanceof Image) {
-                attributes.remove("alt");
-                attributes.put("test", "hey");
-            }
-        };
+        AttributeProviderFactory custom =
+                context ->
+                        (node, tagName, attributes) -> {
+                            if (node instanceof Image) {
+                                attributes.remove("alt");
+                                attributes.put("test", "hey");
+                            }
+                        };
 
         HtmlRenderer renderer = HtmlRenderer.builder().attributeProviderFactory(custom).build();
         String rendered = renderer.render(parse("![foo](/url)\n"));
@@ -198,15 +256,18 @@ public class HtmlRendererTest {
 
     @Test
     public void attributeProviderFactoryNewInstanceForEachRender() {
-        AttributeProviderFactory factory = context -> new AttributeProvider() {
-            int i = 0;
+        AttributeProviderFactory factory =
+                context ->
+                        new AttributeProvider() {
+                            int i = 0;
 
-            @Override
-            public void setAttributes(Node node, String tagName, Map<String, String> attributes) {
-                attributes.put("key", "" + i);
-                i++;
-            }
-        };
+                            @Override
+                            public void setAttributes(
+                                    Node node, String tagName, Map<String, String> attributes) {
+                                attributes.put("key", "" + i);
+                                i++;
+                            }
+                        };
 
         HtmlRenderer renderer = HtmlRenderer.builder().attributeProviderFactory(factory).build();
         String rendered = renderer.render(parse("text node"));
@@ -216,51 +277,60 @@ public class HtmlRendererTest {
 
     @Test
     public void overrideNodeRender() {
-        HtmlNodeRendererFactory nodeRendererFactory = context -> new NodeRenderer() {
-            @Override
-            public Set<Class<? extends Node>> getNodeTypes() {
-                return Set.of(Link.class);
-            }
+        HtmlNodeRendererFactory nodeRendererFactory =
+                context ->
+                        new NodeRenderer() {
+                            @Override
+                            public Set<Class<? extends Node>> getNodeTypes() {
+                                return Set.of(Link.class);
+                            }
 
-            @Override
-            public void render(Node node) {
-                context.getWriter().text("test");
-            }
-        };
+                            @Override
+                            public void render(Node node) {
+                                context.getWriter().text("test");
+                            }
+                        };
 
-        HtmlRenderer renderer = HtmlRenderer.builder().nodeRendererFactory(nodeRendererFactory).build();
+        HtmlRenderer renderer =
+                HtmlRenderer.builder().nodeRendererFactory(nodeRendererFactory).build();
         String rendered = renderer.render(parse("foo [bar](/url)"));
         assertThat(rendered).isEqualTo("<p>foo test</p>\n");
     }
 
     @Test
     public void orderedListStartZero() {
-        assertThat(defaultRenderer().render(parse("0. Test\n"))).isEqualTo("<ol start=\"0\">\n<li>Test</li>\n</ol>\n");
+        assertThat(defaultRenderer().render(parse("0. Test\n")))
+                .isEqualTo("<ol start=\"0\">\n<li>Test</li>\n</ol>\n");
     }
 
     @Test
     public void imageAltTextWithSoftLineBreak() {
-        assertThat(defaultRenderer().render(parse("![foo\nbar](/url)\n"))).isEqualTo("<p><img src=\"/url\" alt=\"foo\nbar\" /></p>\n");
+        assertThat(defaultRenderer().render(parse("![foo\nbar](/url)\n")))
+                .isEqualTo("<p><img src=\"/url\" alt=\"foo\nbar\" /></p>\n");
     }
 
     @Test
     public void imageAltTextWithHardLineBreak() {
-        assertThat(defaultRenderer().render(parse("![foo  \nbar](/url)\n"))).isEqualTo("<p><img src=\"/url\" alt=\"foo\nbar\" /></p>\n");
+        assertThat(defaultRenderer().render(parse("![foo  \nbar](/url)\n")))
+                .isEqualTo("<p><img src=\"/url\" alt=\"foo\nbar\" /></p>\n");
     }
 
     @Test
     public void imageAltTextWithEntities() {
-        assertThat(defaultRenderer().render(parse("![foo &auml;](/url)\n"))).isEqualTo("<p><img src=\"/url\" alt=\"foo \u00E4\" /></p>\n");
+        assertThat(defaultRenderer().render(parse("![foo &auml;](/url)\n")))
+                .isEqualTo("<p><img src=\"/url\" alt=\"foo \u00E4\" /></p>\n");
     }
 
     @Test
     public void imageAltTextWithInlines() {
-        assertThat(defaultRenderer().render(parse("![_foo_ **bar** [link](/url)](/url)\n"))).isEqualTo("<p><img src=\"/url\" alt=\"foo bar link\" /></p>\n");
+        assertThat(defaultRenderer().render(parse("![_foo_ **bar** [link](/url)](/url)\n")))
+                .isEqualTo("<p><img src=\"/url\" alt=\"foo bar link\" /></p>\n");
     }
 
     @Test
     public void imageAltTextWithCode() {
-        assertThat(defaultRenderer().render(parse("![`foo` bar](/url)\n"))).isEqualTo("<p><img src=\"/url\" alt=\"foo bar\" /></p>\n");
+        assertThat(defaultRenderer().render(parse("![`foo` bar](/url)\n")))
+                .isEqualTo("<p><img src=\"/url\" alt=\"foo bar\" /></p>\n");
     }
 
     @Test
@@ -277,7 +347,8 @@ public class HtmlRendererTest {
             document.appendChild(current);
         }
 
-        assertThat(defaultRenderer().render(document)).isEqualTo("Here I have a test <a href=\"http://www.google.com\">link</a>");
+        assertThat(defaultRenderer().render(document))
+                .isEqualTo("Here I have a test <a href=\"http://www.google.com\">link</a>");
     }
 
     @Test
@@ -318,7 +389,10 @@ public class HtmlRendererTest {
     }
 
     private static HtmlRenderer sanitizeUrlsRenderer() {
-        return HtmlRenderer.builder().sanitizeUrls(true).urlSanitizer(new DefaultUrlSanitizer()).build();
+        return HtmlRenderer.builder()
+                .sanitizeUrls(true)
+                .urlSanitizer(new DefaultUrlSanitizer())
+                .build();
     }
 
     private static HtmlRenderer rawUrlsRenderer() {

--- a/commonmark/src/test/java/org/commonmark/test/InlineParserContextTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/InlineParserContextTest.java
@@ -1,22 +1,21 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import org.commonmark.internal.InlineParserImpl;
-import org.commonmark.parser.beta.LinkProcessor;
-import org.commonmark.parser.beta.InlineContentParserFactory;
 import org.commonmark.node.LinkReferenceDefinition;
 import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.InlineParserContext;
 import org.commonmark.parser.InlineParserFactory;
 import org.commonmark.parser.Parser;
+import org.commonmark.parser.beta.InlineContentParserFactory;
+import org.commonmark.parser.beta.LinkProcessor;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class InlineParserContextTest {
 
@@ -42,38 +41,40 @@ public class InlineParserContextTest {
 
         @Override
         public InlineParser create(final InlineParserContext inlineParserContext) {
-            InlineParserContext wrappedContext = new InlineParserContext() {
-                @Override
-                public List<InlineContentParserFactory> getCustomInlineContentParserFactories() {
-                    return inlineParserContext.getCustomInlineContentParserFactories();
-                }
+            InlineParserContext wrappedContext =
+                    new InlineParserContext() {
+                        @Override
+                        public List<InlineContentParserFactory>
+                                getCustomInlineContentParserFactories() {
+                            return inlineParserContext.getCustomInlineContentParserFactories();
+                        }
 
-                @Override
-                public List<DelimiterProcessor> getCustomDelimiterProcessors() {
-                    return inlineParserContext.getCustomDelimiterProcessors();
-                }
+                        @Override
+                        public List<DelimiterProcessor> getCustomDelimiterProcessors() {
+                            return inlineParserContext.getCustomDelimiterProcessors();
+                        }
 
-                @Override
-                public List<LinkProcessor> getCustomLinkProcessors() {
-                    return inlineParserContext.getCustomLinkProcessors();
-                }
+                        @Override
+                        public List<LinkProcessor> getCustomLinkProcessors() {
+                            return inlineParserContext.getCustomLinkProcessors();
+                        }
 
-                @Override
-                public Set<Character> getCustomLinkMarkers() {
-                    return inlineParserContext.getCustomLinkMarkers();
-                }
+                        @Override
+                        public Set<Character> getCustomLinkMarkers() {
+                            return inlineParserContext.getCustomLinkMarkers();
+                        }
 
-                @Override
-                public LinkReferenceDefinition getLinkReferenceDefinition(String label) {
-                    return getDefinition(LinkReferenceDefinition.class, label);
-                }
+                        @Override
+                        public LinkReferenceDefinition getLinkReferenceDefinition(String label) {
+                            return getDefinition(LinkReferenceDefinition.class, label);
+                        }
 
-                @Override
-                public <D> D getDefinition(Class<D> type, String label) {
-                    lookups.add(label);
-                    return inlineParserContext.getDefinition(type, label);
-                }
-            };
+                        @Override
+                        public <D> D getDefinition(Class<D> type, String label) {
+                            lookups.add(label);
+                            return inlineParserContext.getDefinition(type, label);
+                        }
+                    };
 
             return new InlineParserImpl(wrappedContext);
         }

--- a/commonmark/src/test/java/org/commonmark/test/LinkReferenceDefinitionNodeTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/LinkReferenceDefinitionNodeTest.java
@@ -1,12 +1,11 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class LinkReferenceDefinitionNodeTest {
 
@@ -47,14 +46,16 @@ public class LinkReferenceDefinitionNodeTest {
 
     @Test
     public void testMultipleDefinitionsWithSameLabel() {
-        Node document = parse("This is a paragraph with a [foo] link.\n\n[foo]: /url1\n[foo]: /url2");
+        Node document =
+                parse("This is a paragraph with a [foo] link.\n\n[foo]: /url1\n[foo]: /url2");
         List<Node> nodes = Nodes.getChildren(document);
 
         assertThat(nodes).hasSize(3);
         assertThat(nodes.get(0)).isInstanceOf(Paragraph.class);
         LinkReferenceDefinition def1 = assertDef(nodes.get(1), "foo");
         assertThat(def1.getDestination()).isEqualTo("/url1");
-        // When there's multiple definitions with the same label, the first one "wins", as in reference links will use
+        // When there's multiple definitions with the same label, the first one "wins", as in
+        // reference links will use
         // that. But we still want to preserve the original definitions in the document.
         LinkReferenceDefinition def2 = assertDef(nodes.get(2), "foo");
         assertThat(def2.getDestination()).isEqualTo("/url2");

--- a/commonmark/src/test/java/org/commonmark/test/ListBlockParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ListBlockParserTest.java
@@ -1,11 +1,11 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.commonmark.node.ListItem;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ListBlockParserTest {
 
@@ -56,7 +56,8 @@ public class ListBlockParserTest {
         assertListItemIndents("1.\tfoo", 0, 4);
     }
 
-    private void assertListItemIndents(String input, int expectedMarkerIndent, int expectedContentIndent) {
+    private void assertListItemIndents(
+            String input, int expectedMarkerIndent, int expectedContentIndent) {
         Node doc = PARSER.parse(input);
         ListItem listItem = Nodes.find(doc, ListItem.class);
         assertThat((int) listItem.getMarkerIndent()).isEqualTo(expectedMarkerIndent);

--- a/commonmark/src/test/java/org/commonmark/test/ListTightLooseTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ListTightLooseTest.java
@@ -6,188 +6,150 @@ public class ListTightLooseTest extends CoreRenderingTestCase {
 
     @Test
     public void tight() {
-        assertRendering("- foo\n" +
-                        "- bar\n" +
-                        "+ baz\n",
-                "<ul>\n" +
-                        "<li>foo</li>\n" +
-                        "<li>bar</li>\n" +
-                        "</ul>\n" +
-                        "<ul>\n" +
-                        "<li>baz</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "- foo\n" + "- bar\n" + "+ baz\n",
+                "<ul>\n"
+                        + "<li>foo</li>\n"
+                        + "<li>bar</li>\n"
+                        + "</ul>\n"
+                        + "<ul>\n"
+                        + "<li>baz</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void loose() {
-        assertRendering("- foo\n" +
-                        "\n" +
-                        "- bar\n" +
-                        "\n" +
-                        "\n" +
-                        "- baz\n",
-                "<ul>\n" +
-                        "<li>\n" +
-                        "<p>foo</p>\n" +
-                        "</li>\n" +
-                        "<li>\n" +
-                        "<p>bar</p>\n" +
-                        "</li>\n" +
-                        "<li>\n" +
-                        "<p>baz</p>\n" +
-                        "</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "- foo\n" + "\n" + "- bar\n" + "\n" + "\n" + "- baz\n",
+                "<ul>\n"
+                        + "<li>\n"
+                        + "<p>foo</p>\n"
+                        + "</li>\n"
+                        + "<li>\n"
+                        + "<p>bar</p>\n"
+                        + "</li>\n"
+                        + "<li>\n"
+                        + "<p>baz</p>\n"
+                        + "</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void looseNested() {
-        assertRendering("- foo\n" +
-                        "  - bar\n" +
-                        "\n" +
-                        "\n" +
-                        "    baz",
-                "<ul>\n" +
-                        "<li>foo\n" +
-                        "<ul>\n" +
-                        "<li>\n" +
-                        "<p>bar</p>\n" +
-                        "<p>baz</p>\n" +
-                        "</li>\n" +
-                        "</ul>\n" +
-                        "</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "- foo\n" + "  - bar\n" + "\n" + "\n" + "    baz",
+                "<ul>\n"
+                        + "<li>foo\n"
+                        + "<ul>\n"
+                        + "<li>\n"
+                        + "<p>bar</p>\n"
+                        + "<p>baz</p>\n"
+                        + "</li>\n"
+                        + "</ul>\n"
+                        + "</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void looseNested2() {
-        assertRendering("- a\n" +
-                        "  - b\n" +
-                        "\n" +
-                        "    c\n" +
-                        "- d\n",
-                "<ul>\n" +
-                        "<li>a\n" +
-                        "<ul>\n" +
-                        "<li>\n" +
-                        "<p>b</p>\n" +
-                        "<p>c</p>\n" +
-                        "</li>\n" +
-                        "</ul>\n" +
-                        "</li>\n" +
-                        "<li>d</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "- a\n" + "  - b\n" + "\n" + "    c\n" + "- d\n",
+                "<ul>\n"
+                        + "<li>a\n"
+                        + "<ul>\n"
+                        + "<li>\n"
+                        + "<p>b</p>\n"
+                        + "<p>c</p>\n"
+                        + "</li>\n"
+                        + "</ul>\n"
+                        + "</li>\n"
+                        + "<li>d</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void looseOuter() {
-        assertRendering("- foo\n" +
-                        "  - bar\n" +
-                        "\n" +
-                        "\n" +
-                        "  baz",
-                "<ul>\n" +
-                        "<li>\n" +
-                        "<p>foo</p>\n" +
-                        "<ul>\n" +
-                        "<li>bar</li>\n" +
-                        "</ul>\n" +
-                        "<p>baz</p>\n" +
-                        "</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "- foo\n" + "  - bar\n" + "\n" + "\n" + "  baz",
+                "<ul>\n"
+                        + "<li>\n"
+                        + "<p>foo</p>\n"
+                        + "<ul>\n"
+                        + "<li>bar</li>\n"
+                        + "</ul>\n"
+                        + "<p>baz</p>\n"
+                        + "</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void looseListItem() {
-        assertRendering("- one\n" +
-                        "\n" +
-                        "  two\n",
-                "<ul>\n" +
-                        "<li>\n" +
-                        "<p>one</p>\n" +
-                        "<p>two</p>\n" +
-                        "</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "- one\n" + "\n" + "  two\n",
+                "<ul>\n" + "<li>\n" + "<p>one</p>\n" + "<p>two</p>\n" + "</li>\n" + "</ul>\n");
     }
 
     @Test
     public void tightWithBlankLineAfter() {
-        assertRendering("- foo\n" +
-                        "- bar\n" +
-                        "\n",
-                "<ul>\n" +
-                        "<li>foo</li>\n" +
-                        "<li>bar</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "- foo\n" + "- bar\n" + "\n",
+                "<ul>\n" + "<li>foo</li>\n" + "<li>bar</li>\n" + "</ul>\n");
     }
 
     @Test
     public void tightListWithCodeBlock() {
-        assertRendering("- a\n" +
-                        "- ```\n" +
-                        "  b\n" +
-                        "\n" +
-                        "\n" +
-                        "  ```\n" +
-                        "- c\n",
-                "<ul>\n" +
-                        "<li>a</li>\n" +
-                        "<li>\n" +
-                        "<pre><code>b\n" +
-                        "\n" +
-                        "\n" +
-                        "</code></pre>\n" +
-                        "</li>\n" +
-                        "<li>c</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "- a\n" + "- ```\n" + "  b\n" + "\n" + "\n" + "  ```\n" + "- c\n",
+                "<ul>\n"
+                        + "<li>a</li>\n"
+                        + "<li>\n"
+                        + "<pre><code>b\n"
+                        + "\n"
+                        + "\n"
+                        + "</code></pre>\n"
+                        + "</li>\n"
+                        + "<li>c</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void tightListWithCodeBlock2() {
-        assertRendering("* foo\n" +
-                        "  ```\n" +
-                        "  bar\n" +
-                        "\n" +
-                        "  ```\n" +
-                        "  baz\n",
-                "<ul>\n" +
-                        "<li>foo\n" +
-                        "<pre><code>bar\n" +
-                        "\n" +
-                        "</code></pre>\n" +
-                        "baz</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "* foo\n" + "  ```\n" + "  bar\n" + "\n" + "  ```\n" + "  baz\n",
+                "<ul>\n"
+                        + "<li>foo\n"
+                        + "<pre><code>bar\n"
+                        + "\n"
+                        + "</code></pre>\n"
+                        + "baz</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void looseEmptyListItem() {
-        assertRendering("* a\n" +
-                        "*\n" +
-                        "\n" +
-                        "* c",
-                "<ul>\n" +
-                        "<li>\n" +
-                        "<p>a</p>\n" +
-                        "</li>\n" +
-                        "<li></li>\n" +
-                        "<li>\n" +
-                        "<p>c</p>\n" +
-                        "</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "* a\n" + "*\n" + "\n" + "* c",
+                "<ul>\n"
+                        + "<li>\n"
+                        + "<p>a</p>\n"
+                        + "</li>\n"
+                        + "<li></li>\n"
+                        + "<li>\n"
+                        + "<p>c</p>\n"
+                        + "</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void looseBlankLineAfterCodeBlock() {
-        assertRendering("1. ```\n" +
-                        "   foo\n" +
-                        "   ```\n" +
-                        "\n" +
-                        "   bar",
-                "<ol>\n" +
-                        "<li>\n" +
-                        "<pre><code>foo\n" +
-                        "</code></pre>\n" +
-                        "<p>bar</p>\n" +
-                        "</li>\n" +
-                        "</ol>\n");
+        assertRendering(
+                "1. ```\n" + "   foo\n" + "   ```\n" + "\n" + "   bar",
+                "<ol>\n"
+                        + "<li>\n"
+                        + "<pre><code>foo\n"
+                        + "</code></pre>\n"
+                        + "<p>bar</p>\n"
+                        + "</li>\n"
+                        + "</ol>\n");
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/Nodes.java
+++ b/commonmark/src/test/java/org/commonmark/test/Nodes.java
@@ -1,10 +1,9 @@
 package org.commonmark.test;
 
-import org.commonmark.node.Node;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.commonmark.node.Node;
 
 public class Nodes {
 
@@ -19,7 +18,7 @@ public class Nodes {
     /**
      * Recursively try to find a node with the given type within the children of the specified node.
      *
-     * @param parent    The node to get children from (node itself will not be checked)
+     * @param parent The node to get children from (node itself will not be checked)
      * @param nodeClass The type of node to find
      */
     public static <T> T tryFind(Node parent, Class<T> nodeClass) {
@@ -40,11 +39,12 @@ public class Nodes {
     }
 
     /**
-     * Recursively try to find a node with the given type within the children of the specified node. Throw if node
-     * could not be found.
+     * Recursively try to find a node with the given type within the children of the specified node.
+     * Throw if node could not be found.
      */
     public static <T> T find(Node parent, Class<T> nodeClass) {
-        return Objects.requireNonNull(tryFind(parent, nodeClass),
+        return Objects.requireNonNull(
+                tryFind(parent, nodeClass),
                 "Could not find a " + nodeClass.getSimpleName() + " node in " + parent);
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -1,11 +1,7 @@
 package org.commonmark.test;
 
-import org.commonmark.node.*;
-import org.commonmark.parser.*;
-import org.commonmark.renderer.html.HtmlRenderer;
-import org.commonmark.renderer.markdown.MarkdownRenderer;
-import org.commonmark.testutil.TestResources;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,9 +12,12 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.commonmark.node.*;
+import org.commonmark.parser.*;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
+import org.commonmark.testutil.TestResources;
+import org.junit.jupiter.api.Test;
 
 public class ParserTest {
 
@@ -62,8 +61,12 @@ public class ParserTest {
     @Test
     public void enabledBlockTypesThrowsWhenGivenUnknownClass() {
         // BulletList can't be enabled separately at the moment, only all ListBlock types
-        assertThatThrownBy(() ->
-                Parser.builder().enabledBlockTypes(Set.of(Heading.class, BulletList.class)).build()).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(
+                        () ->
+                                Parser.builder()
+                                        .enabledBlockTypes(Set.of(Heading.class, BulletList.class))
+                                        .build())
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -89,14 +92,16 @@ public class ParserTest {
 
     @Test
     public void inlineParser() {
-        final InlineParser fakeInlineParser = (lines, node) -> node.appendChild(new ThematicBreak());
+        final InlineParser fakeInlineParser =
+                (lines, node) -> node.appendChild(new ThematicBreak());
 
         InlineParserFactory fakeInlineParserFactory = inlineParserContext -> fakeInlineParser;
 
         Parser parser = Parser.builder().inlineParserFactory(fakeInlineParserFactory).build();
         String input = "**bold** **bold** ~~strikethrough~~";
 
-        assertThat(parser.parse(input).getFirstChild().getFirstChild()).isInstanceOf(ThematicBreak.class);
+        assertThat(parser.parse(input).getFirstChild().getFirstChild())
+                .isInstanceOf(ThematicBreak.class);
     }
 
     @Test
@@ -123,8 +128,8 @@ public class ParserTest {
 
     @Test
     public void maxOpenBlockParsersMustBeZeroOrGreater() {
-        assertThatThrownBy(() ->
-                Parser.builder().maxOpenBlockParsers(-1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Parser.builder().maxOpenBlockParsers(-1))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -169,11 +174,10 @@ public class ParserTest {
     public void maxOpenBlockParsersAlsoLimitsMixedListAndBlockQuoteNesting() {
         var parser = Parser.builder().maxOpenBlockParsers(5).build();
 
-        var document = parser.parse(String.join("\n",
-                "- level1",
-                "  > level2",
-                "  > > level3",
-                "  > > > level4"));
+        var document =
+                parser.parse(
+                        String.join(
+                                "\n", "- level1", "  > level2", "  > > level3", "  > > > level4"));
 
         var listBlock = document.getFirstChild();
         assertThat(listBlock).isInstanceOf(BulletList.class);

--- a/commonmark/src/test/java/org/commonmark/test/PathologicalTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/PathologicalTest.java
@@ -1,15 +1,12 @@
 package org.commonmark.test;
 
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
 
-import java.util.concurrent.TimeUnit;
-
-/**
- * Pathological input cases (from commonmark.js).
- */
+/** Pathological input cases (from commonmark.js). */
 @Timeout(value = 3, unit = TimeUnit.SECONDS)
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class PathologicalTest extends CoreRenderingTestCase {
@@ -22,50 +19,41 @@ public class PathologicalTest extends CoreRenderingTestCase {
         x = 500;
         assertRendering(
                 "*a **a ".repeat(x) + "b" + " a** a*".repeat(x),
-                "<p>" + "<em>a <strong>a ".repeat(x) + "b" +
-                        " a</strong> a</em>".repeat(x) + "</p>\n");
+                "<p>"
+                        + "<em>a <strong>a ".repeat(x)
+                        + "b"
+                        + " a</strong> a</em>".repeat(x)
+                        + "</p>\n");
     }
 
     @Test
     public void emphasisClosersWithNoOpeners() {
-        assertRendering(
-                "a_ ".repeat(x),
-                "<p>" + "a_ ".repeat(x - 1) + "a_</p>\n");
+        assertRendering("a_ ".repeat(x), "<p>" + "a_ ".repeat(x - 1) + "a_</p>\n");
     }
 
     @Test
     public void emphasisOpenersWithNoClosers() {
-        assertRendering(
-                "_a ".repeat(x),
-                "<p>" + "_a ".repeat(x - 1) + "_a</p>\n");
+        assertRendering("_a ".repeat(x), "<p>" + "_a ".repeat(x - 1) + "_a</p>\n");
     }
 
     @Test
     public void linkClosersWithNoOpeners() {
-        assertRendering(
-                "a] ".repeat(x),
-                "<p>" + "a] ".repeat(x - 1) + "a]</p>\n");
+        assertRendering("a] ".repeat(x), "<p>" + "a] ".repeat(x - 1) + "a]</p>\n");
     }
 
     @Test
     public void linkOpenersWithNoClosers() {
-        assertRendering(
-                "[a ".repeat(x),
-                "<p>" + "[a ".repeat(x - 1) + "[a</p>\n");
+        assertRendering("[a ".repeat(x), "<p>" + "[a ".repeat(x - 1) + "[a</p>\n");
     }
 
     @Test
     public void linkOpenersAndEmphasisClosers() {
-        assertRendering(
-                "[ a_ ".repeat(x),
-                "<p>" + "[ a_ ".repeat(x - 1) + "[ a_</p>\n");
+        assertRendering("[ a_ ".repeat(x), "<p>" + "[ a_ ".repeat(x - 1) + "[ a_</p>\n");
     }
 
     @Test
     public void mismatchedOpenersAndClosers() {
-        assertRendering(
-                "*a_ ".repeat(x),
-                "<p>" + "*a_ ".repeat(x - 1) + "*a_</p>\n");
+        assertRendering("*a_ ".repeat(x), "<p>" + "*a_ ".repeat(x - 1) + "*a_</p>\n");
     }
 
     @Test
@@ -81,28 +69,23 @@ public class PathologicalTest extends CoreRenderingTestCase {
         x = 1000;
         assertRendering(
                 "> ".repeat(x) + "a\n",
-                "<blockquote>\n".repeat(x) + "<p>a</p>\n" +
-                        "</blockquote>\n".repeat(x));
+                "<blockquote>\n".repeat(x) + "<p>a</p>\n" + "</blockquote>\n".repeat(x));
     }
 
     @Test
     public void hugeHorizontalRule() {
-        assertRendering(
-                "*".repeat(10000) + "\n",
-                "<hr />\n");
+        assertRendering("*".repeat(10000) + "\n", "<hr />\n");
     }
 
     @Test
     public void backslashInLink() {
         // See https://github.com/commonmark/commonmark.js/issues/157
-        assertRendering("[" + "\\".repeat(x) + "\n",
-                "<p>" + "[" + "\\".repeat(x / 2) + "</p>\n");
+        assertRendering("[" + "\\".repeat(x) + "\n", "<p>" + "[" + "\\".repeat(x / 2) + "</p>\n");
     }
 
     @Test
     public void unclosedInlineLinks() {
         // See https://github.com/commonmark/commonmark.js/issues/129
-        assertRendering("[](".repeat(x) + "\n",
-                "<p>" + "[](".repeat(x) + "</p>\n");
+        assertRendering("[](".repeat(x) + "\n", "<p>" + "[](".repeat(x) + "</p>\n");
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/RegressionTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/RegressionTest.java
@@ -1,5 +1,9 @@
 package org.commonmark.test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
@@ -11,23 +15,18 @@ import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 @ParameterizedClass
 @MethodSource("data")
 public class RegressionTest extends RenderingTestCase {
 
     private static final Parser PARSER = Parser.builder().build();
     // The spec says URL-escaping is optional, but the examples assume that it's enabled.
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().percentEncodeUrls(true).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().percentEncodeUrls(true).build();
 
     private static final Map<String, String> OVERRIDDEN_EXAMPLES = getOverriddenExamples();
 
-    @Parameter
-    Example example;
+    @Parameter Example example;
 
     static List<Example> data() {
         var data = new ArrayList<Example>();
@@ -54,8 +53,10 @@ public class RegressionTest extends RenderingTestCase {
     private static Map<String, String> getOverriddenExamples() {
         Map<String, String> m = new HashMap<>();
 
-        // The only difference is that we don't change `%28` and `%29` to `(` and `)` (percent encoding is preserved)
-        m.put("[XSS](javascript&amp;colon;alert%28&#039;XSS&#039;%29)\n",
+        // The only difference is that we don't change `%28` and `%29` to `(` and `)` (percent
+        // encoding is preserved)
+        m.put(
+                "[XSS](javascript&amp;colon;alert%28&#039;XSS&#039;%29)\n",
                 "<p><a href=\"javascript&amp;colon;alert%28'XSS'%29\">XSS</a></p>\n");
         // Callers should handle BOMs
         m.put("\uFEFF# Hi\n", "<p>\uFEFF# Hi</p>\n");

--- a/commonmark/src/test/java/org/commonmark/test/SourceLineTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceLineTest.java
@@ -1,11 +1,11 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.SourceLine;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SourceLineTest {
 
@@ -29,16 +29,19 @@ public class SourceLineTest {
     @Test
     public void testSubstringBeginOutOfBounds() {
         var sourceLine = SourceLine.of("abcd", SourceSpan.of(3, 10, 13, 4));
-        assertThatThrownBy(() -> sourceLine.substring(3, 2)).isInstanceOf(StringIndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> sourceLine.substring(3, 2))
+                .isInstanceOf(StringIndexOutOfBoundsException.class);
     }
 
     @Test
     public void testSubstringEndOutOfBounds() {
         var sourceLine = SourceLine.of("abcd", SourceSpan.of(3, 10, 13, 4));
-        assertThatThrownBy(() -> sourceLine.substring(0, 5)).isInstanceOf(StringIndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> sourceLine.substring(0, 5))
+                .isInstanceOf(StringIndexOutOfBoundsException.class);
     }
 
-    private static void assertSourceLine(SourceLine sourceLine, String expectedContent, SourceSpan expectedSourceSpan) {
+    private static void assertSourceLine(
+            SourceLine sourceLine, String expectedContent, SourceSpan expectedSourceSpan) {
         assertThat(sourceLine.getContent()).isEqualTo(expectedContent);
         assertThat(sourceLine.getSourceSpan()).isEqualTo(expectedSourceSpan);
     }

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpanRenderer.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpanRenderer.java
@@ -1,15 +1,12 @@
 package org.commonmark.test;
 
+import java.util.*;
 import org.commonmark.node.AbstractVisitor;
 import org.commonmark.node.Node;
 
-import java.util.*;
-
 public class SourceSpanRenderer {
 
-    /**
-     * Render source spans in the document using source position's line and column index.
-     */
+    /** Render source spans in the document using source position's line and column index. */
     public static String renderWithLineColumn(Node document, String source) {
         SourceSpanMarkersVisitor visitor = new SourceSpanMarkersVisitor();
         document.accept(visitor);
@@ -33,9 +30,7 @@ public class SourceSpanRenderer {
         return sb.toString();
     }
 
-    /**
-     * Render source spans in the document using source position's input index.
-     */
+    /** Render source spans in the document using source position's input index. */
     public static String renderWithInputIndex(Node document, String source) {
         SourceSpanMarkersVisitor visitor = new SourceSpanMarkersVisitor();
         document.accept(visitor);
@@ -49,7 +44,8 @@ public class SourceSpanRenderer {
         return sb.toString();
     }
 
-    private static void appendMarkers(Map<Integer, List<String>> lineMarkers, int columnIndex, StringBuilder sb) {
+    private static void appendMarkers(
+            Map<Integer, List<String>> lineMarkers, int columnIndex, StringBuilder sb) {
         if (lineMarkers != null) {
             List<String> columnMarkers = lineMarkers.get(columnIndex);
             if (columnMarkers != null) {
@@ -93,7 +89,9 @@ public class SourceSpanRenderer {
                     getMarkers(line, col + length).add(0, closer);
 
                     inputIndexMarkers.computeIfAbsent(input, k -> new LinkedList<>()).add(opener);
-                    inputIndexMarkers.computeIfAbsent(input + length, k -> new LinkedList<>()).add(0, closer);
+                    inputIndexMarkers
+                            .computeIfAbsent(input + length, k -> new LinkedList<>())
+                            .add(0, closer);
                 }
                 markerIndex++;
             }

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpanTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpanTest.java
@@ -1,10 +1,10 @@
 package org.commonmark.test;
 
-import org.commonmark.node.SourceSpan;
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.commonmark.node.SourceSpan;
+import org.junit.jupiter.api.Test;
 
 public class SourceSpanTest {
 
@@ -19,7 +19,8 @@ public class SourceSpanTest {
         assertThat(span.subSpan(2)).isEqualTo(SourceSpan.of(1, 4, 5, 3));
         assertThat(span.subSpan(3)).isEqualTo(SourceSpan.of(1, 5, 6, 2));
         assertThat(span.subSpan(4)).isEqualTo(SourceSpan.of(1, 6, 7, 1));
-        // Not sure if empty spans are useful, but it probably makes sense to mirror how substrings work
+        // Not sure if empty spans are useful, but it probably makes sense to mirror how substrings
+        // work
         assertThat(span.subSpan(5)).isEqualTo(SourceSpan.of(1, 7, 8, 0));
         assertThat("abcde".substring(5)).isEqualTo("");
 
@@ -39,30 +40,35 @@ public class SourceSpanTest {
     @Test
     public void testSubSpanBeginIndexNegative() {
         var sourceSpan = SourceSpan.of(1, 2, 3, 5);
-        assertThatThrownBy(() -> sourceSpan.subSpan(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> sourceSpan.subSpan(-1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
     }
 
     @Test
     public void testSubSpanBeginIndexOutOfBounds() {
         var sourceSpan = SourceSpan.of(1, 2, 3, 5);
-        assertThatThrownBy(() -> sourceSpan.subSpan(6)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> sourceSpan.subSpan(6))
+                .isInstanceOf(IndexOutOfBoundsException.class);
     }
 
     @Test
     public void testSubSpanEndIndexNegative() {
         var sourceSpan = SourceSpan.of(1, 2, 3, 5);
-        assertThatThrownBy(() -> sourceSpan.subSpan(0, -1)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> sourceSpan.subSpan(0, -1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
     }
 
     @Test
     public void testSubSpanEndIndexOutOfBounds() {
         var sourceSpan = SourceSpan.of(1, 2, 3, 5);
-        assertThatThrownBy(() -> sourceSpan.subSpan(0, 6)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> sourceSpan.subSpan(0, 6))
+                .isInstanceOf(IndexOutOfBoundsException.class);
     }
 
     @Test
     public void testSubSpanBeginIndexGreaterThanEndIndex() {
         var sourceSpan = SourceSpan.of(1, 2, 3, 5);
-        assertThatThrownBy(() -> sourceSpan.subSpan(2, 1)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> sourceSpan.subSpan(2, 1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
@@ -1,31 +1,52 @@
 package org.commonmark.test;
 
-import org.commonmark.node.*;
-import org.commonmark.parser.IncludeSourceSpans;
-import org.commonmark.parser.Parser;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.commonmark.node.*;
+import org.commonmark.parser.IncludeSourceSpans;
+import org.commonmark.parser.Parser;
+import org.junit.jupiter.api.Test;
 
 public class SourceSpansTest {
 
-    private static final Parser PARSER = Parser.builder().includeSourceSpans(IncludeSourceSpans.BLOCKS).build();
-    private static final Parser INLINES_PARSER = Parser.builder().includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES).build();
+    private static final Parser PARSER =
+            Parser.builder().includeSourceSpans(IncludeSourceSpans.BLOCKS).build();
+    private static final Parser INLINES_PARSER =
+            Parser.builder().includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES).build();
 
     @Test
     public void paragraph() {
         assertSpans("foo\n", Paragraph.class, SourceSpan.of(0, 0, 0, 3));
-        assertSpans("foo\nbar\n", Paragraph.class, SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3));
-        assertSpans("  foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 5));
-        assertSpans("> foo\n> bar\n", Paragraph.class, SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3));
-        assertSpans("* foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3));
-        assertSpans("* foo\nbar\n", Paragraph.class, SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 0, 6, 3));
+        assertSpans(
+                "foo\nbar\n",
+                Paragraph.class,
+                SourceSpan.of(0, 0, 0, 3),
+                SourceSpan.of(1, 0, 4, 3));
+        assertSpans(
+                "  foo\n  bar\n",
+                Paragraph.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 5));
+        assertSpans(
+                "> foo\n> bar\n",
+                Paragraph.class,
+                SourceSpan.of(0, 2, 2, 3),
+                SourceSpan.of(1, 2, 8, 3));
+        assertSpans(
+                "* foo\n  bar\n",
+                Paragraph.class,
+                SourceSpan.of(0, 2, 2, 3),
+                SourceSpan.of(1, 2, 8, 3));
+        assertSpans(
+                "* foo\nbar\n",
+                Paragraph.class,
+                SourceSpan.of(0, 2, 2, 3),
+                SourceSpan.of(1, 0, 6, 3));
     }
 
     @Test
@@ -45,10 +66,24 @@ public class SourceSpansTest {
 
     @Test
     public void setextHeading() {
-        assertSpans("foo\n===\n", Heading.class, SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3));
-        assertSpans("foo\nbar\n====\n", Heading.class, SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3), SourceSpan.of(2, 0, 8, 4));
-        assertSpans("  foo\n  ===\n", Heading.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 5));
-        assertSpans("> foo\n> ===\n", Heading.class, SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3));
+        assertSpans(
+                "foo\n===\n", Heading.class, SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3));
+        assertSpans(
+                "foo\nbar\n====\n",
+                Heading.class,
+                SourceSpan.of(0, 0, 0, 3),
+                SourceSpan.of(1, 0, 4, 3),
+                SourceSpan.of(2, 0, 8, 4));
+        assertSpans(
+                "  foo\n  ===\n",
+                Heading.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 5));
+        assertSpans(
+                "> foo\n> ===\n",
+                Heading.class,
+                SourceSpan.of(0, 2, 2, 3),
+                SourceSpan.of(1, 2, 8, 3));
     }
 
     @Test
@@ -63,30 +98,77 @@ public class SourceSpansTest {
         assertSpans("    \t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 9));
         assertSpans("\t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 5));
         assertSpans("\t  foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 6));
-        assertSpans("    foo\n     bar\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 8));
-        assertSpans("    foo\n\tbar\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 4));
-        assertSpans("    foo\n    \n     \n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 4), SourceSpan.of(2, 0, 13, 5));
+        assertSpans(
+                "    foo\n     bar\n",
+                IndentedCodeBlock.class,
+                SourceSpan.of(0, 0, 0, 7),
+                SourceSpan.of(1, 0, 8, 8));
+        assertSpans(
+                "    foo\n\tbar\n",
+                IndentedCodeBlock.class,
+                SourceSpan.of(0, 0, 0, 7),
+                SourceSpan.of(1, 0, 8, 4));
+        assertSpans(
+                "    foo\n    \n     \n",
+                IndentedCodeBlock.class,
+                SourceSpan.of(0, 0, 0, 7),
+                SourceSpan.of(1, 0, 8, 4),
+                SourceSpan.of(2, 0, 13, 5));
         assertSpans(">     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 2, 2, 7));
     }
 
     @Test
     public void fencedCodeBlock() {
-        assertSpans("```\nfoo\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3), SourceSpan.of(2, 0, 8, 3));
-        assertSpans("```\n foo\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 4), SourceSpan.of(2, 0, 9, 3));
-        assertSpans("```\nfoo\nbar\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 0, 3), SourceSpan.of(1, 0, 4, 3), SourceSpan.of(2, 0, 8, 3), SourceSpan.of(3, 0, 12, 3));
-        assertSpans("   ```\n   foo\n   ```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 0, 6), SourceSpan.of(1, 0, 7, 6), SourceSpan.of(2, 0, 14, 6));
-        assertSpans(" ```\n foo\nfoo\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 0, 4), SourceSpan.of(1, 0, 5, 4), SourceSpan.of(2, 0, 10, 3), SourceSpan.of(3, 0, 14, 3));
-        assertSpans("```info\nfoo\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 3), SourceSpan.of(2, 0, 12, 3));
-        assertSpans("* ```\n  foo\n  ```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3), SourceSpan.of(2, 2, 14, 3));
-        assertSpans("> ```\n> foo\n> ```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 2, 2, 3), SourceSpan.of(1, 2, 8, 3), SourceSpan.of(2, 2, 14, 3));
+        assertSpans(
+                "```\nfoo\n```\n",
+                FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 0, 3),
+                SourceSpan.of(1, 0, 4, 3),
+                SourceSpan.of(2, 0, 8, 3));
+        assertSpans(
+                "```\n foo\n```\n",
+                FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 0, 3),
+                SourceSpan.of(1, 0, 4, 4),
+                SourceSpan.of(2, 0, 9, 3));
+        assertSpans(
+                "```\nfoo\nbar\n```\n",
+                FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 0, 3),
+                SourceSpan.of(1, 0, 4, 3),
+                SourceSpan.of(2, 0, 8, 3),
+                SourceSpan.of(3, 0, 12, 3));
+        assertSpans(
+                "   ```\n   foo\n   ```\n",
+                FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 0, 6),
+                SourceSpan.of(1, 0, 7, 6),
+                SourceSpan.of(2, 0, 14, 6));
+        assertSpans(
+                " ```\n foo\nfoo\n```\n",
+                FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 0, 4),
+                SourceSpan.of(1, 0, 5, 4),
+                SourceSpan.of(2, 0, 10, 3),
+                SourceSpan.of(3, 0, 14, 3));
+        assertSpans(
+                "```info\nfoo\n```\n",
+                FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 0, 7),
+                SourceSpan.of(1, 0, 8, 3),
+                SourceSpan.of(2, 0, 12, 3));
+        assertSpans(
+                "* ```\n  foo\n  ```\n",
+                FencedCodeBlock.class,
+                SourceSpan.of(0, 2, 2, 3),
+                SourceSpan.of(1, 2, 8, 3),
+                SourceSpan.of(2, 2, 14, 3));
+        assertSpans(
+                "> ```\n> foo\n> ```\n",
+                FencedCodeBlock.class,
+                SourceSpan.of(0, 2, 2, 3),
+                SourceSpan.of(1, 2, 8, 3),
+                SourceSpan.of(2, 2, 14, 3));
 
         Node document = PARSER.parse("```\nfoo\n```\nbar\n");
         Paragraph paragraph = (Paragraph) document.getLastChild();
@@ -96,7 +178,9 @@ public class SourceSpansTest {
     @Test
     public void htmlBlock() {
         assertSpans("<div>\n", HtmlBlock.class, SourceSpan.of(0, 0, 0, 5));
-        assertSpans(" <div>\n foo\n </div>\n", HtmlBlock.class,
+        assertSpans(
+                " <div>\n foo\n </div>\n",
+                HtmlBlock.class,
                 SourceSpan.of(0, 0, 0, 6),
                 SourceSpan.of(1, 0, 7, 4),
                 SourceSpan.of(2, 0, 12, 7));
@@ -109,27 +193,75 @@ public class SourceSpansTest {
         assertSpans("> foo\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 5));
         assertSpans(">  foo\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 6));
         assertSpans(" > foo\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 6));
-        assertSpans("   > foo\n  > bar\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 8), SourceSpan.of(1, 0, 9, 7));
+        assertSpans(
+                "   > foo\n  > bar\n",
+                BlockQuote.class,
+                SourceSpan.of(0, 0, 0, 8),
+                SourceSpan.of(1, 0, 9, 7));
         // Lazy continuations
-        assertSpans("> foo\nbar\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3));
-        assertSpans("> foo\nbar\n> baz\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3), SourceSpan.of(2, 0, 10, 5));
-        assertSpans("> > foo\nbar\n", BlockQuote.class, SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 3));
+        assertSpans(
+                "> foo\nbar\n",
+                BlockQuote.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 3));
+        assertSpans(
+                "> foo\nbar\n> baz\n",
+                BlockQuote.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 3),
+                SourceSpan.of(2, 0, 10, 5));
+        assertSpans(
+                "> > foo\nbar\n",
+                BlockQuote.class,
+                SourceSpan.of(0, 0, 0, 7),
+                SourceSpan.of(1, 0, 8, 3));
     }
 
     @Test
     public void listBlock() {
         assertSpans("* foo\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5));
-        assertSpans("* foo\n  bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 5));
-        assertSpans("* foo\n* bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 5));
-        assertSpans("* foo\n  # bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 7));
-        assertSpans("* foo\n  * bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 7));
+        assertSpans(
+                "* foo\n  bar\n",
+                ListBlock.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 5));
+        assertSpans(
+                "* foo\n* bar\n",
+                ListBlock.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 5));
+        assertSpans(
+                "* foo\n  # bar\n",
+                ListBlock.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 7));
+        assertSpans(
+                "* foo\n  * bar\n",
+                ListBlock.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 7));
         assertSpans("* foo\n> bar\n", ListBlock.class, SourceSpan.of(0, 0, 0, 5));
         assertSpans("> * foo\n", ListBlock.class, SourceSpan.of(0, 2, 2, 5));
 
         // Lazy continuations
-        assertSpans("* foo\nbar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3), SourceSpan.of(2, 0, 10, 3));
-        assertSpans("* foo\nbar\n* baz", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3), SourceSpan.of(2, 0, 10, 5));
-        assertSpans("* foo\n  * bar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 7), SourceSpan.of(2, 0, 14, 3));
+        assertSpans(
+                "* foo\nbar\nbaz",
+                ListBlock.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 3),
+                SourceSpan.of(2, 0, 10, 3));
+        assertSpans(
+                "* foo\nbar\n* baz",
+                ListBlock.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 3),
+                SourceSpan.of(2, 0, 10, 5));
+        assertSpans(
+                "* foo\n  * bar\nbaz",
+                ListBlock.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 7),
+                SourceSpan.of(2, 0, 14, 3));
 
         Node document = PARSER.parse("* foo\n  * bar\n");
         ListBlock listBlock = (ListBlock) document.getFirstChild().getFirstChild().getLastChild();
@@ -142,23 +274,40 @@ public class SourceSpansTest {
         assertSpans(" * foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 6));
         assertSpans("  * foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 7));
         assertSpans("   * foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 8));
-        assertSpans("*\n  foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 1), SourceSpan.of(1, 0, 2, 5));
-        assertSpans("*\n  foo\n  bar\n", ListItem.class, SourceSpan.of(0, 0, 0, 1), SourceSpan.of(1, 0, 2, 5), SourceSpan.of(2, 0, 8, 5));
+        assertSpans(
+                "*\n  foo\n", ListItem.class, SourceSpan.of(0, 0, 0, 1), SourceSpan.of(1, 0, 2, 5));
+        assertSpans(
+                "*\n  foo\n  bar\n",
+                ListItem.class,
+                SourceSpan.of(0, 0, 0, 1),
+                SourceSpan.of(1, 0, 2, 5),
+                SourceSpan.of(2, 0, 8, 5));
         assertSpans("> * foo\n", ListItem.class, SourceSpan.of(0, 2, 2, 5));
 
         // Lazy continuations
-        assertSpans("* foo\nbar\n", ListItem.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3));
-        assertSpans("* foo\nbar\nbaz\n", ListItem.class, SourceSpan.of(0, 0, 0, 5), SourceSpan.of(1, 0, 6, 3), SourceSpan.of(2, 0, 10, 3));
+        assertSpans(
+                "* foo\nbar\n",
+                ListItem.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 3));
+        assertSpans(
+                "* foo\nbar\nbaz\n",
+                ListItem.class,
+                SourceSpan.of(0, 0, 0, 5),
+                SourceSpan.of(1, 0, 6, 3),
+                SourceSpan.of(2, 0, 10, 3));
     }
 
     @Test
     public void linkReferenceDefinition() {
-        // This is tricky due to how link reference definition parsing works. It is stripped from the paragraph if it's
-        // successfully parsed, otherwise it stays part of the paragraph.
+        // This is tricky due to how link reference definition parsing works. It is stripped from
+        // the paragraph if it's successfully parsed, otherwise it stays part of the paragraph.
         Node document = PARSER.parse("[foo]: /url\ntext\n");
 
-        LinkReferenceDefinition linkReferenceDefinition = (LinkReferenceDefinition) document.getFirstChild();
-        assertThat(linkReferenceDefinition.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 11)));
+        LinkReferenceDefinition linkReferenceDefinition =
+                (LinkReferenceDefinition) document.getFirstChild();
+        assertThat(linkReferenceDefinition.getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(0, 0, 0, 11)));
 
         Paragraph paragraph = (Paragraph) document.getLastChild();
         assertThat(paragraph.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(1, 0, 12, 4)));
@@ -193,15 +342,18 @@ public class SourceSpansTest {
 
     @Test
     public void linkReferenceDefinitionHeading() {
-        // This is probably the trickiest because we have a link reference definition at the start of a paragraph
-        // that gets replaced because of a heading. Phew.
+        // This is probably the trickiest because we have a link reference definition at the start
+        // of a paragraph that gets replaced because of a heading. Phew.
         Node document = PARSER.parse("[foo]: /url\nHeading\n===\n");
 
-        LinkReferenceDefinition linkReferenceDefinition = (LinkReferenceDefinition) document.getFirstChild();
-        assertThat(linkReferenceDefinition.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 11)));
+        LinkReferenceDefinition linkReferenceDefinition =
+                (LinkReferenceDefinition) document.getFirstChild();
+        assertThat(linkReferenceDefinition.getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(0, 0, 0, 11)));
 
         Heading heading = (Heading) document.getLastChild();
-        assertThat(heading.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(1, 0, 12, 7), SourceSpan.of(2, 0, 20, 3)));
+        assertThat(heading.getSourceSpans())
+                .isEqualTo(List.of(SourceSpan.of(1, 0, 12, 7), SourceSpan.of(2, 0, 20, 3)));
     }
 
     @Test
@@ -212,13 +364,17 @@ public class SourceSpansTest {
             var doc = PARSER.parse("> > > foo\nbar\n");
 
             var bq1 = (BlockQuote) doc.getLastChild();
-            assertThat(bq1.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 9), SourceSpan.of(1, 0, 10, 3)));
+            assertThat(bq1.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 0, 0, 9), SourceSpan.of(1, 0, 10, 3)));
             var bq2 = (BlockQuote) bq1.getLastChild();
-            assertThat(bq2.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 2, 2, 7), SourceSpan.of(1, 0, 10, 3)));
+            assertThat(bq2.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 2, 2, 7), SourceSpan.of(1, 0, 10, 3)));
             var bq3 = (BlockQuote) bq2.getLastChild();
-            assertThat(bq3.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 4, 4, 5), SourceSpan.of(1, 0, 10, 3)));
+            assertThat(bq3.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 4, 4, 5), SourceSpan.of(1, 0, 10, 3)));
             var paragraph = (Paragraph) bq3.getLastChild();
-            assertThat(paragraph.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 6, 6, 3), SourceSpan.of(1, 0, 10, 3)));
+            assertThat(paragraph.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 6, 6, 3), SourceSpan.of(1, 0, 10, 3)));
         }
 
         {
@@ -226,13 +382,17 @@ public class SourceSpansTest {
             var doc = PARSER.parse("> > > foo\nbars\n");
 
             var bq1 = (BlockQuote) doc.getLastChild();
-            assertThat(bq1.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 9), SourceSpan.of(1, 0, 10, 4)));
+            assertThat(bq1.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 0, 0, 9), SourceSpan.of(1, 0, 10, 4)));
             var bq2 = (BlockQuote) bq1.getLastChild();
-            assertThat(bq2.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 2, 2, 7), SourceSpan.of(1, 0, 10, 4)));
+            assertThat(bq2.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 2, 2, 7), SourceSpan.of(1, 0, 10, 4)));
             var bq3 = (BlockQuote) bq2.getLastChild();
-            assertThat(bq3.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 4, 4, 5), SourceSpan.of(1, 0, 10, 4)));
+            assertThat(bq3.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 4, 4, 5), SourceSpan.of(1, 0, 10, 4)));
             var paragraph = (Paragraph) bq3.getLastChild();
-            assertThat(paragraph.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 6, 6, 3), SourceSpan.of(1, 0, 10, 4)));
+            assertThat(paragraph.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 6, 6, 3), SourceSpan.of(1, 0, 10, 4)));
         }
 
         {
@@ -240,15 +400,20 @@ public class SourceSpansTest {
             var doc = PARSER.parse("> 1. > Blockquote\ncontinued here.");
 
             var bq1 = (BlockQuote) doc.getLastChild();
-            assertThat(bq1.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 17), SourceSpan.of(1, 0, 18, 15)));
+            assertThat(bq1.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 0, 0, 17), SourceSpan.of(1, 0, 18, 15)));
             var orderedList = (OrderedList) bq1.getLastChild();
-            assertThat(orderedList.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 2, 2, 15), SourceSpan.of(1, 0, 18, 15)));
+            assertThat(orderedList.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 2, 2, 15), SourceSpan.of(1, 0, 18, 15)));
             var listItem = (ListItem) orderedList.getLastChild();
-            assertThat(listItem.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 2, 2, 15), SourceSpan.of(1, 0, 18, 15)));
+            assertThat(listItem.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 2, 2, 15), SourceSpan.of(1, 0, 18, 15)));
             var bq2 = (BlockQuote) listItem.getLastChild();
-            assertThat(bq2.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 5, 5, 12), SourceSpan.of(1, 0, 18, 15)));
+            assertThat(bq2.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 5, 5, 12), SourceSpan.of(1, 0, 18, 15)));
             var paragraph = (Paragraph) bq2.getLastChild();
-            assertThat(paragraph.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 7, 7, 10), SourceSpan.of(1, 0, 18, 15)));
+            assertThat(paragraph.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 7, 7, 10), SourceSpan.of(1, 0, 18, 15)));
         }
 
         {
@@ -256,18 +421,25 @@ public class SourceSpansTest {
             var doc = PARSER.parse("> > foo\n> bar\n");
 
             var bq1 = (BlockQuote) doc.getLastChild();
-            assertThat(bq1.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 5)));
+            assertThat(bq1.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 0, 0, 7), SourceSpan.of(1, 0, 8, 5)));
             var bq2 = (BlockQuote) bq1.getLastChild();
-            assertThat(bq2.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 2, 2, 5), SourceSpan.of(1, 2, 10, 3)));
+            assertThat(bq2.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 2, 2, 5), SourceSpan.of(1, 2, 10, 3)));
             var paragraph = (Paragraph) bq2.getLastChild();
-            assertThat(paragraph.getSourceSpans()).isEqualTo(List.of(SourceSpan.of(0, 4, 4, 3), SourceSpan.of(1, 2, 10, 3)));
+            assertThat(paragraph.getSourceSpans())
+                    .isEqualTo(List.of(SourceSpan.of(0, 4, 4, 3), SourceSpan.of(1, 2, 10, 3)));
         }
     }
 
     @Test
     public void visualCheck() {
-        assertVisualize("> * foo\n>   bar\n> * baz\n", "(> {[* <foo>]})\n(> {[  <bar>]})\n(> {⸢* ⸤baz⸥⸣})\n");
-        assertVisualize("> * ```\n>   foo\n>   ```\n", "(> {[* <```>]})\n(> {[  <foo>]})\n(> {[  <```>]})\n");
+        assertVisualize(
+                "> * foo\n>   bar\n> * baz\n",
+                "(> {[* <foo>]})\n(> {[  <bar>]})\n(> {⸢* ⸤baz⸥⸣})\n");
+        assertVisualize(
+                "> * ```\n>   foo\n>   ```\n",
+                "(> {[* <```>]})\n(> {[  <foo>]})\n(> {[  <```>]})\n");
     }
 
     @Test
@@ -276,7 +448,8 @@ public class SourceSpansTest {
         assertInlineSpans("> foo", Text.class, SourceSpan.of(0, 2, 2, 3));
         assertInlineSpans("* foo", Text.class, SourceSpan.of(0, 2, 2, 3));
 
-        // SourceSpans should be merged: ` is a separate Text node while inline parsing and gets merged at the end
+        // SourceSpans should be merged: ` is a separate Text node while inline parsing and gets
+        // merged at the end
         assertInlineSpans("foo`bar", Text.class, SourceSpan.of(0, 0, 0, 7));
         assertInlineSpans("foo[bar", Text.class, SourceSpan.of(0, 0, 0, 7));
         assertInlineSpans("> foo`bar", Text.class, SourceSpan.of(0, 2, 2, 7));
@@ -305,9 +478,8 @@ public class SourceSpansTest {
     @Test
     public void inlineBackticks() {
         assertInlineSpans("see `code`", Code.class, SourceSpan.of(0, 4, 4, 6));
-        assertInlineSpans("`multi\nline`", Code.class,
-                SourceSpan.of(0, 0, 0, 6),
-                SourceSpan.of(1, 0, 7, 5));
+        assertInlineSpans(
+                "`multi\nline`", Code.class, SourceSpan.of(0, 0, 0, 6), SourceSpan.of(1, 0, 7, 5));
         assertInlineSpans("text ```", Text.class, SourceSpan.of(0, 0, 0, 8));
     }
 
@@ -368,13 +540,14 @@ public class SourceSpansTest {
     @Test
     public void differentLineTerminators() {
         var input = "foo\nbar\rbaz\r\nqux\r\n\r\n> *hi*";
-        assertSpans(input, Paragraph.class,
+        assertSpans(
+                input,
+                Paragraph.class,
                 SourceSpan.of(0, 0, 0, 3),
                 SourceSpan.of(1, 0, 4, 3),
                 SourceSpan.of(2, 0, 8, 3),
                 SourceSpan.of(3, 0, 13, 3));
-        assertSpans(input, BlockQuote.class,
-                SourceSpan.of(5, 0, 20, 6));
+        assertSpans(input, BlockQuote.class, SourceSpan.of(5, 0, 20, 6));
 
         assertInlineSpans(input, Emphasis.class, SourceSpan.of(5, 2, 22, 4));
     }
@@ -385,25 +558,32 @@ public class SourceSpansTest {
         assertThat(SourceSpanRenderer.renderWithInputIndex(doc, source)).isEqualTo(expected);
     }
 
-    private static void assertSpans(String input, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
+    private static void assertSpans(
+            String input, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
         assertSpans(PARSER.parse(input), nodeClass, expectedSourceSpans);
         try {
-            assertSpans(PARSER.parseReader(new StringReader(input)), nodeClass, expectedSourceSpans);
+            assertSpans(
+                    PARSER.parseReader(new StringReader(input)), nodeClass, expectedSourceSpans);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private static void assertInlineSpans(String input, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
+    private static void assertInlineSpans(
+            String input, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
         assertSpans(INLINES_PARSER.parse(input), nodeClass, expectedSourceSpans);
         try {
-            assertSpans(INLINES_PARSER.parseReader(new StringReader(input)), nodeClass, expectedSourceSpans);
+            assertSpans(
+                    INLINES_PARSER.parseReader(new StringReader(input)),
+                    nodeClass,
+                    expectedSourceSpans);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private static void assertSpans(Node rootNode, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
+    private static void assertSpans(
+            Node rootNode, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
         Node node = findNode(rootNode, nodeClass);
         assertThat(node.getSourceSpans()).isEqualTo(List.of(expectedSourceSpans));
     }

--- a/commonmark/src/test/java/org/commonmark/test/SpecBenchmark.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecBenchmark.java
@@ -1,5 +1,6 @@
 package org.commonmark.test;
 
+import java.util.List;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -11,8 +12,6 @@ import org.openjdk.jmh.runner.options.CommandLineOptions;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.util.List;
-
 @State(Scope.Benchmark)
 @Fork(5)
 @Warmup(iterations = 10)
@@ -20,17 +19,19 @@ import java.util.List;
 public class SpecBenchmark {
 
     private static final String SPEC = TestResources.readAsString(TestResources.getSpec());
-    private static final List<String> SPEC_EXAMPLES = ExampleReader.readExampleSources(TestResources.getSpec());
+    private static final List<String> SPEC_EXAMPLES =
+            ExampleReader.readExampleSources(TestResources.getSpec());
     private static final Parser PARSER = Parser.builder().build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().build();
 
     private static final Node SPEC_NODE = PARSER.parse(SPEC);
 
     public static void main(String[] args) throws Exception {
-        Options options = new OptionsBuilder()
-                .parent(new CommandLineOptions(args))
-                .include(SpecBenchmark.class.getName() + ".*")
-                .build();
+        Options options =
+                new OptionsBuilder()
+                        .parent(new CommandLineOptions(args))
+                        .include(SpecBenchmark.class.getName() + ".*")
+                        .build();
         new Runner(options).run();
     }
 

--- a/commonmark/src/test/java/org/commonmark/test/SpecCoreTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecCoreTest.java
@@ -1,5 +1,8 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.fail;
+import static org.commonmark.testutil.Asserts.assertRendering;
+
 import org.commonmark.node.AbstractVisitor;
 import org.commonmark.node.Node;
 import org.commonmark.node.Text;
@@ -8,41 +11,47 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.SpecTestCase;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.fail;
-import static org.commonmark.testutil.Asserts.assertRendering;
-
 public class SpecCoreTest extends SpecTestCase {
 
     private static final Parser PARSER = Parser.builder().build();
     // The spec says URL-escaping is optional, but the examples assume that it's enabled.
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().percentEncodeUrls(true).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().percentEncodeUrls(true).build();
 
     @Test
     public void testTextNodesContiguous() {
         final String source = example.getSource();
         Node node = PARSER.parse(source);
-        node.accept(new AbstractVisitor() {
-            @Override
-            protected void visitChildren(Node parent) {
-                if (parent instanceof Text && parent.getFirstChild() != null) {
-                    fail("Text node is not allowed to have children, literal is \"" + ((Text) parent).getLiteral() + "\"");
-                }
-                boolean lastText = false;
-                Node node = parent.getFirstChild();
-                while (node != null) {
-                    if (node instanceof Text) {
-                        if (lastText) {
-                            fail("Adjacent text nodes found, second node literal is \"" + ((Text) node).getLiteral() + "\", source:\n" + source);
+        node.accept(
+                new AbstractVisitor() {
+                    @Override
+                    protected void visitChildren(Node parent) {
+                        if (parent instanceof Text && parent.getFirstChild() != null) {
+                            fail(
+                                    "Text node is not allowed to have children, literal is \""
+                                            + ((Text) parent).getLiteral()
+                                            + "\"");
                         }
-                        lastText = true;
-                    } else {
-                        lastText = false;
+                        boolean lastText = false;
+                        Node node = parent.getFirstChild();
+                        while (node != null) {
+                            if (node instanceof Text) {
+                                if (lastText) {
+                                    fail(
+                                            "Adjacent text nodes found, second node literal is \""
+                                                    + ((Text) node).getLiteral()
+                                                    + "\", source:\n"
+                                                    + source);
+                                }
+                                lastText = true;
+                            } else {
+                                lastText = false;
+                            }
+                            node = node.getNext();
+                        }
+                        super.visitChildren(parent);
                     }
-                    node = node.getNext();
-                }
-                super.visitChildren(parent);
-            }
-        });
+                });
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/test/SpecCrLfCoreTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecCrLfCoreTest.java
@@ -1,20 +1,22 @@
 package org.commonmark.test;
 
+import static org.commonmark.testutil.Asserts.assertRendering;
+
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.SpecTestCase;
 import org.junit.jupiter.api.Test;
 
-import static org.commonmark.testutil.Asserts.assertRendering;
-
 /**
- * Same as {@link SpecCoreTest} but converts line endings to Windows-style CR+LF endings before parsing.
+ * Same as {@link SpecCoreTest} but converts line endings to Windows-style CR+LF endings before
+ * parsing.
  */
 public class SpecCrLfCoreTest extends SpecTestCase {
 
     private static final Parser PARSER = Parser.builder().build();
     // The spec says URL-escaping is optional, but the examples assume that it's enabled.
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().percentEncodeUrls(true).build();
+    private static final HtmlRenderer RENDERER =
+            HtmlRenderer.builder().percentEncodeUrls(true).build();
 
     @Test
     public void testHtmlRendering() {

--- a/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
@@ -31,8 +31,11 @@ public class SpecialInputTest extends CoreRenderingTestCase {
 
     @Test
     public void mixedLineSeparators() {
-        assertRendering("- a\n- b\r- c\r\n- d", "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n</ul>\n");
-        assertRendering("a\n\nb\r\rc\r\n\r\nd\n\re", "<p>a</p>\n<p>b</p>\n<p>c</p>\n<p>d</p>\n<p>e</p>\n");
+        assertRendering(
+                "- a\n- b\r- c\r\n- d",
+                "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n</ul>\n");
+        assertRendering(
+                "a\n\nb\r\rc\r\n\r\nd\n\re", "<p>a</p>\n<p>b</p>\n<p>c</p>\n<p>d</p>\n<p>e</p>\n");
     }
 
     @Test
@@ -52,13 +55,16 @@ public class SpecialInputTest extends CoreRenderingTestCase {
 
     @Test
     public void tightListInBlockQuote() {
-        assertRendering("> *\n> * a", "<blockquote>\n<ul>\n<li></li>\n<li>a</li>\n</ul>\n</blockquote>\n");
+        assertRendering(
+                "> *\n> * a", "<blockquote>\n<ul>\n<li></li>\n<li>a</li>\n</ul>\n</blockquote>\n");
     }
 
     @Test
     public void looseListInBlockQuote() {
         // Second line in block quote is considered blank for purpose of loose list
-        assertRendering("> *\n>\n> * a", "<blockquote>\n<ul>\n<li></li>\n<li>\n<p>a</p>\n</li>\n</ul>\n</blockquote>\n");
+        assertRendering(
+                "> *\n>\n> * a",
+                "<blockquote>\n<ul>\n<li></li>\n<li>\n<p>a</p>\n</li>\n</ul>\n</blockquote>\n");
     }
 
     @Test
@@ -68,7 +74,8 @@ public class SpecialInputTest extends CoreRenderingTestCase {
 
     @Test
     public void listWithTwoSpacesForFirstBullet() {
-        // We have two spaces after the bullet, but no content. With content, the next line would be required
+        // We have two spaces after the bullet, but no content. With content, the next line would be
+        // required
         assertRendering("*  \n  foo\n", "<ul>\n<li>foo</li>\n</ul>\n");
     }
 
@@ -79,9 +86,11 @@ public class SpecialInputTest extends CoreRenderingTestCase {
 
     @Test
     public void columnIsInTabOnPreviousLine() {
-        assertRendering("- foo\n\n\tbar\n\n# baz\n",
+        assertRendering(
+                "- foo\n\n\tbar\n\n# baz\n",
                 "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n<h1>baz</h1>\n");
-        assertRendering("- foo\n\n\tbar\n# baz\n",
+        assertRendering(
+                "- foo\n\n\tbar\n# baz\n",
                 "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n<h1>baz</h1>\n");
     }
 
@@ -95,15 +104,20 @@ public class SpecialInputTest extends CoreRenderingTestCase {
     @Test
     public void linkLabelLength() {
         String label1 = "a".repeat(999);
-        assertRendering("[foo][" + label1 + "]\n\n[" + label1 + "]: /", "<p><a href=\"/\">foo</a></p>\n");
-        assertRendering("[foo][x" + label1 + "]\n\n[x" + label1 + "]: /",
+        assertRendering(
+                "[foo][" + label1 + "]\n\n[" + label1 + "]: /", "<p><a href=\"/\">foo</a></p>\n");
+        assertRendering(
+                "[foo][x" + label1 + "]\n\n[x" + label1 + "]: /",
                 "<p>[foo][x" + label1 + "]</p>\n<p>[x" + label1 + "]: /</p>\n");
-        assertRendering("[foo][\n" + label1 + "]\n\n[\n" + label1 + "]: /",
+        assertRendering(
+                "[foo][\n" + label1 + "]\n\n[\n" + label1 + "]: /",
                 "<p>[foo][\n" + label1 + "]</p>\n<p>[\n" + label1 + "]: /</p>\n");
 
         String label2 = "a\n".repeat(499);
-        assertRendering("[foo][" + label2 + "]\n\n[" + label2 + "]: /", "<p><a href=\"/\">foo</a></p>\n");
-        assertRendering("[foo][12" + label2 + "]\n\n[12" + label2 + "]: /",
+        assertRendering(
+                "[foo][" + label2 + "]\n\n[" + label2 + "]: /", "<p><a href=\"/\">foo</a></p>\n");
+        assertRendering(
+                "[foo][12" + label2 + "]\n\n[12" + label2 + "]: /",
                 "<p>[foo][12" + label2 + "]</p>\n<p>[12" + label2 + "]: /</p>\n");
     }
 
@@ -111,7 +125,8 @@ public class SpecialInputTest extends CoreRenderingTestCase {
     public void linkDestinationEscaping() {
         // Backslash escapes `)`
         assertRendering("[foo](\\))", "<p><a href=\")\">foo</a></p>\n");
-        // ` ` is not escapable, so the backslash is a literal backslash and there's an optional space at the end
+        // ` ` is not escapable, so the backslash is a literal backslash and there's an optional
+        // space at the end
         assertRendering("[foo](\\ )", "<p><a href=\"\\\">foo</a></p>\n");
         // Backslash is a literal, so valid
         assertRendering("[foo](<a\\b>)", "<p><a href=\"a\\b\">foo</a></p>\n");
@@ -141,35 +156,35 @@ public class SpecialInputTest extends CoreRenderingTestCase {
 
     @Test
     public void renderEvenRegexpProducesStackoverflow() {
-        render("Contents: <!--[if gte mso 9]> <w:LatentStyles DefLockedState=\"false\" DefUnhideWhenUsed=\"false\" DefSemiHidden=\"false\" DefQFormat=\"false\" DefPriority=\"99\" LatentStyleCount=\"371\">  <w:xxx Locked=\"false\" Priority=\"52\" Name=\"Grid Table 7 Colorful 6\"/> <w:xxx Locked=\"false\" Priority=\"46\" Name=\"List Table 1 Light\"/> <w:xxx Locked=\"false\" Priority=\"47\" Name=\"List Table 2\"/> <w:xxx Locked=\"false\" Priority=\"48\" Name=\"List Table 3\"/> <w:xxx Locked=\"false\" Priority=\"49\" Name=\"List Table 4\"/> <w:xxx Locked=\"false\" Priority=\"50\" Name=\"List Table 5 Dark\"/> <w:xxx Locked=\"false\" Priority=\"51\" Name=\"List Table 6 Colorful\"/> <w:xxx Locked=\"false\" Priority=\"52\" Name=\"List Table 7 Colorful\"/> <w:xxx Locked=\"false\" Priority=\"46\" Name=\"List Table 1 Light Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"47\" Name=\"List Table 2 Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"48\" Name=\"List Table 3 Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"49\" Name=\"List Table 4 Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"50\" Name=\"List Table 5 Dark Accent 1\"/>  <w:xxx Locked=\"false\" Priority=\"52\" Name=\"List Table 7 Colorful Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"46\" Name=\"List Table 1 Light Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"47\" Name=\"List Table 2 Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"48\" Name=\"List Table 3 Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"49\" Name=\"List Table 4 Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"50\" Name=\"List Table 5 Dark Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"51\" Name=\"List Table 6 Colorful Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"52\" Name=\"List Table 7 Colorful Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"46\" Name=\"List Table 1 Light Accent 3\"/> <w:xxx Locked=\"false\" Priority=\"47\" Name=\"List Table 2 Accent 3\"/> <w:xxx Locked=\"false\" Priority=\"48\" Name=\"List Table 3 Accent 3\"/> <w:xxx Locked=\"false\" Priority=\"49\" Name=\"List Table 4 Accent 3\" /> <w:xxx Locked=\"false\" Priority=\"50\" Name=\"List Table 5 Dark Accent 3\"/><w:xxx Locked=\"false\" Priority=\"51\" Name=\"List Table 6 Colorful Accent 3\"/></xml>");
+        render(
+                "Contents: <!--[if gte mso 9]> <w:LatentStyles DefLockedState=\"false\" DefUnhideWhenUsed=\"false\" DefSemiHidden=\"false\" DefQFormat=\"false\" DefPriority=\"99\" LatentStyleCount=\"371\">  <w:xxx Locked=\"false\" Priority=\"52\" Name=\"Grid Table 7 Colorful 6\"/> <w:xxx Locked=\"false\" Priority=\"46\" Name=\"List Table 1 Light\"/> <w:xxx Locked=\"false\" Priority=\"47\" Name=\"List Table 2\"/> <w:xxx Locked=\"false\" Priority=\"48\" Name=\"List Table 3\"/> <w:xxx Locked=\"false\" Priority=\"49\" Name=\"List Table 4\"/> <w:xxx Locked=\"false\" Priority=\"50\" Name=\"List Table 5 Dark\"/> <w:xxx Locked=\"false\" Priority=\"51\" Name=\"List Table 6 Colorful\"/> <w:xxx Locked=\"false\" Priority=\"52\" Name=\"List Table 7 Colorful\"/> <w:xxx Locked=\"false\" Priority=\"46\" Name=\"List Table 1 Light Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"47\" Name=\"List Table 2 Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"48\" Name=\"List Table 3 Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"49\" Name=\"List Table 4 Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"50\" Name=\"List Table 5 Dark Accent 1\"/>  <w:xxx Locked=\"false\" Priority=\"52\" Name=\"List Table 7 Colorful Accent 1\"/> <w:xxx Locked=\"false\" Priority=\"46\" Name=\"List Table 1 Light Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"47\" Name=\"List Table 2 Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"48\" Name=\"List Table 3 Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"49\" Name=\"List Table 4 Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"50\" Name=\"List Table 5 Dark Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"51\" Name=\"List Table 6 Colorful Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"52\" Name=\"List Table 7 Colorful Accent 2\"/> <w:xxx Locked=\"false\" Priority=\"46\" Name=\"List Table 1 Light Accent 3\"/> <w:xxx Locked=\"false\" Priority=\"47\" Name=\"List Table 2 Accent 3\"/> <w:xxx Locked=\"false\" Priority=\"48\" Name=\"List Table 3 Accent 3\"/> <w:xxx Locked=\"false\" Priority=\"49\" Name=\"List Table 4 Accent 3\" /> <w:xxx Locked=\"false\" Priority=\"50\" Name=\"List Table 5 Dark Accent 3\"/><w:xxx Locked=\"false\" Priority=\"51\" Name=\"List Table 6 Colorful Accent 3\"/></xml>");
     }
 
     @Test
     public void deeplyIndentedList() {
-        assertRendering("* one\n" +
-                        "  * two\n" +
-                        "    * three\n" +
-                        "      * four",
-                "<ul>\n" +
-                        "<li>one\n" +
-                        "<ul>\n" +
-                        "<li>two\n" +
-                        "<ul>\n" +
-                        "<li>three\n" +
-                        "<ul>\n" +
-                        "<li>four</li>\n" +
-                        "</ul>\n" +
-                        "</li>\n" +
-                        "</ul>\n" +
-                        "</li>\n" +
-                        "</ul>\n" +
-                        "</li>\n" +
-                        "</ul>\n");
+        assertRendering(
+                "* one\n" + "  * two\n" + "    * three\n" + "      * four",
+                "<ul>\n"
+                        + "<li>one\n"
+                        + "<ul>\n"
+                        + "<li>two\n"
+                        + "<ul>\n"
+                        + "<li>three\n"
+                        + "<ul>\n"
+                        + "<li>four</li>\n"
+                        + "</ul>\n"
+                        + "</li>\n"
+                        + "</ul>\n"
+                        + "</li>\n"
+                        + "</ul>\n"
+                        + "</li>\n"
+                        + "</ul>\n");
     }
 
     @Test
     public void trailingTabs() {
-        // The tab is not treated as 4 spaces here and so does not result in a hard line break, but is just preserved.
+        // The tab is not treated as 4 spaces here and so does not result in a hard line break, but
+        // is just preserved.
         // This matches what commonmark.js did at the time of writing.
         assertRendering("a\t\nb\n", "<p>a\t\nb</p>\n");
     }
@@ -177,52 +192,46 @@ public class SpecialInputTest extends CoreRenderingTestCase {
     @Test
     public void unicodePunctuationEmphasis() {
         // The character here is: U+12470 CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER
-        // Which is in Unicode category "Po" and needs 2 code units in UTF-16. That means to implement
-        // it correctly, we need to check code points, not Java chars.
-        // Note that currently the reference implementation doesn't implement this correctly (resulting in no <em>).
+        // Which is in Unicode category "Po" and needs 2 code units in UTF-16. That means to
+        // implement it correctly, we need to check code points, not Java chars.
+        // Note that currently the reference implementation doesn't implement this correctly
+        // (resulting in no <em>).
         assertRendering("foo\uD809\uDC70_(bar)_", "<p>foo\uD809\uDC70<em>(bar)</em></p>\n");
     }
 
     @Test
     public void htmlBlockInterruptingList() {
-        assertRendering("- <script>\n" +
-                "- some text\n" +
-                "some other text\n" +
-                "</script>\n", "<ul>\n" +
-                "<li>\n" +
-                "<script>\n" +
-                "</li>\n" +
-                "<li>some text\n" +
-                "some other text\n" +
-                "</script></li>\n" +
-                "</ul>\n");
+        assertRendering(
+                "- <script>\n" + "- some text\n" + "some other text\n" + "</script>\n",
+                "<ul>\n"
+                        + "<li>\n"
+                        + "<script>\n"
+                        + "</li>\n"
+                        + "<li>some text\n"
+                        + "some other text\n"
+                        + "</script></li>\n"
+                        + "</ul>\n");
 
-        assertRendering("- <script>\n" +
-                "- some text\n" +
-                "some other text\n" +
-                "\n" +
-                "</script>\n", "<ul>\n" +
-                "<li>\n" +
-                "<script>\n" +
-                "</li>\n" +
-                "<li>some text\n" +
-                "some other text</li>\n" +
-                "</ul>\n" +
-                "</script>\n");
+        assertRendering(
+                "- <script>\n" + "- some text\n" + "some other text\n" + "\n" + "</script>\n",
+                "<ul>\n"
+                        + "<li>\n"
+                        + "<script>\n"
+                        + "</li>\n"
+                        + "<li>some text\n"
+                        + "some other text</li>\n"
+                        + "</ul>\n"
+                        + "</script>\n");
     }
 
     @Test
     public void emphasisAfterHardLineBreak() {
-        assertRendering("Hello  \n" +
-                "**Bar**\n" +
-                "Foo\n", "<p>Hello<br />\n" +
-                "<strong>Bar</strong>\n" +
-                "Foo</p>\n");
+        assertRendering(
+                "Hello  \n" + "**Bar**\n" + "Foo\n",
+                "<p>Hello<br />\n" + "<strong>Bar</strong>\n" + "Foo</p>\n");
 
-        assertRendering("Hello  \n" +
-                "**Bar**  \n" +
-                "Foo\n", "<p>Hello<br />\n" +
-                "<strong>Bar</strong><br />\n" +
-                "Foo</p>\n");
+        assertRendering(
+                "Hello  \n" + "**Bar**  \n" + "Foo\n",
+                "<p>Hello<br />\n" + "<strong>Bar</strong><br />\n" + "Foo</p>\n");
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
@@ -1,26 +1,28 @@
 package org.commonmark.test;
 
+import java.util.Set;
 import org.commonmark.node.Link;
 import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
 import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.text.LineBreakRendering;
 import org.commonmark.renderer.text.TextContentNodeRendererContext;
 import org.commonmark.renderer.text.TextContentNodeRendererFactory;
 import org.commonmark.renderer.text.TextContentRenderer;
-import org.commonmark.parser.Parser;
 import org.commonmark.testutil.Asserts;
 import org.junit.jupiter.api.Test;
-
-import java.util.Set;
 
 public class TextContentRendererTest {
 
     private static final Parser PARSER = Parser.builder().build();
-    private static final TextContentRenderer COMPACT_RENDERER = TextContentRenderer.builder().build();
-    private static final TextContentRenderer SEPARATE_RENDERER = TextContentRenderer.builder()
-            .lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS).build();
-    private static final TextContentRenderer STRIPPED_RENDERER = TextContentRenderer.builder()
-            .lineBreakRendering(LineBreakRendering.STRIP).build();
+    private static final TextContentRenderer COMPACT_RENDERER =
+            TextContentRenderer.builder().build();
+    private static final TextContentRenderer SEPARATE_RENDERER =
+            TextContentRenderer.builder()
+                    .lineBreakRendering(LineBreakRendering.SEPARATE_BLOCKS)
+                    .build();
+    private static final TextContentRenderer STRIPPED_RENDERER =
+            TextContentRenderer.builder().lineBreakRendering(LineBreakRendering.STRIP).build();
 
     @Test
     public void textContentText() {
@@ -82,7 +84,8 @@ public class TextContentRendererTest {
 
     @Test
     public void textContentImages() {
-        assertAll("foo ![text](http://link \"title\") bar", "foo \"text\" (title: http://link) bar");
+        assertAll(
+                "foo ![text](http://link \"title\") bar", "foo \"text\" (title: http://link) bar");
         assertAll("foo ![text](http://link) bar", "foo \"text\" (http://link) bar");
         assertAll("foo ![text]() bar", "foo \"text\" bar");
     }
@@ -138,7 +141,6 @@ public class TextContentRendererTest {
         // Separate preserves it
         assertSeparate(s, "foo\n\n* bar\n\n* baz");
         assertStripped(s, "foo bar baz");
-
     }
 
     @Test
@@ -182,13 +184,14 @@ public class TextContentRendererTest {
 
     @Test
     public void textContentHtml() {
-        String html = "<table>\n" +
-                "  <tr>\n" +
-                "    <td>\n" +
-                "           foobar\n" +
-                "    </td>\n" +
-                "  </tr>\n" +
-                "</table>";
+        String html =
+                "<table>\n"
+                        + "  <tr>\n"
+                        + "    <td>\n"
+                        + "           foobar\n"
+                        + "    </td>\n"
+                        + "  </tr>\n"
+                        + "</table>";
         assertCompact(html, html);
         assertSeparate(html, html);
 
@@ -198,9 +201,7 @@ public class TextContentRendererTest {
 
     @Test
     public void testContentNestedLists() {
-        var s = "List:\n" +
-                "1. 2) 3. \n" +
-                "end";
+        var s = "List:\n" + "1. 2) 3. \n" + "end";
         assertCompact(s, s);
 
         var s2 = "1. A\n   1) B\n      1. Test";
@@ -209,35 +210,37 @@ public class TextContentRendererTest {
 
     @Test
     public void testOverrideNodeRendering() {
-        var nodeRendererFactory = new TextContentNodeRendererFactory() {
-            @Override
-            public NodeRenderer create(TextContentNodeRendererContext context) {
-                return new NodeRenderer() {
-
+        var nodeRendererFactory =
+                new TextContentNodeRendererFactory() {
                     @Override
-                    public Set<Class<? extends Node>> getNodeTypes() {
-                        return Set.of(Link.class);
-                    }
+                    public NodeRenderer create(TextContentNodeRendererContext context) {
+                        return new NodeRenderer() {
 
-                    @Override
-                    public void render(Node node) {
-                        context.getWriter().write('"');
-                        renderChildren(node);
-                        context.getWriter().write('"');
-                    }
+                            @Override
+                            public Set<Class<? extends Node>> getNodeTypes() {
+                                return Set.of(Link.class);
+                            }
 
-                    private void renderChildren(Node parent) {
-                        Node node = parent.getFirstChild();
-                        while (node != null) {
-                            Node next = node.getNext();
-                            context.render(node);
-                            node = next;
-                        }
+                            @Override
+                            public void render(Node node) {
+                                context.getWriter().write('"');
+                                renderChildren(node);
+                                context.getWriter().write('"');
+                            }
+
+                            private void renderChildren(Node parent) {
+                                Node node = parent.getFirstChild();
+                                while (node != null) {
+                                    Node next = node.getNext();
+                                    context.render(node);
+                                    node = next;
+                                }
+                            }
+                        };
                     }
                 };
-            }
-        };
-        var renderer = TextContentRenderer.builder().nodeRendererFactory(nodeRendererFactory).build();
+        var renderer =
+                TextContentRenderer.builder().nodeRendererFactory(nodeRendererFactory).build();
         var source = "Hi [Example](https://example.com)";
         Asserts.assertRendering(source, "Hi \"Example\"", renderer.render(PARSER.parse(source)));
     }

--- a/commonmark/src/test/java/org/commonmark/test/TextContentWriterTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentWriterTest.java
@@ -1,9 +1,9 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.commonmark.renderer.text.TextContentWriter;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TextContentWriterTest {
 

--- a/commonmark/src/test/java/org/commonmark/test/ThematicBreakParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ThematicBreakParserTest.java
@@ -1,10 +1,10 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.commonmark.node.ThematicBreak;
 import org.commonmark.parser.Parser;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThematicBreakParserTest {
 

--- a/commonmark/src/test/java/org/commonmark/test/UsageExampleTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/UsageExampleTest.java
@@ -1,5 +1,13 @@
 package org.commonmark.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Set;
 import org.commonmark.node.*;
 import org.commonmark.parser.IncludeSourceSpans;
 import org.commonmark.parser.Parser;
@@ -8,15 +16,6 @@ import org.commonmark.renderer.html.*;
 import org.commonmark.renderer.markdown.MarkdownRenderer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class UsageExampleTest {
 
@@ -44,7 +43,8 @@ public class UsageExampleTest {
     @Disabled
     public void parseReaderRender() throws IOException {
         Parser parser = Parser.builder().build();
-        try (InputStreamReader reader = new InputStreamReader(new FileInputStream("file.md"), StandardCharsets.UTF_8)) {
+        try (InputStreamReader reader =
+                new InputStreamReader(new FileInputStream("file.md"), StandardCharsets.UTF_8)) {
             Node document = parser.parseReader(reader);
             // ...
         }
@@ -61,7 +61,8 @@ public class UsageExampleTest {
 
     @Test
     public void sourcePositions() {
-        var parser = Parser.builder().includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES).build();
+        var parser =
+                Parser.builder().includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES).build();
 
         var source = "foo\n\nbar *baz*";
         var doc = parser.parse(source);
@@ -71,26 +72,30 @@ public class UsageExampleTest {
         assertThat(s.getColumnIndex()).isEqualTo(4);
         assertThat(s.getInputIndex()).isEqualTo(9);
         assertThat(s.getLength()).isEqualTo(5);
-        assertThat(source.substring(s.getInputIndex(), s.getInputIndex() + s.getLength())).isEqualTo("*baz*");
+        assertThat(source.substring(s.getInputIndex(), s.getInputIndex() + s.getLength()))
+                .isEqualTo("*baz*");
     }
 
     @Test
     public void addAttributes() {
         Parser parser = Parser.builder().build();
-        HtmlRenderer renderer = HtmlRenderer.builder()
-                .attributeProviderFactory(context -> new ImageAttributeProvider())
-                .build();
+        HtmlRenderer renderer =
+                HtmlRenderer.builder()
+                        .attributeProviderFactory(context -> new ImageAttributeProvider())
+                        .build();
 
         Node document = parser.parse("![text](/url.png)");
-        assertThat(renderer.render(document)).isEqualTo("<p><img src=\"/url.png\" alt=\"text\" class=\"border\" /></p>\n");
+        assertThat(renderer.render(document))
+                .isEqualTo("<p><img src=\"/url.png\" alt=\"text\" class=\"border\" /></p>\n");
     }
 
     @Test
     public void customizeRendering() {
         Parser parser = Parser.builder().build();
-        HtmlRenderer renderer = HtmlRenderer.builder()
-                .nodeRendererFactory(IndentedCodeBlockNodeRenderer::new)
-                .build();
+        HtmlRenderer renderer =
+                HtmlRenderer.builder()
+                        .nodeRendererFactory(IndentedCodeBlockNodeRenderer::new)
+                        .build();
 
         Node document = parser.parse("Example:\n\n    code");
         assertThat(renderer.render(document)).isEqualTo("<p>Example:</p>\n<pre>code\n</pre>\n");
@@ -104,10 +109,12 @@ public class UsageExampleTest {
         public void visit(Text text) {
             // This is called for all Text nodes. Override other visit methods for other node types.
 
-            // Count words (this is just an example, don't actually do it this way for various reasons).
+            // Count words (this is just an example, don't actually do it this way for various
+            // reasons).
             wordCount += text.getLiteral().split("\\W+").length;
 
-            // Descend into children (could be omitted in this case because Text nodes don't have children).
+            // Descend into children (could be omitted in this case because Text nodes don't have
+            // children).
             visitChildren(text);
         }
     }

--- a/commonmark/src/test/java/org/commonmark/text/CharactersTest.java
+++ b/commonmark/src/test/java/org/commonmark/text/CharactersTest.java
@@ -1,8 +1,8 @@
 package org.commonmark.text;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 public class CharactersTest {
 
@@ -10,14 +10,48 @@ public class CharactersTest {
     public void isPunctuation() {
         // From https://spec.commonmark.org/0.29/#ascii-punctuation-character
         char[] chars = {
-                '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', // (U+0021–2F)
-                ':', ';', '<', '=', '>', '?', '@', // (U+003A–0040)
-                '[', '\\', ']', '^', '_', '`', // (U+005B–0060)
-                '{', '|', '}', '~' // (U+007B–007E)
+            // (U+0021–2F)
+            '!',
+            '"',
+            '#',
+            '$',
+            '%',
+            '&',
+            '\'',
+            '(',
+            ')',
+            '*',
+            '+',
+            ',',
+            '-',
+            '.',
+            '/',
+            // (U+003A–0040)
+            ':',
+            ';',
+            '<',
+            '=',
+            '>',
+            '?',
+            '@',
+            // (U+005B–0060)
+            '[',
+            '\\',
+            ']',
+            '^',
+            '_',
+            '`',
+            // (U+007B–007E)
+            '{',
+            '|',
+            '}',
+            '~'
         };
 
         for (char c : chars) {
-            assertThat(Characters.isPunctuationCodePoint(c)).as("Expected to be punctuation: " + c).isTrue();
+            assertThat(Characters.isPunctuationCodePoint(c))
+                    .as("Expected to be punctuation: " + c)
+                    .isTrue();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>3.9.0</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat>
+                            <style>AOSP</style>
+                        </googleJavaFormat>
+                    </java>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Using AOSP style because:
- It's 4 spaces indentation (instead of 2 for the default). 4 spaces matches
  the current style, so reformatting isn't going to change all lines.
- It's also closer to OpenJDK's own style as commonmark-java is vendored there:
  https://github.com/openjdk/jdk/tree/master/src/jdk.internal.md/share/classes/jdk/internal/org/commonmark

Can check formatting with `mvn spotless:check` and run formatting with `mvn spotless:apply`. We could add the check to CI at some point, but yeah.