### PR TITLE
Use text blocks in tests (set testRelease to 17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17, 21, 25]
+        java: [17, 21, 25]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
 
       - name: Build with coverage
@@ -54,7 +54,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
 
       - name: Android Lint checks

--- a/commonmark-ext-autolink/src/test/java/org/commonmark/ext/autolink/AutolinkTest.java
+++ b/commonmark-ext-autolink/src/test/java/org/commonmark/ext/autolink/AutolinkTest.java
@@ -91,12 +91,14 @@ public class AutolinkTest extends RenderingTestCase {
                         .extensions(EXTENSIONS)
                         .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
                         .build();
-        Node document =
-                parser.parse(
-                        "abc\n"
-                                + "http://example.com/one\n"
-                                + "def http://example.com/two\n"
-                                + "ghi http://example.com/three jkl");
+        var s =
+                """
+                abc
+                http://example.com/one
+                def http://example.com/two
+                ghi http://example.com/three jkl
+                """;
+        Node document = parser.parse(s);
 
         Paragraph paragraph = (Paragraph) document.getFirstChild();
         Text abc = (Text) paragraph.getFirstChild();

--- a/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnoteHtmlRendererTest.java
+++ b/commonmark-ext-footnotes/src/test/java/org/commonmark/ext/footnotes/FootnoteHtmlRendererTest.java
@@ -21,15 +21,21 @@ public class FootnoteHtmlRendererTest extends RenderingTestCase {
     @Test
     public void testOne() {
         assertRendering(
-                "Test [^foo]\n\n[^foo]: note\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-foo\">\n"
-                        + "<p>note <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                Test [^foo]
+
+                [^foo]: note
+                """,
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn-foo" id="fnref-foo" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-foo">
+                <p>note <a href="#fnref-foo" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
@@ -37,15 +43,21 @@ public class FootnoteHtmlRendererTest extends RenderingTestCase {
         // Labels match via their normalized form. For the href and IDs to match, rendering needs to
         // use the label from the definition consistently.
         assertRendering(
-                "Test [^bar]\n\n[^BAR]: note\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-BAR\" id=\"fnref-BAR\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-BAR\">\n"
-                        + "<p>note <a href=\"#fnref-BAR\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                Test [^bar]
+
+                [^BAR]: note
+                """,
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn-BAR" id="fnref-BAR" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-BAR">
+                <p>note <a href="#fnref-BAR" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
@@ -55,53 +67,80 @@ public class FootnoteHtmlRendererTest extends RenderingTestCase {
         // - The same number is used when a definition is referenced multiple times
         // - Multiple backrefs are rendered
         assertRendering(
-                "First [^foo]\n\nThen [^bar]\n\nThen [^foo] again\n\n[^bar]: b\n[^foo]: f\n",
-                "<p>First <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<p>Then <sup class=\"footnote-ref\"><a href=\"#fn-bar\" id=\"fnref-bar\" data-footnote-ref>2</a></sup></p>\n"
-                        + "<p>Then <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo-2\" data-footnote-ref>1</a></sup> again</p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-foo\">\n"
-                        + "<p>f <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a> <a href=\"#fnref-foo-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-2\" aria-label=\"Back to reference 1-2\"><sup class=\"footnote-ref\">2</sup>↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn-bar\">\n"
-                        + "<p>b <a href=\"#fnref-bar\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                First [^foo]
+
+                Then [^bar]
+
+                Then [^foo] again
+
+                [^bar]: b
+                [^foo]: f
+                """,
+                """
+                <p>First <sup class="footnote-ref"><a href="#fn-foo" id="fnref-foo" data-footnote-ref>1</a></sup></p>
+                <p>Then <sup class="footnote-ref"><a href="#fn-bar" id="fnref-bar" data-footnote-ref>2</a></sup></p>
+                <p>Then <sup class="footnote-ref"><a href="#fn-foo" id="fnref-foo-2" data-footnote-ref>1</a></sup> again</p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-foo">
+                <p>f <a href="#fnref-foo" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a> <a href="#fnref-foo-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-2" aria-label="Back to reference 1-2"><sup class="footnote-ref">2</sup>↩</a></p>
+                </li>
+                <li id="fn-bar">
+                <p>b <a href="#fnref-bar" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
     public void testDefinitionWithTwoParagraphs() {
         // With two paragraphs, the backref <a> should be added to the second one
         assertRendering(
-                "Test [^foo]\n\n[^foo]: one\n    \n    two\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-foo\">\n"
-                        + "<p>one</p>\n"
-                        + "<p>two <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                Test [^foo]
+
+                [^foo]: one
+                   \s
+                    two
+                """,
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn-foo" id="fnref-foo" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-foo">
+                <p>one</p>
+                <p>two <a href="#fnref-foo" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
     public void testDefinitionWithList() {
         assertRendering(
-                "Test [^foo]\n\n[^foo]:\n    - one\n    - two\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-foo\">\n"
-                        + "<ul>\n"
-                        + "<li>one</li>\n"
-                        + "<li>two</li>\n"
-                        + "</ul>\n"
-                        + "<a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                Test [^foo]
+
+                [^foo]:
+                    - one
+                    - two
+                """,
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn-foo" id="fnref-foo" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-foo">
+                <ul>
+                <li>one</li>
+                <li>two</li>
+                </ul>
+                <a href="#fnref-foo" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></li>
+                </ol>
+                </section>
+                """);
     }
 
     // See docs on FootnoteHtmlNodeRenderer about nested footnotes.
@@ -109,18 +148,25 @@ public class FootnoteHtmlRendererTest extends RenderingTestCase {
     @Test
     public void testNestedFootnotesSimple() {
         assertRendering(
-                "[^foo1]\n" + "\n" + "[^foo1]: one [^foo2]\n" + "[^foo2]: two\n",
-                "<p><sup class=\"footnote-ref\"><a href=\"#fn-foo1\" id=\"fnref-foo1\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-foo1\">\n"
-                        + "<p>one <sup class=\"footnote-ref\"><a href=\"#fn-foo2\" id=\"fnref-foo2\" data-footnote-ref>2</a></sup> <a href=\"#fnref-foo1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn-foo2\">\n"
-                        + "<p>two <a href=\"#fnref-foo2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                [^foo1]
+
+                [^foo1]: one [^foo2]
+                [^foo2]: two
+                """,
+                """
+                <p><sup class="footnote-ref"><a href="#fn-foo1" id="fnref-foo1" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-foo1">
+                <p>one <sup class="footnote-ref"><a href="#fn-foo2" id="fnref-foo2" data-footnote-ref>2</a></sup> <a href="#fnref-foo1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                <li id="fn-foo2">
+                <p>two <a href="#fnref-foo2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
@@ -129,149 +175,196 @@ public class FootnoteHtmlRendererTest extends RenderingTestCase {
         // The reason is that the number is done based on all references in document order,
         // including references in definitions. So [^bar] from the first line is first.
         assertRendering(
-                "[^foo]: foo [^bar]\n" + "\n" + "[^foo]\n" + "\n" + "[^bar]: bar\n",
-                "<p><sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-foo\">\n"
-                        + "<p>foo <sup class=\"footnote-ref\"><a href=\"#fn-bar\" id=\"fnref-bar\" data-footnote-ref>2</a></sup> <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn-bar\">\n"
-                        + "<p>bar <a href=\"#fnref-bar\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                [^foo]: foo [^bar]
+
+                [^foo]
+
+                [^bar]: bar
+                """,
+                """
+                <p><sup class="footnote-ref"><a href="#fn-foo" id="fnref-foo" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-foo">
+                <p>foo <sup class="footnote-ref"><a href="#fn-bar" id="fnref-bar" data-footnote-ref>2</a></sup> <a href="#fnref-foo" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                <li id="fn-bar">
+                <p>bar <a href="#fnref-bar" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
     public void testNestedFootnotesOrder2() {
         assertRendering(
-                "[^1]\n"
-                        + "\n"
-                        + "[^4]: four\n"
-                        + "[^3]: three [^4]\n"
-                        + "[^2]: two [^4]\n"
-                        + "[^1]: one [^2][^3]\n",
-                "<p><sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-1\">\n"
-                        + "<p>one <sup class=\"footnote-ref\"><a href=\"#fn-2\" id=\"fnref-2\" data-footnote-ref>2</a></sup><sup class=\"footnote-ref\"><a href=\"#fn-3\" id=\"fnref-3\" data-footnote-ref>3</a></sup> <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn-2\">\n"
-                        + "<p>two <sup class=\"footnote-ref\"><a href=\"#fn-4\" id=\"fnref-4\" data-footnote-ref>4</a></sup> <a href=\"#fnref-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn-3\">\n"
-                        + "<p>three <sup class=\"footnote-ref\"><a href=\"#fn-4\" id=\"fnref-4-2\" data-footnote-ref>4</a></sup> <a href=\"#fnref-3\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"3\" aria-label=\"Back to reference 3\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn-4\">\n"
-                        + "<p>four <a href=\"#fnref-4\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"4\" aria-label=\"Back to reference 4\">↩</a> <a href=\"#fnref-4-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"4-2\" aria-label=\"Back to reference 4-2\"><sup class=\"footnote-ref\">2</sup>↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                [^1]
+
+                [^4]: four
+                [^3]: three [^4]
+                [^2]: two [^4]
+                [^1]: one [^2][^3]
+                """,
+                """
+                <p><sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-1">
+                <p>one <sup class="footnote-ref"><a href="#fn-2" id="fnref-2" data-footnote-ref>2</a></sup><sup class="footnote-ref"><a href="#fn-3" id="fnref-3" data-footnote-ref>3</a></sup> <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                <li id="fn-2">
+                <p>two <sup class="footnote-ref"><a href="#fn-4" id="fnref-4" data-footnote-ref>4</a></sup> <a href="#fnref-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+                </li>
+                <li id="fn-3">
+                <p>three <sup class="footnote-ref"><a href="#fn-4" id="fnref-4-2" data-footnote-ref>4</a></sup> <a href="#fnref-3" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="3" aria-label="Back to reference 3">↩</a></p>
+                </li>
+                <li id="fn-4">
+                <p>four <a href="#fnref-4" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="4" aria-label="Back to reference 4">↩</a> <a href="#fnref-4-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="4-2" aria-label="Back to reference 4-2"><sup class="footnote-ref">2</sup>↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
     public void testNestedFootnotesCycle() {
         // Footnotes can contain cycles, lol.
         assertRendering(
-                "[^foo1]\n" + "\n" + "[^foo1]: one [^foo2]\n" + "[^foo2]: two [^foo1]\n",
-                "<p><sup class=\"footnote-ref\"><a href=\"#fn-foo1\" id=\"fnref-foo1\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-foo1\">\n"
-                        + "<p>one <sup class=\"footnote-ref\"><a href=\"#fn-foo2\" id=\"fnref-foo2\" data-footnote-ref>2</a></sup> <a href=\"#fnref-foo1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a> <a href=\"#fnref-foo1-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-2\" aria-label=\"Back to reference 1-2\"><sup class=\"footnote-ref\">2</sup>↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn-foo2\">\n"
-                        + "<p>two <sup class=\"footnote-ref\"><a href=\"#fn-foo1\" id=\"fnref-foo1-2\" data-footnote-ref>1</a></sup> <a href=\"#fnref-foo2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                [^foo1]
+
+                [^foo1]: one [^foo2]
+                [^foo2]: two [^foo1]
+                """,
+                """
+                <p><sup class="footnote-ref"><a href="#fn-foo1" id="fnref-foo1" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-foo1">
+                <p>one <sup class="footnote-ref"><a href="#fn-foo2" id="fnref-foo2" data-footnote-ref>2</a></sup> <a href="#fnref-foo1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a> <a href="#fnref-foo1-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-2" aria-label="Back to reference 1-2"><sup class="footnote-ref">2</sup>↩</a></p>
+                </li>
+                <li id="fn-foo2">
+                <p>two <sup class="footnote-ref"><a href="#fn-foo1" id="fnref-foo1-2" data-footnote-ref>1</a></sup> <a href="#fnref-foo2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
     public void testNestedFootnotesUnreferenced() {
         // This should not result in any footnotes, as baz itself isn't referenced.
         // But GitHub renders bar only, with a broken backref, because bar is referenced from foo.
-        assertRendering("[^foo]: foo[^bar]\n" + "[^bar]: bar\n", "");
+        assertRendering(
+                """
+                [^foo]: foo[^bar]
+                [^bar]: bar
+                """,
+                "");
 
         // And here only 1 is rendered.
         assertRendering(
-                "[^1]\n" + "\n" + "[^1]: one\n" + "[^foo]: foo[^bar]\n" + "[^bar]: bar\n",
-                "<p><sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-1\">\n"
-                        + "<p>one <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                [^1]
+
+                [^1]: one
+                [^foo]: foo[^bar]
+                [^bar]: bar
+                """,
+                """
+                <p><sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-1">
+                <p>one <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
     public void testInlineFootnotes() {
         assertRenderingInline(
                 "Test ^[inline *footnote*]",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn1\">\n"
-                        + "<p>inline <em>footnote</em> <a href=\"#fnref1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn1" id="fnref1" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn1">
+                <p>inline <em>footnote</em> <a href="#fnref1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
     public void testInlineFootnotesNested() {
         assertRenderingInline(
                 "Test ^[inline ^[nested]]",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn1\">\n"
-                        + "<p>inline <sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\" data-footnote-ref>2</a></sup> <a href=\"#fnref1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn2\">\n"
-                        + "<p>nested <a href=\"#fnref2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn1" id="fnref1" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn1">
+                <p>inline <sup class="footnote-ref"><a href="#fn2" id="fnref2" data-footnote-ref>2</a></sup> <a href="#fnref1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                <li id="fn2">
+                <p>nested <a href="#fnref2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
     public void testInlineFootnoteWithReference() {
         // This is a bit tricky because the IDs need to be unique.
         assertRenderingInline(
-                "Test ^[inline [^1]]\n" + "\n" + "[^1]: normal",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn1\">\n"
-                        + "<p>inline <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>2</a></sup> <a href=\"#fnref1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn-1\">\n"
-                        + "<p>normal <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                Test ^[inline [^1]]
+
+                [^1]: normal""",
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn1" id="fnref1" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn1">
+                <p>inline <sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>2</a></sup> <a href="#fnref1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                <li id="fn-1">
+                <p>normal <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
     public void testInlineFootnoteInsideDefinition() {
         assertRenderingInline(
-                "Test [^1]\n" + "\n" + "[^1]: Definition ^[inline]\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-1\">\n"
-                        + "<p>Definition <sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\" data-footnote-ref>2</a></sup> <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn2\">\n"
-                        + "<p>inline <a href=\"#fnref2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                Test [^1]
+
+                [^1]: Definition ^[inline]
+                """,
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-1">
+                <p>Definition <sup class="footnote-ref"><a href="#fn2" id="fnref2" data-footnote-ref>2</a></sup> <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                <li id="fn2">
+                <p>inline <a href="#fnref2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
@@ -279,24 +372,30 @@ public class FootnoteHtmlRendererTest extends RenderingTestCase {
         // Tricky because of the nested inline footnote which we want to visit after foo
         // (breadth-first).
         assertRenderingInline(
-                "Test [^1]\n" + "\n" + "[^1]: Definition ^[inline ^[nested]] ^[foo]\n",
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-1\">\n"
-                        + "<p>Definition <sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\" data-footnote-ref>2</a></sup> <sup class=\"footnote-ref\"><a href=\"#fn3\" id=\"fnref3\" data-footnote-ref>3</a></sup> <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn2\">\n"
-                        + "<p>inline <sup class=\"footnote-ref\"><a href=\"#fn4\" id=\"fnref4\" data-footnote-ref>4</a></sup> <a href=\"#fnref2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn3\">\n"
-                        + "<p>foo <a href=\"#fnref3\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"3\" aria-label=\"Back to reference 3\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "<li id=\"fn4\">\n"
-                        + "<p>nested <a href=\"#fnref4\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"4\" aria-label=\"Back to reference 4\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n");
+                """
+                Test [^1]
+
+                [^1]: Definition ^[inline ^[nested]] ^[foo]
+                """,
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-1">
+                <p>Definition <sup class="footnote-ref"><a href="#fn2" id="fnref2" data-footnote-ref>2</a></sup> <sup class="footnote-ref"><a href="#fn3" id="fnref3" data-footnote-ref>3</a></sup> <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                <li id="fn2">
+                <p>inline <sup class="footnote-ref"><a href="#fn4" id="fnref4" data-footnote-ref>4</a></sup> <a href="#fnref2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+                </li>
+                <li id="fn3">
+                <p>foo <a href="#fnref3" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="3" aria-label="Back to reference 3">↩</a></p>
+                </li>
+                <li id="fn4">
+                <p>nested <a href="#fnref4" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="4" aria-label="Back to reference 4">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """);
     }
 
     @Test
@@ -314,14 +413,16 @@ public class FootnoteHtmlRendererTest extends RenderingTestCase {
         doc.appendChild(def);
 
         var expected =
-                "<p>Test <sup class=\"footnote-ref\"><a href=\"#fn-foo\" id=\"fnref-foo\" data-footnote-ref>1</a></sup></p>\n"
-                        + "<section class=\"footnotes\" data-footnotes>\n"
-                        + "<ol>\n"
-                        + "<li id=\"fn-foo\">\n"
-                        + "<p>note! <a href=\"#fnref-foo\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n"
-                        + "</li>\n"
-                        + "</ol>\n"
-                        + "</section>\n";
+                """
+                <p>Test <sup class="footnote-ref"><a href="#fn-foo" id="fnref-foo" data-footnote-ref>1</a></sup></p>
+                <section class="footnotes" data-footnotes>
+                <ol>
+                <li id="fn-foo">
+                <p>note! <a href="#fnref-foo" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+                </li>
+                </ol>
+                </section>
+                """;
         Asserts.assertRendering("", expected, RENDERER.render(doc));
     }
 

--- a/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsTest.java
+++ b/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/AlertsTest.java
@@ -59,10 +59,12 @@ public class AlertsTest extends RenderingTestCase {
 
         assertThat(renderer.render(parser.parse("> [!INFO]\n> Custom alert")))
                 .isEqualTo(
-                        "<div class=\"markdown-alert markdown-alert-info\" data-alert-type=\"info\">\n"
-                                + "<p class=\"markdown-alert-title\">Information</p>\n"
-                                + "<p>Custom alert</p>\n"
-                                + "</div>\n");
+                        """
+                        <div class="markdown-alert markdown-alert-info" data-alert-type="info">
+                        <p class="markdown-alert-title">Information</p>
+                        <p>Custom alert</p>
+                        </div>
+                        """);
     }
 
     @Test
@@ -77,23 +79,33 @@ public class AlertsTest extends RenderingTestCase {
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        assertThat(
-                        renderer.render(
-                                parser.parse(
-                                        "> [!INFO]\n> Info content\n\n> [!SUCCESS]\n> Success content\n\n> [!DANGER]\n> Danger content")))
+        var s =
+                """
+                > [!INFO]
+                > Info content
+
+                > [!SUCCESS]
+                > Success content
+
+                > [!DANGER]
+                > Danger content
+                """;
+        assertThat(renderer.render(parser.parse(s)))
                 .isEqualTo(
-                        "<div class=\"markdown-alert markdown-alert-info\" data-alert-type=\"info\">\n"
-                                + "<p class=\"markdown-alert-title\">Information</p>\n"
-                                + "<p>Info content</p>\n"
-                                + "</div>\n"
-                                + "<div class=\"markdown-alert markdown-alert-success\" data-alert-type=\"success\">\n"
-                                + "<p class=\"markdown-alert-title\">Success!</p>\n"
-                                + "<p>Success content</p>\n"
-                                + "</div>\n"
-                                + "<div class=\"markdown-alert markdown-alert-danger\" data-alert-type=\"danger\">\n"
-                                + "<p class=\"markdown-alert-title\">Danger!</p>\n"
-                                + "<p>Danger content</p>\n"
-                                + "</div>\n");
+                        """
+                        <div class="markdown-alert markdown-alert-info" data-alert-type="info">
+                        <p class="markdown-alert-title">Information</p>
+                        <p>Info content</p>
+                        </div>
+                        <div class="markdown-alert markdown-alert-success" data-alert-type="success">
+                        <p class="markdown-alert-title">Success!</p>
+                        <p>Success content</p>
+                        </div>
+                        <div class="markdown-alert markdown-alert-danger" data-alert-type="danger">
+                        <p class="markdown-alert-title">Danger!</p>
+                        <p>Danger content</p>
+                        </div>
+                        """);
     }
 
     @Test
@@ -103,12 +115,19 @@ public class AlertsTest extends RenderingTestCase {
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        assertThat(renderer.render(parser.parse("> [!NOTE]\n> Standard type")))
+        var s =
+                """
+                > [!NOTE]
+                > Standard type
+                """;
+        assertThat(renderer.render(parser.parse(s)))
                 .isEqualTo(
-                        "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                                + "<p class=\"markdown-alert-title\">Note</p>\n"
-                                + "<p>Standard type</p>\n"
-                                + "</div>\n");
+                        """
+                        <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                        <p class="markdown-alert-title">Note</p>
+                        <p>Standard type</p>
+                        </div>
+                        """);
     }
 
     @Test
@@ -118,12 +137,19 @@ public class AlertsTest extends RenderingTestCase {
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        assertThat(renderer.render(parser.parse("> [!NOTE]\n> Localized title")))
+        var s =
+                """
+                > [!NOTE]
+                > Localized title
+                """;
+        assertThat(renderer.render(parser.parse(s)))
                 .isEqualTo(
-                        "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                                + "<p class=\"markdown-alert-title\">Nota</p>\n"
-                                + "<p>Localized title</p>\n"
-                                + "</div>\n");
+                        """
+                        <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                        <p class="markdown-alert-title">Nota</p>
+                        <p>Localized title</p>
+                        </div>
+                        """);
     }
 
     // Custom type validation
@@ -162,33 +188,61 @@ public class AlertsTest extends RenderingTestCase {
         var parser = Parser.builder().extensions(Set.of(extension)).build();
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
-        assertThat(renderer.render(parser.parse("> [!NOTE]\n> Regular block quote")))
+        var s =
+                """
+                > [!NOTE]
+                > Regular block quote
+                """;
+        assertThat(renderer.render(parser.parse(s)))
                 .isEqualTo(
-                        "<blockquote>\n"
-                                + "<p>[!NOTE]\n"
-                                + "Regular block quote</p>\n"
-                                + "</blockquote>\n");
+                        """
+                        <blockquote>
+                        <p>[!NOTE]
+                        Regular block quote</p>
+                        </blockquote>
+                        """);
 
-        assertThat(renderer.render(parser.parse("> [!TIP]\n> Regular block quote")))
+        s =
+                """
+                > [!TIP]
+                > Regular block quote
+                """;
+        assertThat(renderer.render(parser.parse(s)))
                 .isEqualTo(
-                        "<blockquote>\n"
-                                + "<p>[!TIP]\n"
-                                + "Regular block quote</p>\n"
-                                + "</blockquote>\n");
+                        """
+                        <blockquote>
+                        <p>[!TIP]
+                        Regular block quote</p>
+                        </blockquote>
+                        """);
 
-        assertThat(renderer.render(parser.parse("> [!IMPORTANT]\n> Alert")))
+        s =
+                """
+                > [!IMPORTANT]
+                > Alert
+                """;
+        assertThat(renderer.render(parser.parse(s)))
                 .isEqualTo(
-                        "<div class=\"markdown-alert markdown-alert-important\" data-alert-type=\"important\">\n"
-                                + "<p class=\"markdown-alert-title\">Important</p>\n"
-                                + "<p>Alert</p>\n"
-                                + "</div>\n");
+                        """
+                        <div class="markdown-alert markdown-alert-important" data-alert-type="important">
+                        <p class="markdown-alert-title">Important</p>
+                        <p>Alert</p>
+                        </div>
+                        """);
 
-        assertThat(renderer.render(parser.parse("> [!BUG]\n> Alert")))
+        s =
+                """
+                > [!BUG]
+                > Alert
+                """;
+        assertThat(renderer.render(parser.parse(s)))
                 .isEqualTo(
-                        "<div class=\"markdown-alert markdown-alert-bug\" data-alert-type=\"bug\">\n"
-                                + "<p class=\"markdown-alert-title\">Known Bug</p>\n"
-                                + "<p>Alert</p>\n"
-                                + "</div>\n");
+                        """
+                        <div class="markdown-alert markdown-alert-bug" data-alert-type="bug">
+                        <p class="markdown-alert-title">Known Bug</p>
+                        <p>Alert</p>
+                        </div>
+                        """);
     }
 
     // Overwriting types validation
@@ -222,130 +276,198 @@ public class AlertsTest extends RenderingTestCase {
     @Test
     public void customTitle() {
         assertRenderingCustomTitles(
-                "> [!NOTE] Custom title\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom title</p>\n"
-                        + "<p>Note with a custom title</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE] Custom title
+                > Note with a custom title
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom title</p>
+                <p>Note with a custom title</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleNoSpace() {
         assertRenderingCustomTitles(
-                "> [!NOTE]Custom title\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom title</p>\n"
-                        + "<p>Note with a custom title</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE]Custom title
+                > Note with a custom title
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom title</p>
+                <p>Note with a custom title</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleExtraSpace() {
         assertRenderingCustomTitles(
-                "> [!NOTE]            Custom title  \n>    Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom title</p>\n"
-                        + "<p>Note with a custom title</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE]            Custom title \s
+                >    Note with a custom title
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom title</p>
+                <p>Note with a custom title</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleNoHardLineBreak() {
         assertRenderingCustomTitles(
-                "> [!NOTE] Custom title\\\n>    Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom title\\</p>\n"
-                        + "<p>Note with a custom title</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE] Custom title\\
+                >    Note with a custom title
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom title\\</p>
+                <p>Note with a custom title</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleWithComment() {
         assertRenderingCustomTitles(
-                "> [!NOTE] Custom title <!-- Comment -->  \n>    Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom title <!-- Comment --></p>\n"
-                        + "<p>Note with a custom title</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE] Custom title <!-- Comment --> \s
+                >    Note with a custom title
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom title <!-- Comment --></p>
+                <p>Note with a custom title</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleWithInlineFormatting() {
         assertRenderingCustomTitles(
-                "> [!NOTE] Custom _title <ins>with **formatting**</ins>_\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom <em>title <ins>with <strong>formatting</strong></ins></em></p>\n"
-                        + "<p>Note with a custom title</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE] Custom _title <ins>with **formatting**</ins>_
+                > Note with a custom title
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom <em>title <ins>with <strong>formatting</strong></ins></em></p>
+                <p>Note with a custom title</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleWithLinkAndCode() {
         assertRenderingCustomTitles(
-                "> [!IMPORTANT] See [docs](https://example.com) or `run()`\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-important\" data-alert-type=\"important\">\n"
-                        + "<p class=\"markdown-alert-title\">See <a href=\"https://example.com\">docs</a> or <code>run()</code></p>\n"
-                        + "<p>Note with a custom title</p>\n"
-                        + "</div>\n");
+                """
+                > [!IMPORTANT] See [docs](https://example.com) or `run()`
+                > Note with a custom title
+                """,
+                """
+                <div class="markdown-alert markdown-alert-important" data-alert-type="important">
+                <p class="markdown-alert-title">See <a href="https://example.com">docs</a> or <code>run()</code></p>
+                <p>Note with a custom title</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleLeadingEmptyLines() {
         assertRenderingCustomTitles(
-                ">\n>  \n> [!NOTE] Custom **title**\n> Note with a custom title",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom <strong>title</strong></p>\n"
-                        + "<p>Note with a custom title</p>\n"
-                        + "</div>\n");
+                """
+                >
+                > \s
+                > [!NOTE] Custom **title**
+                > Note with a custom title
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom <strong>title</strong></p>
+                <p>Note with a custom title</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleNoOverlappingInlines() {
         assertRenderingCustomTitles(
-                "> [!NOTE] Custom _title with **opening `delimiters\n> Note` with** closing delimiters_",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom _title with **opening `delimiters</p>\n"
-                        + "<p>Note` with** closing delimiters_</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE] Custom _title with **opening `delimiters
+                > Note` with** closing delimiters_
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom _title with **opening `delimiters</p>
+                <p>Note` with** closing delimiters_</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleIgnoresBlockContent() {
         assertRenderingCustomTitles(
-                "> [!NOTE] ## Custom title looks like an ATX heading\n>But it's not",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">## Custom title looks like an ATX heading</p>\n"
-                        + "<p>But it's not</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE] ## Custom title looks like an ATX heading
+                >But it's not
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">## Custom title looks like an ATX heading</p>
+                <p>But it's not</p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleNoBody() {
         // Alerts with no body are allowed.
         assertRenderingCustomTitles(
-                "> [!NOTE] Custom _title_\n>  \n>\n>",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom <em>title</em></p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE] Custom _title_
+                > \s
+                >
+                >
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom <em>title</em></p>
+                </div>
+                """);
     }
 
     @Test
     public void customTitleNoBodyNoSpace() {
         assertRenderingCustomTitles(
-                "> [!NOTE] Custom _title_",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom <em>title</em></p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE] Custom _title_
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom <em>title</em></p>
+                </div>
+                """);
     }
 
     @Test
     public void onlyTrailingWhitespaceIsNotCustomTitle() {
         assertRenderingCustomTitles(
-                "> [!NOTE]   \n> Body text",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Note</p>\n"
-                        + "<p>Body text</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE]  \s
+                > Body text
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Note</p>
+                <p>Body text</p>
+                </div>
+                """);
     }
 
     // Lazy continuation
@@ -353,21 +475,31 @@ public class AlertsTest extends RenderingTestCase {
     @Test
     public void noLazyContinuationAfterMarker() {
         assertRendering(
-                "> [!NOTE]\nBody text",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Note</p>\n"
-                        + "</div>\n"
-                        + "<p>Body text</p>\n");
+                """
+                > [!NOTE]
+                Body text
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Note</p>
+                </div>
+                <p>Body text</p>
+                """);
     }
 
     @Test
     public void noLazyContinuationAfterTitle() {
         assertRenderingCustomTitles(
-                "> [!NOTE] Custom title\nBody text",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Custom title</p>\n"
-                        + "</div>\n"
-                        + "<p>Body text</p>\n");
+                """
+                > [!NOTE] Custom title
+                Body text
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Custom title</p>
+                </div>
+                <p>Body text</p>
+                """);
     }
 
     // Alert markers take precedence over link reference definitions
@@ -375,32 +507,53 @@ public class AlertsTest extends RenderingTestCase {
     @Test
     public void alertTakesPrecedence() {
         assertRenderingCustomTitles(
-                "> [!NOTE]: https://example.com\n> Body text\n\n[!NOTE]",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">: https://example.com</p>\n"
-                        + "<p>Body text</p>\n"
-                        + "</div>\n"
-                        + "<p>[!NOTE]</p>\n");
+                """
+                > [!NOTE]: https://example.com
+                > Body text
+
+                [!NOTE]
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">: https://example.com</p>
+                <p>Body text</p>
+                </div>
+                <p>[!NOTE]</p>
+                """);
     }
 
     @Test
     public void alertTakesPrecedenceBefore() {
         assertRenderingCustomTitles(
-                "> [!NOTE]\n> Body text\n\n[!NOTE]: https://example.com",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Note</p>\n"
-                        + "<p>Body text</p>\n"
-                        + "</div>\n");
+                """
+                > [!NOTE]
+                > Body text
+
+                [!NOTE]: https://example.com
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Note</p>
+                <p>Body text</p>
+                </div>
+                """);
     }
 
     @Test
     public void alertTakesPrecedenceAfter() {
         assertRenderingCustomTitles(
-                "[!NOTE]: https://example.com\n\n> [!NOTE]\n> Body text",
-                "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">\n"
-                        + "<p class=\"markdown-alert-title\">Note</p>\n"
-                        + "<p>Body text</p>\n"
-                        + "</div>\n");
+                """
+                [!NOTE]: https://example.com
+
+                > [!NOTE]
+                > Body text
+                """,
+                """
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Note</p>
+                <p>Body text</p>
+                </div>
+                """);
     }
 
     // Nested alerts
@@ -408,37 +561,55 @@ public class AlertsTest extends RenderingTestCase {
     @Test
     public void noNestedAlertsByDefault() {
         assertRendering(
-                "> [!TIP]\n> Body\n\n- > [!TIP]\n   > Nested body",
-                "<div class=\"markdown-alert markdown-alert-tip\" data-alert-type=\"tip\">\n"
-                        + "<p class=\"markdown-alert-title\">Tip</p>\n"
-                        + "<p>Body</p>\n"
-                        + "</div>\n"
-                        + "<ul>\n"
-                        + "<li>\n"
-                        + "<blockquote>\n"
-                        + "<p>[!TIP]\n"
-                        + "Nested body</p>\n"
-                        + "</blockquote>\n"
-                        + "</li>\n"
-                        + "</ul>\n");
+                """
+                > [!TIP]
+                > Body
+
+                - > [!TIP]
+                   > Nested body
+                """,
+                """
+                <div class="markdown-alert markdown-alert-tip" data-alert-type="tip">
+                <p class="markdown-alert-title">Tip</p>
+                <p>Body</p>
+                </div>
+                <ul>
+                <li>
+                <blockquote>
+                <p>[!TIP]
+                Nested body</p>
+                </blockquote>
+                </li>
+                </ul>
+                """);
     }
 
     @Test
     public void noNestedAlertsByDefaultLeadingEmptyLines() {
         assertRendering(
-                ">\n>   \n> [!TIP]\n> Body\n\n- > [!TIP]\n   > Nested body",
-                "<div class=\"markdown-alert markdown-alert-tip\" data-alert-type=\"tip\">\n"
-                        + "<p class=\"markdown-alert-title\">Tip</p>\n"
-                        + "<p>Body</p>\n"
-                        + "</div>\n"
-                        + "<ul>\n"
-                        + "<li>\n"
-                        + "<blockquote>\n"
-                        + "<p>[!TIP]\n"
-                        + "Nested body</p>\n"
-                        + "</blockquote>\n"
-                        + "</li>\n"
-                        + "</ul>\n");
+                """
+                >
+                >  \s
+                > [!TIP]
+                > Body
+
+                - > [!TIP]
+                   > Nested body
+                """,
+                """
+                <div class="markdown-alert markdown-alert-tip" data-alert-type="tip">
+                <p class="markdown-alert-title">Tip</p>
+                <p>Body</p>
+                </div>
+                <ul>
+                <li>
+                <blockquote>
+                <p>[!TIP]
+                Nested body</p>
+                </blockquote>
+                </li>
+                </ul>
+                """);
     }
 
     @Test
@@ -448,50 +619,49 @@ public class AlertsTest extends RenderingTestCase {
         var renderer = HtmlRenderer.builder().extensions(Set.of(extension)).build();
 
         var source =
-                String.join(
-                        "\n",
-                        "> [!TIP]",
-                        "> Tip body",
-                        "> > [!IMPORTANT]",
-                        "> > Important body",
-                        "",
-                        "- > [!NOTE]",
-                        "  > Nested body",
-                        "  >",
-                        "  > 1. Ordered list body",
-                        "  >",
-                        "  >    > [!CAUTION]",
-                        "  >    >",
-                        "  >    > Deeply nested body");
-        var expected =
-                String.join(
-                        "\n",
-                        "<div class=\"markdown-alert markdown-alert-tip\" data-alert-type=\"tip\">",
-                        "<p class=\"markdown-alert-title\">Tip</p>",
-                        "<p>Tip body</p>",
-                        "<div class=\"markdown-alert markdown-alert-important\" data-alert-type=\"important\">",
-                        "<p class=\"markdown-alert-title\">Important</p>",
-                        "<p>Important body</p>",
-                        "</div>",
-                        "</div>",
-                        "<ul>",
-                        "<li>",
-                        "<div class=\"markdown-alert markdown-alert-note\" data-alert-type=\"note\">",
-                        "<p class=\"markdown-alert-title\">Note</p>",
-                        "<p>Nested body</p>",
-                        "<ol>",
-                        "<li>",
-                        "<p>Ordered list body</p>",
-                        "<div class=\"markdown-alert markdown-alert-caution\" data-alert-type=\"caution\">",
-                        "<p class=\"markdown-alert-title\">Caution</p>",
-                        "<p>Deeply nested body</p>",
-                        "</div>",
-                        "</li>",
-                        "</ol>",
-                        "</div>",
-                        "</li>",
-                        "</ul>\n");
+                """
+                > [!TIP]
+                > Tip body
+                > > [!IMPORTANT]
+                > > Important body
 
+                - > [!NOTE]
+                  > Nested body
+                  >
+                  > 1. Ordered list body
+                  >
+                  >    > [!CAUTION]
+                  >    >
+                  >    > Deeply nested body
+                  """;
+        var expected =
+                """
+                <div class="markdown-alert markdown-alert-tip" data-alert-type="tip">
+                <p class="markdown-alert-title">Tip</p>
+                <p>Tip body</p>
+                <div class="markdown-alert markdown-alert-important" data-alert-type="important">
+                <p class="markdown-alert-title">Important</p>
+                <p>Important body</p>
+                </div>
+                </div>
+                <ul>
+                <li>
+                <div class="markdown-alert markdown-alert-note" data-alert-type="note">
+                <p class="markdown-alert-title">Note</p>
+                <p>Nested body</p>
+                <ol>
+                <li>
+                <p>Ordered list body</p>
+                <div class="markdown-alert markdown-alert-caution" data-alert-type="caution">
+                <p class="markdown-alert-title">Caution</p>
+                <p>Deeply nested body</p>
+                </div>
+                </li>
+                </ol>
+                </div>
+                </li>
+                </ul>
+                """;
         assertThat(renderer.render(parser.parse(source))).isEqualTo(expected);
     }
 
@@ -499,7 +669,12 @@ public class AlertsTest extends RenderingTestCase {
 
     @Test
     public void alertParsedAsAlertNode() {
-        var document = PARSER.parse("> [!NOTE]\n> This is a note");
+        var document =
+                PARSER.parse(
+                        """
+                        > [!NOTE]
+                        > This is a note
+                        """);
         var firstChild = document.getFirstChild();
         assertThat(firstChild).isInstanceOf(Alert.class);
         var alert = (Alert) firstChild;
@@ -522,7 +697,11 @@ public class AlertsTest extends RenderingTestCase {
 
     @Test
     public void titleSourcePositionPreserved() {
-        var source = "> [!NOTE] Custom title\n> Body text";
+        var source =
+                """
+                > [!NOTE] Custom title
+                > Body text
+                """;
         var document = PARSER_CUSTOM_TITLES.parse(source);
         var alert = (Alert) document.getFirstChild();
         var title = (AlertTitle) alert.getFirstChild();
@@ -533,7 +712,15 @@ public class AlertsTest extends RenderingTestCase {
 
     @Test
     public void titleSourcePositionPreservedBetweenBlocks() {
-        var source = "- List\n\n> [!NOTE] Custom title\n> Body text\n\nPlain paragraph";
+        var source =
+                """
+                - List
+
+                > [!NOTE] Custom title
+                > Body text
+
+                Plain paragraph
+                """;
         var document = PARSER_CUSTOM_TITLES.parse(source);
         var alert = (Alert) document.getFirstChild().getNext();
         var title = (AlertTitle) alert.getFirstChild();
@@ -544,7 +731,11 @@ public class AlertsTest extends RenderingTestCase {
 
     @Test
     public void titleSourcePositionWithLeadingAndTrailingSpaces() {
-        var source = "> [!NOTE]    Custom title   \n> Body text";
+        var source =
+                """
+                > [!NOTE]    Custom title  \s
+                > Body text
+                """;
         var document = PARSER_CUSTOM_TITLES.parse(source);
         var alert = (Alert) document.getFirstChild();
         var title = (AlertTitle) alert.getFirstChild();
@@ -555,7 +746,11 @@ public class AlertsTest extends RenderingTestCase {
 
     @Test
     public void titleWithInlineFormattingSourcePosition() {
-        var source = "> [!NOTE] Custom _title_\n> Body text";
+        var source =
+                """
+                > [!NOTE] Custom _title_
+                > Body text
+                """;
         var document = PARSER_CUSTOM_TITLES.parse(source);
         var alert = (Alert) document.getFirstChild();
         var title = (AlertTitle) alert.getFirstChild();
@@ -583,7 +778,11 @@ public class AlertsTest extends RenderingTestCase {
 
     @Test
     public void titleWithNestedInlineFormattingSourcePosition() {
-        var source = "> [!NOTE] Text with **bold _and italic_**\n> Body text";
+        var source =
+                """
+                > [!NOTE] Text with **bold _and italic_**
+                > Body text
+                """;
         var document = PARSER_CUSTOM_TITLES.parse(source);
         var alert = (Alert) document.getFirstChild();
         var title = (AlertTitle) alert.getFirstChild();

--- a/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/examples/AlertsExample.java
+++ b/commonmark-ext-gfm-alerts/src/test/java/org/commonmark/ext/gfm/alerts/examples/AlertsExample.java
@@ -25,17 +25,24 @@ public class AlertsExample {
         var renderer = HtmlRenderer.builder().extensions(List.of(extension)).build();
 
         var markdown =
-                "# GFM Alerts Demo\n\n"
-                        + "> [!NOTE]\n"
-                        + "> Highlights information that users should take into account.\n\n"
-                        + "> [!TIP]\n"
-                        + "> Helpful advice for doing things better.\n\n"
-                        + "> [!IMPORTANT]\n"
-                        + "> Key information users need to know.\n\n"
-                        + "> [!WARNING]\n"
-                        + "> Urgent info that needs immediate attention.\n\n"
-                        + "> [!CAUTION]\n"
-                        + "> Advises about risks or negative outcomes.\n";
+                """
+                # GFM Alerts Demo
+
+                > [!NOTE]
+                > Highlights information that users should take into account.
+
+                > [!TIP]
+                > Helpful advice for doing things better.
+
+                > [!IMPORTANT]
+                > Key information users need to know.
+
+                > [!WARNING]
+                > Urgent info that needs immediate attention.
+
+                > [!CAUTION]
+                > Advises about risks or negative outcomes.
+                """;
 
         var html = renderer.render(parser.parse(markdown));
 
@@ -56,13 +63,18 @@ public class AlertsExample {
         var renderer = HtmlRenderer.builder().extensions(List.of(extension)).build();
 
         var markdown =
-                "# Custom Alert Types\n\n"
-                        + "> [!NOTE]\n"
-                        + "> Useful information that users should know.\n\n"
-                        + "> [!TIP]\n"
-                        + "> Helpful advice for doing things better.\n\n"
-                        + "> [!BUG]\n"
-                        + "> This feature has a known issue with large files (see #42).\n";
+                """
+                # Custom Alert Types
+
+                > [!NOTE]
+                > Useful information that users should know.
+
+                > [!TIP]
+                > Helpful advice for doing things better.
+
+                > [!BUG]
+                > This feature has a known issue with large files (see #42).
+                """;
 
         var html = renderer.render(parser.parse(markdown));
 

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -30,238 +30,405 @@ public class TablesTest extends RenderingTestCase {
     @Test
     public void separatorMustBeOneOrMore() {
         assertRendering(
-                "Abc|Def\n-|-",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                -|-
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                </table>
+                """);
         assertRendering(
-                "Abc|Def\n--|--",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                --|--
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                </table>
+                """);
     }
 
     @Test
     public void separatorMustNotContainInvalidChars() {
-        assertRendering("Abc|Def\n |-a-|---", "<p>Abc|Def\n|-a-|---</p>\n");
-        assertRendering("Abc|Def\n |:--a|---", "<p>Abc|Def\n|:--a|---</p>\n");
-        assertRendering("Abc|Def\n |:--a--:|---", "<p>Abc|Def\n|:--a--:|---</p>\n");
+        assertRendering(
+                """
+                Abc|Def
+                |-a-|---
+                """,
+                """
+                <p>Abc|Def
+                |-a-|---</p>
+                """);
+        assertRendering(
+                """
+                Abc|Def
+                |:--a|---
+                """,
+                """
+                <p>Abc|Def
+                |:--a|---</p>
+                """);
+        assertRendering(
+                """
+                Abc|Def
+                |:--a--:|---
+                """,
+                """
+                <p>Abc|Def
+                |:--a--:|---</p>
+                """);
     }
 
     @Test
     public void separatorCanHaveLeadingSpaceThenPipe() {
         assertRendering(
-                "Abc|Def\n |---|---",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                 |---|---
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                </table>
+                """);
     }
 
     @Test
     public void separatorCanNotHaveAdjacentPipes() {
-        assertRendering("Abc|Def\n---||---", "<p>Abc|Def\n---||---</p>\n");
+        assertRendering(
+                """
+                Abc|Def
+                ---||---
+                """,
+                """
+                <p>Abc|Def
+                ---||---</p>
+                """);
     }
 
     @Test
     public void separatorNeedsPipes() {
-        assertRendering("Abc|Def\n|--- ---", "<p>Abc|Def\n|--- ---</p>\n");
+        assertRendering(
+                """
+                Abc|Def
+                |--- ---
+                """,
+                """
+                <p>Abc|Def
+                |--- ---</p>
+                """);
     }
 
     @Test
     public void oneHeadNoBody() {
         assertRendering(
-                "Abc|Def\n---|---",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|---
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                </table>
+                """);
     }
 
     @Test
     public void oneColumnOneHeadNoBody() {
         String expected =
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "</table>\n";
-        assertRendering("|Abc\n|---\n", expected);
-        assertRendering("|Abc|\n|---|\n", expected);
-        assertRendering("Abc|\n---|\n", expected);
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                </tr>
+                </thead>
+                </table>
+                """;
+        assertRendering(
+                """
+                |Abc
+                |---
+                """,
+                expected);
+        assertRendering(
+                """
+                |Abc|
+                |---|
+                """,
+                expected);
+        assertRendering(
+                """
+                Abc|
+                ---|
+                """,
+                expected);
 
         // Pipe required on separator
-        assertRendering("|Abc\n---\n", "<h2>|Abc</h2>\n");
+        assertRendering(
+                """
+                |Abc
+                ---
+                """,
+                """
+                <h2>|Abc</h2>
+                """);
         // Pipe required on head
-        assertRendering("Abc\n|---\n", "<p>Abc\n|---</p>\n");
+        assertRendering(
+                """
+                Abc
+                |---
+                """,
+                """
+                <p>Abc
+                |---</p>
+                """);
     }
 
     @Test
     public void oneColumnOneHeadOneBody() {
         String expected =
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n";
-        assertRendering("|Abc\n|---\n|1", expected);
-        assertRendering("|Abc|\n|---|\n|1|", expected);
-        assertRendering("Abc|\n---|\n1|", expected);
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                </tr>
+                </tbody>
+                </table>
+                """;
+        assertRendering(
+                """
+                |Abc
+                |---
+                |1
+                """,
+                expected);
+        assertRendering(
+                """
+                |Abc|
+                |---|
+                |1|
+                """,
+                expected);
+        assertRendering(
+                """
+                Abc|
+                ---|
+                1|
+                """,
+                expected);
 
         // Pipe required on separator
-        assertRendering("|Abc\n---\n|1", "<h2>|Abc</h2>\n<p>|1</p>\n");
+        assertRendering(
+                """
+                |Abc
+                ---
+                |1
+                """,
+                """
+                <h2>|Abc</h2>
+                <p>|1</p>
+                """);
     }
 
     @Test
     public void oneHeadOneBody() {
         assertRendering(
-                "Abc|Def\n---|---\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|---
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void spaceBeforeSeparator() {
         assertRendering(
-                "  |Abc|Def|\n  |---|---|\n  |1|2|",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                |Abc|Def|
+                |---|---|
+                |1|2|
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void separatorMustNotHaveLessPartsThanHead() {
-        assertRendering("Abc|Def|Ghi\n---|---\n1|2|3", "<p>Abc|Def|Ghi\n---|---\n1|2|3</p>\n");
+        assertRendering(
+                """
+                Abc|Def|Ghi
+                ---|---
+                1|2|3
+                """,
+                """
+                <p>Abc|Def|Ghi
+                ---|---
+                1|2|3</p>
+                """);
     }
 
     @Test
     public void padding() {
         assertRendering(
-                " Abc  | Def \n --- | --- \n 1 | 2 ",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                 Abc  | Def\s
+                 --- | ---\s
+                 1 | 2\s
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void paddingWithCodeBlockIndentation() {
         assertRendering(
-                "Abc|Def\n---|---\n    1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|---
+                    1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void pipesOnOutside() {
         assertRendering(
-                "|Abc|Def|\n|---|---|\n|1|2|",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                |Abc|Def|
+                |---|---|
+                |1|2|
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void pipesOnOutsideWhitespaceAfterHeader() {
         assertRendering(
-                "|Abc|Def| \n|---|---|\n|1|2|",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                |Abc|Def|\s
+                |---|---|
+                |1|2|
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
@@ -269,63 +436,81 @@ public class TablesTest extends RenderingTestCase {
         // This is literally what someone has done IRL - it helped to expose
         // an issue with parsing the last header cell correctly
         assertRendering(
-                "||center header||\n" + "-|-------------|-\n" + "1|      2      |3",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th></th>\n"
-                        + "<th>center header</th>\n"
-                        + "<th></th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "<td>3</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                ||center header||
+                -|-------------|-
+                1|      2      |3
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th></th>
+                <th>center header</th>
+                <th></th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                <td>3</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void inlineElements() {
         assertRendering(
-                "*Abc*|Def\n---|---\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th><em>Abc</em></th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                *Abc*|Def
+                ---|---
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th><em>Abc</em></th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void escapedPipe() {
         assertRendering(
-                "Abc|Def\n---|---\n1\\|2|20",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1|2</td>\n"
-                        + "<td>20</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|---
+                1\\|2|20
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1|2</td>
+                <td>20</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
@@ -334,21 +519,27 @@ public class TablesTest extends RenderingTestCase {
         // followed by a pipe (so two cells). Instead, the `\|` is parsed as an escaped pipe first,
         // so just a single cell. The inline parser then gets `1\|2` which renders as `1|2`.
         assertRendering(
-                "Abc|Def\n---|---\n1\\\\|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1|2</td>\n"
-                        + "<td></td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|---
+                1\\\\|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1|2</td>
+                <td></td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
@@ -357,421 +548,580 @@ public class TablesTest extends RenderingTestCase {
         // table, otherwise inline parsing is wrong. So we have to be careful where we do/don't
         // consume the backslash.
         assertRendering(
-                "Abc|Def\n---|---\n1|\\`not code`",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>`not code`</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|---
+                1|\\`not code`
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>`not code`</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void backslashAtEnd() {
         assertRendering(
-                "Abc|Def\n---|---\n1|2\\",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2\\</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|---
+                1|2\\
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2\\</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void alignLeft() {
         assertRendering(
-                "Abc|Def\n:-|-\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"left\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"left\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                :-|-
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="left">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="left">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
         assertRendering(
-                "Abc|Def\n:-|-\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"left\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"left\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                :-|-
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="left">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="left">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
         assertRendering(
-                "Abc|Def\n:---|---\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"left\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"left\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                :---|---
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="left">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="left">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void alignRight() {
         assertRendering(
-                "Abc|Def\n-:|-\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"right\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"right\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                -:|-
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="right">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="right">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
         assertRendering(
-                "Abc|Def\n--:|--\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"right\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"right\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                --:|--
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="right">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="right">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
         assertRendering(
-                "Abc|Def\n---:|---\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"right\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"right\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---:|---
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="right">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="right">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void alignCenter() {
         assertRendering(
-                "Abc|Def\n:-:|-\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"center\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"center\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                :-:|-
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="center">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="center">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
         assertRendering(
-                "Abc|Def\n:--:|--\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"center\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"center\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                :--:|--
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="center">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="center">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
         assertRendering(
-                "Abc|Def\n:---:|---\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"center\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"center\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                :---:|---
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="center">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="center">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void alignCenterSecond() {
         assertRendering(
-                "Abc|Def\n---|:---:\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th align=\"center\">Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td align=\"center\">2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|:---:
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th align="center">Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td align="center">2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void alignLeftWithSpaces() {
         assertRendering(
-                "Abc|Def\n :--- |---\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"left\">Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"left\">1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                 :--- |---
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="left">Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="left">1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void alignmentMarkerMustBeNextToDashes() {
-        assertRendering("Abc|Def\n: ---|---", "<p>Abc|Def\n: ---|---</p>\n");
-        assertRendering("Abc|Def\n--- :|---", "<p>Abc|Def\n--- :|---</p>\n");
-        assertRendering("Abc|Def\n---|: ---", "<p>Abc|Def\n---|: ---</p>\n");
-        assertRendering("Abc|Def\n---|--- :", "<p>Abc|Def\n---|--- :</p>\n");
+        assertRendering(
+                """
+                Abc|Def
+                : ---|---
+                """,
+                """
+                <p>Abc|Def
+                : ---|---</p>
+                """);
+        assertRendering(
+                """
+                Abc|Def
+                --- :|---
+                """,
+                """
+                <p>Abc|Def
+                --- :|---</p>
+                """);
+        assertRendering(
+                """
+                Abc|Def
+                ---|: ---
+                """,
+                """
+                <p>Abc|Def
+                ---|: ---</p>
+                """);
+        assertRendering(
+                """
+                Abc|Def
+                ---|--- :
+                """,
+                """
+                <p>Abc|Def
+                ---|--- :</p>
+                """);
     }
 
     @Test
     public void bodyCanNotHaveMoreColumnsThanHead() {
         assertRendering(
-                "Abc|Def\n---|---\n1|2|3",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|---
+                1|2|3
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void bodyWithFewerColumnsThanHeadResultsInEmptyCells() {
         assertRendering(
-                "Abc|Def|Ghi\n---|---|---\n1|2",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "<th>Ghi</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "<td></td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def|Ghi
+                ---|---|---
+                1|2
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                <th>Ghi</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                <td></td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void insideBlockQuote() {
         assertRendering(
-                "> Abc|Def\n> ---|---\n> 1|2",
-                "<blockquote>\n"
-                        + "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n"
-                        + "</blockquote>\n");
+                """
+                > Abc|Def
+                > ---|---
+                > 1|2
+                """,
+                """
+                <blockquote>
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                </blockquote>
+                """);
     }
 
     @Test
     public void tableWithLazyContinuationLine() {
         assertRendering(
-                "Abc|Def\n---|---\n1|2\nlazy",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "<tr>\n"
-                        + "<td>lazy</td>\n"
-                        + "<td></td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                Abc|Def
+                ---|---
+                1|2
+                lazy
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                <tr>
+                <td>lazy</td>
+                <td></td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void issue142() {
         assertRendering(
-                "||Alveolar|Bilabial\n"
-                        + "|:--|:-:|:-:\n"
-                        + "|**Plosive**|t, d|b\n"
-                        + "|**Tap**|ɾ|",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th align=\"left\"></th>\n"
-                        + "<th align=\"center\">Alveolar</th>\n"
-                        + "<th align=\"center\">Bilabial</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td align=\"left\"><strong>Plosive</strong></td>\n"
-                        + "<td align=\"center\">t, d</td>\n"
-                        + "<td align=\"center\">b</td>\n"
-                        + "</tr>\n"
-                        + "<tr>\n"
-                        + "<td align=\"left\"><strong>Tap</strong></td>\n"
-                        + "<td align=\"center\">ɾ</td>\n"
-                        + "<td align=\"center\"></td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                ||Alveolar|Bilabial
+                |:--|:-:|:-:
+                |**Plosive**|t, d|b
+                |**Tap**|ɾ|""",
+                """
+                <table>
+                <thead>
+                <tr>
+                <th align="left"></th>
+                <th align="center">Alveolar</th>
+                <th align="center">Bilabial</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td align="left"><strong>Plosive</strong></td>
+                <td align="center">t, d</td>
+                <td align="center">b</td>
+                </tr>
+                <tr>
+                <td align="left"><strong>Tap</strong></td>
+                <td align="center">ɾ</td>
+                <td align="center"></td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
     public void danglingPipe() {
         assertRendering(
-                "Abc|Def\n" + "---|---\n" + "1|2\n" + "|",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n"
-                        + "<p>|</p>\n");
+                """
+                Abc|Def
+                ---|---
+                1|2
+                |
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                <p>|</p>
+                """);
 
         assertRendering(
-                "Abc|Def\n" + "---|---\n" + "1|2\n" + "  |  ",
-                "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>Abc</th>\n"
-                        + "<th>Def</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>1</td>\n"
-                        + "<td>2</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n"
-                        + "<p>|</p>\n");
+                """
+                Abc|Def
+                ---|---
+                1|2
+                  | \s
+                """,
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>Abc</th>
+                <th>Def</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>1</td>
+                <td>2</td>
+                </tr>
+                </tbody>
+                </table>
+                <p>|</p>
+                """);
     }
 
     @Test
     public void interruptsParagraph() {
         assertRendering(
-                "text\n" + "|a  |\n" + "|---|\n" + "|b  |",
-                "<p>text</p>\n"
-                        + "<table>\n"
-                        + "<thead>\n"
-                        + "<tr>\n"
-                        + "<th>a</th>\n"
-                        + "</tr>\n"
-                        + "</thead>\n"
-                        + "<tbody>\n"
-                        + "<tr>\n"
-                        + "<td>b</td>\n"
-                        + "</tr>\n"
-                        + "</tbody>\n"
-                        + "</table>\n");
+                """
+                text
+                |a  |
+                |---|
+                |b  |
+                """,
+                """
+                <p>text</p>
+                <table>
+                <thead>
+                <tr>
+                <th>a</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td>b</td>
+                </tr>
+                </tbody>
+                </table>
+                """);
     }
 
     @Test
@@ -799,20 +1149,22 @@ public class TablesTest extends RenderingTestCase {
         String rendered = renderer.render(PARSER.parse("Abc|Def\n---|---\n1|2"));
         assertThat(rendered)
                 .isEqualTo(
-                        "<table test=\"block\">\n"
-                                + "<thead test=\"head\">\n"
-                                + "<tr test=\"row\">\n"
-                                + "<th test=\"cell\">Abc</th>\n"
-                                + "<th test=\"cell\">Def</th>\n"
-                                + "</tr>\n"
-                                + "</thead>\n"
-                                + "<tbody test=\"body\">\n"
-                                + "<tr test=\"row\">\n"
-                                + "<td test=\"cell\">1</td>\n"
-                                + "<td test=\"cell\">2</td>\n"
-                                + "</tr>\n"
-                                + "</tbody>\n"
-                                + "</table>\n");
+                        """
+                        <table test="block">
+                        <thead test="head">
+                        <tr test="row">
+                        <th test="cell">Abc</th>
+                        <th test="cell">Def</th>
+                        </tr>
+                        </thead>
+                        <tbody test="body">
+                        <tr test="row">
+                        <td test="cell">1</td>
+                        <td test="cell">2</td>
+                        </tr>
+                        </tbody>
+                        </table>
+                        """);
     }
 
     @Test
@@ -832,20 +1184,22 @@ public class TablesTest extends RenderingTestCase {
         String rendered = renderer.render(PARSER.parse("Abc|Def\n-----|---\n1|2"));
         assertThat(rendered)
                 .isEqualTo(
-                        "<table>\n"
-                                + "<thead>\n"
-                                + "<tr>\n"
-                                + "<th width=\"5em\">Abc</th>\n"
-                                + "<th width=\"3em\">Def</th>\n"
-                                + "</tr>\n"
-                                + "</thead>\n"
-                                + "<tbody>\n"
-                                + "<tr>\n"
-                                + "<td>1</td>\n"
-                                + "<td>2</td>\n"
-                                + "</tr>\n"
-                                + "</tbody>\n"
-                                + "</table>\n");
+                        """
+                        <table>
+                        <thead>
+                        <tr>
+                        <th width="5em">Abc</th>
+                        <th width="3em">Def</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                        <td>1</td>
+                        <td>2</td>
+                        </tr>
+                        </tbody>
+                        </table>
+                        """);
     }
 
     @Test
@@ -937,7 +1291,15 @@ public class TablesTest extends RenderingTestCase {
                         .extensions(EXTENSIONS)
                         .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
                         .build();
-        var document = parser.parse("a\n" + "bc\n" + "|de|\n" + "|---|\n" + "|fg|");
+        var document =
+                parser.parse(
+                        """
+                        a
+                        bc
+                        |de|
+                        |---|
+                        |fg|
+                        """);
 
         var paragraph = (Paragraph) document.getFirstChild();
         var text = (Text) paragraph.getFirstChild();

--- a/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorTest.java
+++ b/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorTest.java
@@ -16,55 +16,96 @@ public class HeadingAnchorTest extends RenderingTestCase {
 
     @Test
     public void baseCaseSingleHeader() {
-        assertRendering("# Heading here\n", "<h1 id=\"heading-here\">Heading here</h1>\n");
+        assertRendering(
+                """
+                # Heading here
+                """,
+                """
+                <h1 id="heading-here">Heading here</h1>
+                """);
     }
 
     @Test
     public void singleHeaderWithCodeBlock() {
         assertRendering(
-                "Hi there\n# Heading `here`\n",
-                "<p>Hi there</p>\n<h1 id=\"heading-here\">Heading <code>here</code></h1>\n");
+                """
+                Hi there
+                # Heading `here`
+                """,
+                """
+                <p>Hi there</p>
+                <h1 id="heading-here">Heading <code>here</code></h1>
+                """);
     }
 
     @Test
     public void duplicateHeadersMakeUniqueIds() {
         assertRendering(
-                "# Heading here\n# Heading here",
-                "<h1 id=\"heading-here\">Heading here</h1>\n<h1 id=\"heading-here-1\">Heading here</h1>\n");
+                """
+                # Heading here
+                # Heading here
+                """,
+                """
+                <h1 id="heading-here">Heading here</h1>
+                <h1 id="heading-here-1">Heading here</h1>
+                """);
     }
 
     @Test
     public void testSupplementalDiacriticalMarks() {
-        assertRendering("# a\u1DC0", "<h1 id=\"a\u1DC0\">a\u1DC0</h1>\n");
+        assertRendering(
+                "# a\u1DC0",
+                """
+                <h1 id="a\u1DC0">a\u1DC0</h1>
+                """);
     }
 
     @Test
     public void testUndertieUnicodeDisplayed() {
-        assertRendering("# undertie \u203F", "<h1 id=\"undertie-\u203F\">undertie \u203F</h1>\n");
+        assertRendering(
+                "# undertie \u203F",
+                """
+                <h1 id="undertie-\u203F">undertie \u203F</h1>
+                """);
     }
 
     @Test
     public void testExplicitHeaderCollision() {
         assertRendering(
-                "# Header\n# Header\n# Header-1",
-                "<h1 id=\"header\">Header</h1>\n"
-                        + "<h1 id=\"header-1\">Header</h1>\n"
-                        + "<h1 id=\"header-1\">Header-1</h1>\n");
+                """
+                # Header
+                # Header
+                # Header-1
+                """,
+                """
+                <h1 id="header">Header</h1>
+                <h1 id="header-1">Header</h1>
+                <h1 id="header-1">Header-1</h1>
+                """);
     }
 
     @Test
     public void testCaseIsIgnoredWhenComparingIds() {
         assertRendering(
-                "# HEADING here\n" + "# heading here",
-                "<h1 id=\"heading-here\">HEADING here</h1>\n"
-                        + "<h1 id=\"heading-here-1\">heading here</h1>\n");
+                """
+                # HEADING here
+                # heading here
+                """,
+                """
+                <h1 id="heading-here">HEADING here</h1>
+                <h1 id="heading-here-1">heading here</h1>
+                """);
     }
 
     @Test
     public void testNestedBlocks() {
         assertRendering(
-                "## `h` `e` **l** *l* o",
-                "<h2 id=\"h-e-l-l-o\"><code>h</code> <code>e</code> <strong>l</strong> <em>l</em> o</h2>\n");
+                """
+                ## `h` `e` **l** *l* o
+                """,
+                """
+                <h2 id="h-e-l-l-o"><code>h</code> <code>e</code> <strong>l</strong> <em>l</em> o</h2>
+                """);
     }
 
     @Test
@@ -77,25 +118,45 @@ public class HeadingAnchorTest extends RenderingTestCase {
     @Test
     public void testStrongEmphasis() {
         assertRendering(
-                "# _**Hi there**_",
-                "<h1 id=\"hi-there\"><em><strong>Hi there</strong></em></h1>\n");
+                """
+                # _**Hi there**_
+                """,
+                """
+                <h1 id="hi-there"><em><strong>Hi there</strong></em></h1>
+                """);
     }
 
     @Test
     public void testMultipleSpacesKept() {
-        assertRendering("# Hi  There", "<h1 id=\"hi--there\">Hi  There</h1>\n");
+        assertRendering(
+                """
+                # Hi  There
+                """,
+                """
+                <h1 id="hi--there">Hi  There</h1>
+                """);
     }
 
     @Test
     public void testNonAsciiCharacterHeading() {
-        assertRendering("# bär", "<h1 id=\"bär\">bär</h1>\n");
+        assertRendering(
+                """
+                # bär
+                """,
+                """
+                <h1 id="bär">bär</h1>
+                """);
     }
 
     @Test
     public void testCombiningDiaeresis() {
         assertRendering(
-                "# Product\u036D\u036B",
-                "<h1 id=\"product\u036D\u036B\">Product\u036D\u036B</h1>\n");
+                """
+                # Product\u036D\u036B
+                """,
+                """
+                <h1 id="product\u036D\u036B">Product\u036D\u036B</h1>
+                """);
     }
 
     @Override

--- a/commonmark-ext-task-list-items/src/test/java/org/commonmark/ext/task/list/items/TaskListItemsTest.java
+++ b/commonmark-ext-task-list-items/src/test/java/org/commonmark/ext/task/list/items/TaskListItemsTest.java
@@ -20,110 +20,253 @@ public class TaskListItemsTest extends RenderingTestCase {
     @Test
     public void baseCase() {
         assertRendering(
-                "- [x] this is *done*\n",
-                "<ul>\n<li>" + HTML_CHECKED + " this is <em>done</em></li>\n</ul>\n");
+                """
+                - [x] this is *done*
+                """,
+                """
+                <ul>
+                <li>%s this is <em>done</em></li>
+                </ul>
+                """
+                        .formatted(HTML_CHECKED));
 
         assertRendering(
-                "- [ ] do this\n", "<ul>\n<li>" + HTML_UNCHECKED + " do this</li>\n</ul>\n");
+                """
+                - [ ] do this
+                """,
+                """
+                <ul>
+                <li>%s do this</li>
+                </ul>
+                """
+                        .formatted(HTML_UNCHECKED));
 
         assertRendering(
-                "- [x] foo\n" + "  - [ ] bar\n" + "  - [x] baz\n" + "- [ ] bim",
-                "<ul>\n"
-                        + "<li>"
-                        + HTML_CHECKED
-                        + " foo\n"
-                        + "<ul>\n"
-                        + "<li>"
-                        + HTML_UNCHECKED
-                        + " bar</li>\n"
-                        + "<li>"
-                        + HTML_CHECKED
-                        + " baz</li>\n"
-                        + "</ul>\n"
-                        + "</li>\n"
-                        + "<li>"
-                        + HTML_UNCHECKED
-                        + " bim</li>\n"
-                        + "</ul>\n");
+                """
+                - [x] foo
+                  - [ ] bar
+                  - [x] baz
+                - [ ] bim
+                """,
+                """
+                <ul>
+                <li>%s foo
+                <ul>
+                <li>%s bar</li>
+                <li>%s baz</li>
+                </ul>
+                </li>
+                <li>%s bim</li>
+                </ul>
+                """
+                        .formatted(HTML_CHECKED, HTML_UNCHECKED, HTML_CHECKED, HTML_UNCHECKED));
 
         assertRendering(
-                "*   [ ]   do this\n*   [ ]   and this",
-                "<ul>\n<li>"
-                        + HTML_UNCHECKED
-                        + " do this</li>\n<li>"
-                        + HTML_UNCHECKED
-                        + " and this</li>\n</ul>\n");
+                """
+                *   [ ]   do this
+                *   [ ]   and this
+                """,
+                """
+                <ul>
+                <li>%s do this</li>
+                <li>%s and this</li>
+                </ul>
+                """
+                        .formatted(HTML_UNCHECKED, HTML_UNCHECKED));
 
         assertRendering(
-                "+ [x] one\n" + "  - [ ] two\n" + "    * [x] three\n",
-                "<ul>\n"
-                        + "<li>"
-                        + HTML_CHECKED
-                        + " one\n"
-                        + "<ul>\n"
-                        + "<li>"
-                        + HTML_UNCHECKED
-                        + " two\n"
-                        + "<ul>\n"
-                        + "<li>"
-                        + HTML_CHECKED
-                        + " three</li>\n"
-                        + "</ul>\n"
-                        + "</li>\n"
-                        + "</ul>\n"
-                        + "</li>\n"
-                        + "</ul>\n");
+                """
+                + [x] one
+                  - [ ] two
+                    * [x] three
+                """,
+                """
+                <ul>
+                <li>%s one
+                <ul>
+                <li>%s two
+                <ul>
+                <li>%s three</li>
+                </ul>
+                </li>
+                </ul>
+                </li>
+                </ul>
+                """
+                        .formatted(HTML_CHECKED, HTML_UNCHECKED, HTML_CHECKED));
 
         assertRendering(
-                "TODO list\n"
-                        + "---------\n"
-                        + "- [ ] first task\n"
-                        + "- [x] second task\n"
-                        + "- [ ] third task\n\n"
-                        + "Let me know when you are finished",
-                "<h2>TODO list</h2>\n"
-                        + "<ul>\n"
-                        + "<li>"
-                        + HTML_UNCHECKED
-                        + " first task</li>\n"
-                        + "<li>"
-                        + HTML_CHECKED
-                        + " second task</li>\n"
-                        + "<li>"
-                        + HTML_UNCHECKED
-                        + " third task</li>\n"
-                        + "</ul>\n"
-                        + "<p>Let me know when you are finished</p>\n");
+                """
+                TODO list
+                ---------
+                - [ ] first task
+                - [x] second task
+                - [ ] third task
+
+                Let me know when you are finished
+                """,
+                """
+                <h2>TODO list</h2>
+                <ul>
+                <li>%s first task</li>
+                <li>%s second task</li>
+                <li>%s third task</li>
+                </ul>
+                <p>Let me know when you are finished</p>
+                """
+                        .formatted(HTML_UNCHECKED, HTML_CHECKED, HTML_UNCHECKED));
     }
 
     @Test
     public void notListItem() {
-        assertRendering("[x] this is not a task\n", "<p>[x] this is not a task</p>\n");
         assertRendering(
-                " [ ] this is not a task either\n", "<p>[ ] this is not a task either</p>\n");
+                """
+                [x] this is not a task
+                """,
+                """
+                <p>[x] this is not a task</p>
+                """);
+        assertRendering(
+                """
+                 [ ] this is not a task either
+                """,
+                """
+                <p>[ ] this is not a task either</p>
+                """);
     }
 
     @Test
     public void notValidTaskFormat() {
-        assertRendering("- [x]no space\n", "<ul>\n<li>[x]no space</li>\n</ul>\n");
         assertRendering(
-                "- [O] is not a _task_\n", "<ul>\n<li>[O] is not a <em>task</em></li>\n</ul>\n");
-        assertRendering("* [] neither is this\n", "<ul>\n<li>[] neither is this</li>\n</ul>\n");
+                """
+                - [x]no space
+                """,
+                """
+                <ul>
+                <li>[x]no space</li>
+                </ul>
+                """);
         assertRendering(
-                "* [  ] nor this\n" + "* [XX] nor this\n",
-                "<ul>\n<li>[  ] nor this</li>\n<li>[XX] nor this</li>\n</ul>\n");
-        assertRendering("+ [x]] is not a task\n", "<ul>\n<li>[x]] is not a task</li>\n</ul>\n");
-        assertRendering("- [x isn't\n", "<ul>\n<li>[x isn't</li>\n</ul>\n");
-        assertRendering("- [[x is not\n", "<ul>\n<li>[[x is not</li>\n</ul>\n");
-        assertRendering("- x] nope\n", "<ul>\n<li>x] nope</li>\n</ul>\n");
-        assertRendering("- x]] no way\n", "<ul>\n<li>x]] no way</li>\n</ul>\n");
-        assertRendering("+ (x) sorry no\n", "<ul>\n<li>(x) sorry no</li>\n</ul>\n");
-        assertRendering("+ {x} sorry not sorry\n", "<ul>\n<li>{x} sorry not sorry</li>\n</ul>\n");
-        assertRendering("+ [[x]] nooo\n", "<ul>\n<li>[[x]] nooo</li>\n</ul>\n");
+                """
+                - [O] is not a _task_
+                """,
+                """
+                <ul>
+                <li>[O] is not a <em>task</em></li>
+                </ul>
+                """);
         assertRendering(
-                "+ text before [x] is not a task\n",
-                "<ul>\n<li>text before [x] is not a task</li>\n</ul>\n");
-        assertRendering("* [x]  \n* [ ]  \n", "<ul>\n<li>[x]</li>\n<li>[ ]</li>\n</ul>\n");
+                """
+                * [] neither is this
+                """,
+                """
+                <ul>
+                <li>[] neither is this</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                * [  ] nor this
+                * [XX] nor this
+                """,
+                """
+                <ul>
+                <li>[  ] nor this</li>
+                <li>[XX] nor this</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                + [x]] is not a task
+                """,
+                """
+                <ul>
+                <li>[x]] is not a task</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                - [x isn't
+                """,
+                """
+                <ul>
+                <li>[x isn't</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                - [[x is not
+                """,
+                """
+                <ul>
+                <li>[[x is not</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                - x] nope
+                """,
+                """
+                <ul>
+                <li>x] nope</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                - x]] no way
+                """,
+                """
+                <ul>
+                <li>x]] no way</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                + (x) sorry no
+                """,
+                """
+                <ul>
+                <li>(x) sorry no</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                + {x} sorry not sorry
+                """,
+                """
+                <ul>
+                <li>{x} sorry not sorry</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                + [[x]] nooo
+                """,
+                """
+                <ul>
+                <li>[[x]] nooo</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                + text before [x] is not a task
+                """,
+                """
+                <ul>
+                <li>text before [x] is not a task</li>
+                </ul>
+                """);
+        assertRendering(
+                """
+                * [x] \s
+                * [ ] \s
+                """,
+                """
+                <ul>
+                <li>[x]</li>
+                <li>[ ]</li>
+                </ul>
+                """);
     }
 
     @Override

--- a/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterDataTest.java
+++ b/commonmark-ext-yaml-front-matter/src/test/java/org/commonmark/ext/front/matter/YamlFrontMatterDataTest.java
@@ -20,7 +20,13 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
 
     @Test
     public void simpleValue() {
-        final String input = "---" + "\nhello: world" + "\n..." + "\n" + "\ngreat";
+        final String input =
+                """
+                ---
+                hello: world
+                ...
+
+                great""";
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatterData(input);
@@ -35,7 +41,13 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
 
     @Test
     public void emptyValue() {
-        final String input = "---" + "\nkey:" + "\n---" + "\n" + "\ngreat";
+        final String input =
+                """
+                ---
+                key:
+                ---
+
+                great""";
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatterData(input);
@@ -50,7 +62,15 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
     @Test
     public void listValues() {
         final String input =
-                "---" + "\nlist:" + "\n  - value1" + "\n  - value2" + "\n..." + "\n" + "\ngreat";
+                """
+                ---
+                list:
+                  - value1
+                  - value2
+                ...
+
+                great
+                """;
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatterData(input);
@@ -67,13 +87,15 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
     @Test
     public void literalValue1() {
         final String input =
-                "---"
-                        + "\nliteral: |"
-                        + "\n  hello markdown!"
-                        + "\n  literal thing..."
-                        + "\n---"
-                        + "\n"
-                        + "\ngreat";
+                """
+                ---
+                literal: |
+                  hello markdown!
+                  literal thing...
+                ---
+
+                great
+                """;
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatterData(input);
@@ -89,7 +111,14 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
     @Test
     public void literalValue2() {
         final String input =
-                "---" + "\nliteral: |" + "\n  - hello markdown!" + "\n---" + "\n" + "\ngreat";
+                """
+                ---
+                literal: |
+                  - hello markdown!
+                ---
+
+                great
+                """;
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatterData(input);
@@ -105,17 +134,19 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
     @Test
     public void complexValues() {
         final String input =
-                "---"
-                        + "\nsimple: value"
-                        + "\nliteral: |"
-                        + "\n  hello markdown!"
-                        + "\n"
-                        + "\n  literal literal"
-                        + "\nlist:"
-                        + "\n    - value1"
-                        + "\n    - value2"
-                        + "\n---"
-                        + "\ngreat";
+                """
+                ---
+                simple: value
+                literal: |
+                  hello markdown!
+
+                  literal literal
+                list:
+                    - value1
+                    - value2
+                ---
+                great
+                """;
         final String rendered = "<p>great</p>\n";
 
         Map<String, List<String>> data = getFrontMatterData(input);
@@ -140,7 +171,12 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
 
     @Test
     public void empty() {
-        final String input = "---\n" + "---\n" + "test";
+        final String input =
+                """
+                ---
+                ---
+                test
+                """;
         final String rendered = "<p>test</p>\n";
 
         Map<String, List<String>> data = getFrontMatterData(input);
@@ -153,9 +189,20 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
     @Test
     public void yamlInParagraph() {
         final String input =
-                "# hello\n" + "\nhello markdown world!" + "\n---" + "\nhello: world" + "\n---";
+                """
+                # hello
+
+                hello markdown world!
+                ---
+                hello: world
+                ---
+                """;
         final String rendered =
-                "<h1>hello</h1>\n<h2>hello markdown world!</h2>\n<h2>hello: world</h2>\n";
+                """
+                <h1>hello</h1>
+                <h2>hello markdown world!</h2>
+                <h2>hello: world</h2>
+                """;
 
         Map<String, List<String>> data = getFrontMatterData(input);
 
@@ -166,8 +213,20 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
 
     @Test
     public void yamlOnSecondLine() {
-        final String input = "hello\n" + "\n---" + "\nhello: world" + "\n---";
-        final String rendered = "<p>hello</p>\n<hr />\n<h2>hello: world</h2>\n";
+        final String input =
+                """
+                hello
+
+                ---
+                hello: world
+                ---
+                """;
+        final String rendered =
+                """
+                <p>hello</p>
+                <hr />
+                <h2>hello: world</h2>
+                """;
 
         Map<String, List<String>> data = getFrontMatterData(input);
 
@@ -178,8 +237,16 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
 
     @Test
     public void nonMatchedStartTag() {
-        final String input = "----\n" + "test";
-        final String rendered = "<hr />\n<p>test</p>\n";
+        final String input =
+                """
+                ----
+                test
+                """;
+        final String rendered =
+                """
+                <hr />
+                <p>test</p>
+                """;
 
         Map<String, List<String>> data = getFrontMatterData(input);
 
@@ -190,8 +257,22 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
 
     @Test
     public void inList() {
-        final String input = "* ---\n" + "  ---\n" + "test";
-        final String rendered = "<ul>\n<li>\n<hr />\n<hr />\n</li>\n</ul>\n<p>test</p>\n";
+        final String input =
+                """
+                * ---
+                  ---
+                test
+                """;
+        final String rendered =
+                """
+                <ul>
+                <li>
+                <hr />
+                <hr />
+                </li>
+                </ul>
+                <p>test</p>
+                """;
 
         Map<String, List<String>> data = getFrontMatterData(input);
 
@@ -202,7 +283,12 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
 
     @Test
     public void visitorIgnoresOtherCustomNodes() {
-        final String input = "---" + "\nhello: world" + "\n---" + "\n";
+        final String input =
+                """
+                ---
+                hello: world
+                ---
+                """;
 
         YamlFrontMatterVisitor visitor = new YamlFrontMatterVisitor();
         Node document = parser.parse(input);
@@ -217,7 +303,12 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
 
     @Test
     public void nodesCanBeModified() {
-        final String input = "---" + "\nhello: world" + "\n---" + "\n";
+        final String input =
+                """
+                ---
+                hello: world
+                ---
+                """;
 
         Node document = parser.parse(input);
         YamlFrontMatterNode node = (YamlFrontMatterNode) document.getFirstChild().getFirstChild();
@@ -235,7 +326,12 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
 
     @Test
     public void dotInKeys() {
-        final String input = "---" + "\nms.author: author" + "\n---" + "\n";
+        final String input =
+                """
+                ---
+                ms.author: author
+                ---
+                """;
 
         Map<String, List<String>> data = getFrontMatterData(input);
 
@@ -248,7 +344,13 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
     @Test
     public void singleQuotedLiterals() {
         final String input =
-                "---" + "\nstring: 'It''s me'" + "\nlist:" + "\n  - 'I''m here'" + "\n---" + "\n";
+                """
+                ---
+                string: 'It''s me'
+                list:
+                  - 'I''m here'
+                ---
+                """;
 
         Map<String, List<String>> data = getFrontMatterData(input);
 
@@ -260,12 +362,13 @@ public class YamlFrontMatterDataTest extends YamlFrontMatterTestCase {
     @Test
     public void doubleQuotedLiteral() {
         final String input =
-                "---"
-                        + "\nstring: \"backslash: \\\\ quote: \\\"\""
-                        + "\nlist:"
-                        + "\n  - \"hey\""
-                        + "\n---"
-                        + "\n";
+                """
+                ---
+                string: "backslash: \\\\ quote: \\""
+                list:
+                  - "hey"
+                ---
+                """;
 
         Map<String, List<String>> data = getFrontMatterData(input);
 

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/ExtensionsIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/ExtensionsIntegrationTest.java
@@ -19,16 +19,27 @@ public class ExtensionsIntegrationTest extends RenderingTestCase {
     @Test
     public void testImageAttributes() {
         assertRendering(
-                "![text](/url.png){height=5 width=6}",
-                "<p><img src=\"/url.png\" alt=\"text\" height=\"5\" width=\"6\" /></p>\n");
+                """
+                ![text](/url.png){height=5 width=6}
+                """,
+                """
+                <p><img src="/url.png" alt="text" height="5" width="6" /></p>
+                """);
     }
 
     @Test
     public void testTaskListItems() {
         assertRendering(
-                "- [ ] task to do\n- [x] task done\n",
-                "<ul>\n<li><input type=\"checkbox\" disabled=\"\"> task to do</li>\n"
-                        + "<li><input type=\"checkbox\" disabled=\"\" checked=\"\"> task done</li>\n</ul>\n");
+                """
+                - [ ] task to do
+                - [x] task done
+                """,
+                """
+                <ul>
+                <li><input type="checkbox" disabled=""> task to do</li>
+                <li><input type="checkbox" disabled="" checked=""> task done</li>
+                </ul>
+                """);
     }
 
     @Override

--- a/commonmark-integration-test/src/test/java/org/commonmark/ui/DingusApp.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/ui/DingusApp.java
@@ -80,10 +80,17 @@ public class DingusApp {
         tabbedPane.addChangeListener(e -> updateOutput(input.getText()));
 
         input.setText(
-                "# Example\n"
-                        + "Enter text *here* and see how it renders on the right.\n\n"
-                        + "* Try\n* this\n\n"
-                        + "```\nor this\n```");
+                """
+                # Example
+                Enter text *here* and see how it renders on the right.
+
+                * Try
+                * this
+
+                ```
+                or this
+                ```
+                """);
         updateOutput(input.getText());
 
         frame.setLayout(new GridLayout());

--- a/commonmark/src/test/java/org/commonmark/test/DelimitedTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/DelimitedTest.java
@@ -13,7 +13,12 @@ public class DelimitedTest {
     @Test
     public void emphasisDelimiters() {
         String input =
-                "* *emphasis* \n" + "* **strong** \n" + "* _important_ \n" + "* __CRITICAL__ \n";
+                """
+                * *emphasis*\s
+                * **strong**\s
+                * _important_\s
+                * __CRITICAL__\s
+                """;
 
         Parser parser = Parser.builder().build();
         Node document = parser.parse(input);

--- a/commonmark/src/test/java/org/commonmark/test/FencedCodeBlockParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/FencedCodeBlockParserTest.java
@@ -3,7 +3,6 @@ package org.commonmark.test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.commonmark.node.FencedCodeBlock;
-import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
@@ -16,7 +15,13 @@ public class FencedCodeBlockParserTest extends RenderingTestCase {
 
     @Test
     public void backtickInfo() {
-        Node document = PARSER.parse("```info ~ test\ncode\n```");
+        var s =
+                """
+                ```info ~ test
+                code
+                ```
+                """;
+        var document = PARSER.parse(s);
         FencedCodeBlock codeBlock = (FencedCodeBlock) document.getFirstChild();
         assertThat(codeBlock.getInfo()).isEqualTo("info ~ test");
         assertThat(codeBlock.getLiteral()).isEqualTo("code\n");
@@ -25,34 +30,78 @@ public class FencedCodeBlockParserTest extends RenderingTestCase {
     @Test
     public void backtickInfoDoesntAllowBacktick() {
         assertRendering(
-                "```info ` test\ncode\n```",
-                "<p>```info ` test\ncode</p>\n<pre><code></code></pre>\n");
+                """
+                ```info ` test
+                code
+                ```
+                """,
+                """
+                <p>```info ` test
+                code</p>
+                <pre><code></code></pre>
+                """);
     }
 
     @Test
     public void backtickAndTildeCantBeMixed() {
-        assertRendering("``~`\ncode\n``~`", "<p><code>~` code </code>~`</p>\n");
+        assertRendering(
+                """
+                ``~`
+                code
+                ``~`
+                """,
+                """
+                <p><code>~` code </code>~`</p>
+                """);
     }
 
     @Test
     public void closingCanHaveSpacesAfter() {
-        assertRendering("```\ncode\n```   ", "<pre><code>code\n</code></pre>\n");
+        assertRendering(
+                """
+                ```
+                code
+                ```  \s
+                """,
+                """
+                <pre><code>code
+                </code></pre>
+                """);
     }
 
     @Test
     public void closingCanNotHaveNonSpaces() {
-        assertRendering("```\ncode\n``` a", "<pre><code>code\n``` a\n</code></pre>\n");
+        assertRendering(
+                """
+                ```
+                code
+                ``` a
+                """,
+                """
+                <pre><code>code
+                ``` a
+                </code></pre>
+                """);
     }
 
     @Test
     public void issue151() {
         assertRendering(
-                "```\nthis code\n\nshould not have BRs or paragraphs in it\nok\n```",
-                "<pre><code>this code\n"
-                        + "\n"
-                        + "should not have BRs or paragraphs in it\n"
-                        + "ok\n"
-                        + "</code></pre>\n");
+                """
+                ```
+                this code
+
+                should not have BRs or paragraphs in it
+                ok
+                ```
+                """,
+                """
+                <pre><code>this code
+
+                should not have BRs or paragraphs in it
+                ok
+                </code></pre>
+                """);
     }
 
     @Override

--- a/commonmark/src/test/java/org/commonmark/test/ListTightLooseTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ListTightLooseTest.java
@@ -7,149 +7,241 @@ public class ListTightLooseTest extends CoreRenderingTestCase {
     @Test
     public void tight() {
         assertRendering(
-                "- foo\n" + "- bar\n" + "+ baz\n",
-                "<ul>\n"
-                        + "<li>foo</li>\n"
-                        + "<li>bar</li>\n"
-                        + "</ul>\n"
-                        + "<ul>\n"
-                        + "<li>baz</li>\n"
-                        + "</ul>\n");
+                """
+                - foo
+                - bar
+                + baz
+                """,
+                """
+                <ul>
+                <li>foo</li>
+                <li>bar</li>
+                </ul>
+                <ul>
+                <li>baz</li>
+                </ul>
+                """);
     }
 
     @Test
     public void loose() {
         assertRendering(
-                "- foo\n" + "\n" + "- bar\n" + "\n" + "\n" + "- baz\n",
-                "<ul>\n"
-                        + "<li>\n"
-                        + "<p>foo</p>\n"
-                        + "</li>\n"
-                        + "<li>\n"
-                        + "<p>bar</p>\n"
-                        + "</li>\n"
-                        + "<li>\n"
-                        + "<p>baz</p>\n"
-                        + "</li>\n"
-                        + "</ul>\n");
+                """
+                - foo
+
+                - bar
+
+
+                - baz
+                """,
+                """
+                <ul>
+                <li>
+                <p>foo</p>
+                </li>
+                <li>
+                <p>bar</p>
+                </li>
+                <li>
+                <p>baz</p>
+                </li>
+                </ul>
+                """);
     }
 
     @Test
     public void looseNested() {
         assertRendering(
-                "- foo\n" + "  - bar\n" + "\n" + "\n" + "    baz",
-                "<ul>\n"
-                        + "<li>foo\n"
-                        + "<ul>\n"
-                        + "<li>\n"
-                        + "<p>bar</p>\n"
-                        + "<p>baz</p>\n"
-                        + "</li>\n"
-                        + "</ul>\n"
-                        + "</li>\n"
-                        + "</ul>\n");
+                """
+                - foo
+                  - bar
+
+
+                    baz
+                """,
+                """
+                <ul>
+                <li>foo
+                <ul>
+                <li>
+                <p>bar</p>
+                <p>baz</p>
+                </li>
+                </ul>
+                </li>
+                </ul>
+                """);
     }
 
     @Test
     public void looseNested2() {
         assertRendering(
-                "- a\n" + "  - b\n" + "\n" + "    c\n" + "- d\n",
-                "<ul>\n"
-                        + "<li>a\n"
-                        + "<ul>\n"
-                        + "<li>\n"
-                        + "<p>b</p>\n"
-                        + "<p>c</p>\n"
-                        + "</li>\n"
-                        + "</ul>\n"
-                        + "</li>\n"
-                        + "<li>d</li>\n"
-                        + "</ul>\n");
+                """
+                - a
+                  - b
+
+                    c
+                - d
+                """,
+                """
+                <ul>
+                <li>a
+                <ul>
+                <li>
+                <p>b</p>
+                <p>c</p>
+                </li>
+                </ul>
+                </li>
+                <li>d</li>
+                </ul>
+                """);
     }
 
     @Test
     public void looseOuter() {
         assertRendering(
-                "- foo\n" + "  - bar\n" + "\n" + "\n" + "  baz",
-                "<ul>\n"
-                        + "<li>\n"
-                        + "<p>foo</p>\n"
-                        + "<ul>\n"
-                        + "<li>bar</li>\n"
-                        + "</ul>\n"
-                        + "<p>baz</p>\n"
-                        + "</li>\n"
-                        + "</ul>\n");
+                """
+                - foo
+                  - bar
+
+
+                  baz
+                """,
+                """
+                <ul>
+                <li>
+                <p>foo</p>
+                <ul>
+                <li>bar</li>
+                </ul>
+                <p>baz</p>
+                </li>
+                </ul>
+                """);
     }
 
     @Test
     public void looseListItem() {
         assertRendering(
-                "- one\n" + "\n" + "  two\n",
-                "<ul>\n" + "<li>\n" + "<p>one</p>\n" + "<p>two</p>\n" + "</li>\n" + "</ul>\n");
+                """
+                - one
+
+                  two
+                """,
+                """
+                <ul>
+                <li>
+                <p>one</p>
+                <p>two</p>
+                </li>
+                </ul>
+                """);
     }
 
     @Test
     public void tightWithBlankLineAfter() {
         assertRendering(
-                "- foo\n" + "- bar\n" + "\n",
-                "<ul>\n" + "<li>foo</li>\n" + "<li>bar</li>\n" + "</ul>\n");
+                """
+                - foo
+                - bar
+
+                """,
+                """
+                <ul>
+                <li>foo</li>
+                <li>bar</li>
+                </ul>
+                """);
     }
 
     @Test
     public void tightListWithCodeBlock() {
         assertRendering(
-                "- a\n" + "- ```\n" + "  b\n" + "\n" + "\n" + "  ```\n" + "- c\n",
-                "<ul>\n"
-                        + "<li>a</li>\n"
-                        + "<li>\n"
-                        + "<pre><code>b\n"
-                        + "\n"
-                        + "\n"
-                        + "</code></pre>\n"
-                        + "</li>\n"
-                        + "<li>c</li>\n"
-                        + "</ul>\n");
+                """
+                - a
+                - ```
+                  b
+
+
+                  ```
+                - c
+                """,
+                """
+                <ul>
+                <li>a</li>
+                <li>
+                <pre><code>b
+
+
+                </code></pre>
+                </li>
+                <li>c</li>
+                </ul>
+                """);
     }
 
     @Test
     public void tightListWithCodeBlock2() {
         assertRendering(
-                "* foo\n" + "  ```\n" + "  bar\n" + "\n" + "  ```\n" + "  baz\n",
-                "<ul>\n"
-                        + "<li>foo\n"
-                        + "<pre><code>bar\n"
-                        + "\n"
-                        + "</code></pre>\n"
-                        + "baz</li>\n"
-                        + "</ul>\n");
+                """
+                * foo
+                  ```
+                  bar
+
+                  ```
+                  baz
+                """,
+                """
+                <ul>
+                <li>foo
+                <pre><code>bar
+
+                </code></pre>
+                baz</li>
+                </ul>
+                """);
     }
 
     @Test
     public void looseEmptyListItem() {
         assertRendering(
-                "* a\n" + "*\n" + "\n" + "* c",
-                "<ul>\n"
-                        + "<li>\n"
-                        + "<p>a</p>\n"
-                        + "</li>\n"
-                        + "<li></li>\n"
-                        + "<li>\n"
-                        + "<p>c</p>\n"
-                        + "</li>\n"
-                        + "</ul>\n");
+                """
+                * a
+                *
+
+                * c""",
+                """
+                <ul>
+                <li>
+                <p>a</p>
+                </li>
+                <li></li>
+                <li>
+                <p>c</p>
+                </li>
+                </ul>
+                """);
     }
 
     @Test
     public void looseBlankLineAfterCodeBlock() {
         assertRendering(
-                "1. ```\n" + "   foo\n" + "   ```\n" + "\n" + "   bar",
-                "<ol>\n"
-                        + "<li>\n"
-                        + "<pre><code>foo\n"
-                        + "</code></pre>\n"
-                        + "<p>bar</p>\n"
-                        + "</li>\n"
-                        + "</ol>\n");
+                """
+                1. ```
+                   foo
+                   ```
+
+                   bar
+                """,
+                """
+                <ol>
+                <li>
+                <pre><code>foo
+                </code></pre>
+                <p>bar</p>
+                </li>
+                </ol>
+                """);
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
@@ -56,69 +56,222 @@ public class SpecialInputTest extends CoreRenderingTestCase {
     @Test
     public void tightListInBlockQuote() {
         assertRendering(
-                "> *\n> * a", "<blockquote>\n<ul>\n<li></li>\n<li>a</li>\n</ul>\n</blockquote>\n");
+                """
+                > *
+                > * a
+                """,
+                """
+                <blockquote>
+                <ul>
+                <li></li>
+                <li>a</li>
+                </ul>
+                </blockquote>
+                """);
     }
 
     @Test
     public void looseListInBlockQuote() {
         // Second line in block quote is considered blank for purpose of loose list
         assertRendering(
-                "> *\n>\n> * a",
-                "<blockquote>\n<ul>\n<li></li>\n<li>\n<p>a</p>\n</li>\n</ul>\n</blockquote>\n");
+                """
+                > *
+                >
+                > * a
+                """,
+                """
+                <blockquote>
+                <ul>
+                <li></li>
+                <li>
+                <p>a</p>
+                </li>
+                </ul>
+                </blockquote>
+                """);
     }
 
     @Test
     public void lineWithOnlySpacesAfterListBullet() {
-        assertRendering("-  \n  \n  foo\n", "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n");
+        assertRendering(
+                """
+                - \s
+                 \s
+                  foo
+                """,
+                """
+                <ul>
+                <li></li>
+                </ul>
+                <p>foo</p>
+                """);
     }
 
     @Test
     public void listWithTwoSpacesForFirstBullet() {
         // We have two spaces after the bullet, but no content. With content, the next line would be
         // required
-        assertRendering("*  \n  foo\n", "<ul>\n<li>foo</li>\n</ul>\n");
+        assertRendering(
+                """
+                * \s
+                  foo
+                """,
+                """
+                <ul>
+                <li>foo</li>
+                </ul>
+                """);
     }
 
     @Test
     public void orderedListMarkerOnly() {
-        assertRendering("2.", "<ol start=\"2\">\n<li></li>\n</ol>\n");
+        assertRendering(
+                """
+                2.
+                """,
+                """
+                <ol start="2">
+                <li></li>
+                </ol>
+                """);
     }
 
     @Test
     public void columnIsInTabOnPreviousLine() {
         assertRendering(
-                "- foo\n\n\tbar\n\n# baz\n",
-                "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n<h1>baz</h1>\n");
+                """
+                - foo
+
+                \tbar
+
+                # baz
+                """,
+                """
+                <ul>
+                <li>
+                <p>foo</p>
+                <p>bar</p>
+                </li>
+                </ul>
+                <h1>baz</h1>
+                """);
         assertRendering(
-                "- foo\n\n\tbar\n# baz\n",
-                "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n<h1>baz</h1>\n");
+                """
+                - foo
+
+                \tbar
+                # baz
+                """,
+                """
+                <ul>
+                <li>
+                <p>foo</p>
+                <p>bar</p>
+                </li>
+                </ul>
+                <h1>baz</h1>
+                """);
     }
 
     @Test
     public void linkLabelWithBracket() {
-        assertRendering("[a[b]\n\n[a[b]: /", "<p>[a[b]</p>\n<p>[a[b]: /</p>\n");
-        assertRendering("[a]b]\n\n[a]b]: /", "<p>[a]b]</p>\n<p>[a]b]: /</p>\n");
-        assertRendering("[a[b]]\n\n[a[b]]: /", "<p>[a[b]]</p>\n<p>[a[b]]: /</p>\n");
+        assertRendering(
+                """
+                [a[b]
+
+                [a[b]: /
+                """,
+                """
+                <p>[a[b]</p>
+                <p>[a[b]: /</p>
+                """);
+        assertRendering(
+                """
+                [a]b]
+
+                [a]b]: /
+                """,
+                """
+                <p>[a]b]</p>
+                <p>[a]b]: /</p>
+                """);
+        assertRendering(
+                """
+                [a[b]]
+
+                [a[b]]: /
+                """,
+                """
+                <p>[a[b]]</p>
+                <p>[a[b]]: /</p>
+                """);
     }
 
     @Test
     public void linkLabelLength() {
         String label1 = "a".repeat(999);
         assertRendering(
-                "[foo][" + label1 + "]\n\n[" + label1 + "]: /", "<p><a href=\"/\">foo</a></p>\n");
+                """
+                [foo][%s]
+
+                [%s]: /
+                """
+                        .formatted(label1, label1),
+                """
+                <p><a href="/">foo</a></p>
+                """);
         assertRendering(
-                "[foo][x" + label1 + "]\n\n[x" + label1 + "]: /",
-                "<p>[foo][x" + label1 + "]</p>\n<p>[x" + label1 + "]: /</p>\n");
+                """
+                [foo][x%s]
+
+                [x%s]: /
+                """
+                        .formatted(label1, label1),
+                """
+                <p>[foo][x%s]</p>
+                <p>[x%s]: /</p>
+                """
+                        .formatted(label1, label1));
         assertRendering(
-                "[foo][\n" + label1 + "]\n\n[\n" + label1 + "]: /",
-                "<p>[foo][\n" + label1 + "]</p>\n<p>[\n" + label1 + "]: /</p>\n");
+                """
+                [foo][
+                %s]
+
+                [
+                %s]: /
+                """
+                        .formatted(label1, label1),
+                """
+                <p>[foo][
+                %s]</p>
+                <p>[
+                %s]: /</p>
+                """
+                        .formatted(label1, label1));
 
         String label2 = "a\n".repeat(499);
         assertRendering(
-                "[foo][" + label2 + "]\n\n[" + label2 + "]: /", "<p><a href=\"/\">foo</a></p>\n");
+                """
+                [foo][%s]
+
+                [%s]: /
+                """
+                        .formatted(label2, label2),
+                """
+                <p><a href="/">foo</a></p>
+                """);
         assertRendering(
-                "[foo][12" + label2 + "]\n\n[12" + label2 + "]: /",
-                "<p>[foo][12" + label2 + "]</p>\n<p>[12" + label2 + "]: /</p>\n");
+                """
+                [foo][12%s]
+
+                [12%s]: /
+                """
+                        .formatted(label2, label2),
+                """
+                <p>[foo][12%s]</p>
+                <p>[12%s]: /</p>
+                """
+                        .formatted(label2, label2));
     }
 
     @Test
@@ -143,9 +296,25 @@ public class SpecialInputTest extends CoreRenderingTestCase {
         // Backslash escapes ']', so not a valid link label
         assertRendering("[\\]: test", "<p>[]: test</p>\n");
         // Backslash is a literal, so valid
-        assertRendering("[a\\b]\n\n[a\\b]: test", "<p><a href=\"test\">a\\b</a></p>\n");
+        assertRendering(
+                """
+                [a\\b]
+
+                [a\\b]: test
+                """,
+                """
+                <p><a href="test">a\\b</a></p>
+                """);
         // Backslash escapes `]` but there's another `]`, valid
-        assertRendering("[a\\]]\n\n[a\\]]: test", "<p><a href=\"test\">a]</a></p>\n");
+        assertRendering(
+                """
+                [a\\]]
+
+                [a\\]]: test
+                """,
+                """
+                <p><a href="test">a]</a></p>
+                """);
     }
 
     // commonmark/cmark#177
@@ -170,22 +339,29 @@ public class SpecialInputTest extends CoreRenderingTestCase {
     @Test
     public void deeplyIndentedList() {
         assertRendering(
-                "* one\n" + "  * two\n" + "    * three\n" + "      * four",
-                "<ul>\n"
-                        + "<li>one\n"
-                        + "<ul>\n"
-                        + "<li>two\n"
-                        + "<ul>\n"
-                        + "<li>three\n"
-                        + "<ul>\n"
-                        + "<li>four</li>\n"
-                        + "</ul>\n"
-                        + "</li>\n"
-                        + "</ul>\n"
-                        + "</li>\n"
-                        + "</ul>\n"
-                        + "</li>\n"
-                        + "</ul>\n");
+                """
+                * one
+                  * two
+                    * three
+                      * four
+                """,
+                """
+                <ul>
+                <li>one
+                <ul>
+                <li>two
+                <ul>
+                <li>three
+                <ul>
+                <li>four</li>
+                </ul>
+                </li>
+                </ul>
+                </li>
+                </ul>
+                </li>
+                </ul>
+                """);
     }
 
     @Test
@@ -193,7 +369,15 @@ public class SpecialInputTest extends CoreRenderingTestCase {
         // The tab is not treated as 4 spaces here and so does not result in a hard line break, but
         // is just preserved.
         // This matches what commonmark.js did at the time of writing.
-        assertRendering("a\t\nb\n", "<p>a\t\nb</p>\n");
+        assertRendering(
+                """
+                a\t
+                b
+                """,
+                """
+                <p>a\t
+                b</p>
+                """);
     }
 
     @Test
@@ -209,36 +393,67 @@ public class SpecialInputTest extends CoreRenderingTestCase {
     @Test
     public void htmlBlockInterruptingList() {
         assertRendering(
-                "- <script>\n" + "- some text\n" + "some other text\n" + "</script>\n",
-                "<ul>\n"
-                        + "<li>\n"
-                        + "<script>\n"
-                        + "</li>\n"
-                        + "<li>some text\n"
-                        + "some other text\n"
-                        + "</script></li>\n"
-                        + "</ul>\n");
+                """
+                - <script>
+                - some text
+                some other text
+                </script>
+                """,
+                """
+                <ul>
+                <li>
+                <script>
+                </li>
+                <li>some text
+                some other text
+                </script></li>
+                </ul>
+                """);
 
         assertRendering(
-                "- <script>\n" + "- some text\n" + "some other text\n" + "\n" + "</script>\n",
-                "<ul>\n"
-                        + "<li>\n"
-                        + "<script>\n"
-                        + "</li>\n"
-                        + "<li>some text\n"
-                        + "some other text</li>\n"
-                        + "</ul>\n"
-                        + "</script>\n");
+                """
+                - <script>
+                - some text
+                some other text
+
+                </script>
+                """,
+                """
+                <ul>
+                <li>
+                <script>
+                </li>
+                <li>some text
+                some other text</li>
+                </ul>
+                </script>
+                """);
     }
 
     @Test
     public void emphasisAfterHardLineBreak() {
         assertRendering(
-                "Hello  \n" + "**Bar**\n" + "Foo\n",
-                "<p>Hello<br />\n" + "<strong>Bar</strong>\n" + "Foo</p>\n");
+                """
+                Hello \s
+                **Bar**
+                Foo
+                """,
+                """
+                <p>Hello<br />
+                <strong>Bar</strong>
+                Foo</p>
+                """);
 
         assertRendering(
-                "Hello  \n" + "**Bar**  \n" + "Foo\n",
-                "<p>Hello<br />\n" + "<strong>Bar</strong><br />\n" + "Foo</p>\n");
+                """
+                Hello \s
+                **Bar** \s
+                Foo
+                """,
+                """
+                <p>Hello<br />
+                <strong>Bar</strong><br />
+                Foo</p>
+                """);
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
@@ -32,17 +32,56 @@ public class TextContentRendererTest {
         assertCompact(s, "foo bar");
         assertStripped(s, "foo bar");
 
-        s = "foo foo\n\nbar\nbar";
-        assertCompact(s, "foo foo\nbar\nbar");
-        assertSeparate(s, "foo foo\n\nbar\nbar");
+        s =
+                """
+                foo foo
+
+                bar
+                bar""";
+        assertCompact(
+                s,
+                """
+                foo foo
+                bar
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo foo
+
+                bar
+                bar""");
         assertStripped(s, "foo foo bar bar");
     }
 
     @Test
     public void textContentHeading() {
-        assertCompact("# Heading\n\nFoo", "Heading\nFoo");
-        assertSeparate("# Heading\n\nFoo", "Heading\n\nFoo");
-        assertStripped("# Heading\n\nFoo", "Heading: Foo");
+        assertCompact(
+                """
+                # Heading
+
+                Foo
+                """,
+                """
+                        Heading
+                        Foo""");
+        assertSeparate(
+                """
+                # Heading
+
+                Foo
+                """,
+                """
+                        Heading
+
+                        Foo""");
+        assertStripped(
+                """
+                # Heading
+
+                Foo
+                """,
+                "Heading: Foo");
     }
 
     @Test
@@ -57,9 +96,29 @@ public class TextContentRendererTest {
         assertCompact(s, "foo foo bar bar");
         assertStripped(s, "foo foo bar bar");
 
-        s = "foo\n***foo***\nbar\n\n***bar***";
-        assertCompact(s, "foo\nfoo\nbar\nbar");
-        assertSeparate(s, "foo\nfoo\nbar\n\nbar");
+        s =
+                """
+                foo
+                ***foo***
+                bar
+
+                ***bar***
+                """;
+        assertCompact(
+                s,
+                """
+                foo
+                foo
+                bar
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+                foo
+                bar
+
+                bar""");
         assertStripped(s, "foo foo bar bar");
     }
 
@@ -67,9 +126,30 @@ public class TextContentRendererTest {
     public void textContentQuotes() {
         String s;
 
-        s = "foo\n>foo\nbar\n\nbar";
-        assertCompact(s, "foo\n«foo\nbar»\nbar");
-        assertSeparate(s, "foo\n\n«foo\nbar»\n\nbar");
+        s =
+                """
+                foo
+                >foo
+                bar
+
+                bar
+                """;
+        assertCompact(
+                s,
+                """
+                foo
+                «foo
+                bar»
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+
+                «foo
+                bar»
+
+                bar""");
         assertStripped(s, "foo «foo bar» bar");
     }
 
@@ -94,52 +174,236 @@ public class TextContentRendererTest {
     public void textContentLists() {
         String s;
 
-        s = "foo\n* foo\n* bar\n\nbar";
-        assertCompact(s, "foo\n* foo\n* bar\nbar");
-        assertSeparate(s, "foo\n\n* foo\n* bar\n\nbar");
+        s =
+                """
+                foo
+                * foo
+                * bar
+
+                bar""";
+        assertCompact(
+                s,
+                """
+                foo
+                * foo
+                * bar
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+
+                * foo
+                * bar
+
+                bar""");
         assertStripped(s, "foo foo bar bar");
 
-        s = "foo\n- foo\n- bar\n\nbar";
-        assertCompact(s, "foo\n- foo\n- bar\nbar");
-        assertSeparate(s, "foo\n\n- foo\n- bar\n\nbar");
+        s =
+                """
+                foo
+                - foo
+                - bar
+
+                bar
+                """;
+        assertCompact(
+                s,
+                """
+                foo
+                - foo
+                - bar
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+
+                - foo
+                - bar
+
+                bar""");
         assertStripped(s, "foo foo bar bar");
 
-        s = "foo\n1. foo\n2. bar\n\nbar";
-        assertCompact(s, "foo\n1. foo\n2. bar\nbar");
-        assertSeparate(s, "foo\n\n1. foo\n2. bar\n\nbar");
+        s =
+                """
+                foo
+                1. foo
+                2. bar
+
+                bar
+                """;
+        assertCompact(
+                s,
+                """
+                foo
+                1. foo
+                2. bar
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+
+                1. foo
+                2. bar
+
+                bar""");
         assertStripped(s, "foo 1. foo 2. bar bar");
 
-        s = "foo\n0) foo\n1) bar\n\nbar";
-        assertCompact(s, "foo\n0) foo\n1) bar\nbar");
-        assertSeparate(s, "foo\n0) foo\n\n1) bar\n\nbar");
+        s =
+                """
+                foo
+                0) foo
+                1) bar
+
+                bar
+                """;
+        assertCompact(
+                s,
+                """
+                foo
+                0) foo
+                1) bar
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+                0) foo
+
+                1) bar
+
+                bar""");
         assertStripped(s, "foo 0) foo 1) bar bar");
 
-        s = "bar\n1. foo\n   1. bar\n2. foo";
-        assertCompact(s, "bar\n1. foo\n   1. bar\n2. foo");
-        assertSeparate(s, "bar\n\n1. foo\n   1. bar\n2. foo");
+        s =
+                """
+                bar
+                1. foo
+                   1. bar
+                2. foo
+                """;
+        assertCompact(
+                s,
+                """
+                bar
+                1. foo
+                   1. bar
+                2. foo""");
+        assertSeparate(
+                s,
+                """
+                bar
+
+                1. foo
+                   1. bar
+                2. foo""");
         assertStripped(s, "bar 1. foo 1. bar 2. foo");
 
-        s = "bar\n* foo\n  - bar\n* foo";
-        assertCompact(s, "bar\n* foo\n  - bar\n* foo");
-        assertSeparate(s, "bar\n\n* foo\n  - bar\n* foo");
+        s =
+                """
+                bar
+                * foo
+                  - bar
+                * foo
+                """;
+        assertCompact(
+                s,
+                """
+                bar
+                * foo
+                  - bar
+                * foo""");
+        assertSeparate(
+                s,
+                """
+                bar
+
+                * foo
+                  - bar
+                * foo""");
         assertStripped(s, "bar foo bar foo");
 
-        s = "bar\n* foo\n  1. bar\n  2. bar\n* foo";
-        assertCompact(s, "bar\n* foo\n  1. bar\n  2. bar\n* foo");
-        assertSeparate(s, "bar\n\n* foo\n  1. bar\n  2. bar\n* foo");
+        s =
+                """
+                bar
+                * foo
+                  1. bar
+                  2. bar
+                * foo
+                """;
+        assertCompact(
+                s,
+                """
+                bar
+                * foo
+                  1. bar
+                  2. bar
+                * foo""");
+        assertSeparate(
+                s,
+                """
+                bar
+
+                * foo
+                  1. bar
+                  2. bar
+                * foo""");
         assertStripped(s, "bar foo 1. bar 2. bar foo");
 
-        s = "bar\n1. foo\n   * bar\n   * bar\n2. foo";
-        assertCompact(s, "bar\n1. foo\n   * bar\n   * bar\n2. foo");
-        assertSeparate(s, "bar\n\n1. foo\n   * bar\n   * bar\n2. foo");
+        s =
+                """
+                bar
+                1. foo
+                   * bar
+                   * bar
+                2. foo
+                """;
+        assertCompact(
+                s,
+                """
+                bar
+                1. foo
+                   * bar
+                   * bar
+                2. foo""");
+        assertSeparate(
+                s,
+                """
+                bar
+
+                1. foo
+                   * bar
+                   * bar
+                2. foo""");
         assertStripped(s, "bar 1. foo bar bar 2. foo");
 
         // For a loose list (not tight)
-        s = "foo\n\n* bar\n\n* baz";
+        s =
+                """
+                foo
+
+                * bar
+
+                * baz
+                """;
         // Compact ignores loose
-        assertCompact(s, "foo\n* bar\n* baz");
+        assertCompact(
+                s,
+                """
+                foo
+                * bar
+                * baz""");
         // Separate preserves it
-        assertSeparate(s, "foo\n\n* bar\n\n* baz");
+        assertSeparate(
+                s,
+                """
+                foo
+
+                * bar
+
+                * baz""");
         assertStripped(s, "foo bar baz");
     }
 
@@ -151,14 +415,43 @@ public class TextContentRendererTest {
     @Test
     public void textContentCodeBlock() {
         String s;
-        s = "foo\n```\nfoo\nbar\n```\nbar";
+        s =
+                """
+                foo
+                ```
+                foo
+                bar
+                ```
+                bar
+                """;
         assertCompact(s, "foo\nfoo\nbar\nbar");
         assertSeparate(s, "foo\n\nfoo\nbar\n\nbar");
         assertStripped(s, "foo foo bar bar");
 
-        s = "foo\n\n    foo\n     bar\nbar";
-        assertCompact(s, "foo\nfoo\n bar\nbar");
-        assertSeparate(s, "foo\n\nfoo\n bar\n\nbar");
+        s =
+                """
+                foo
+
+                    foo
+                     bar
+                bar
+                """;
+        assertCompact(
+                s,
+                """
+                foo
+                foo
+                 bar
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+
+                foo
+                 bar
+
+                bar""");
         assertStripped(s, "foo foo bar bar");
     }
 
@@ -166,32 +459,74 @@ public class TextContentRendererTest {
     public void textContentBreaks() {
         String s;
 
-        s = "foo\nbar";
-        assertCompact(s, "foo\nbar");
-        assertSeparate(s, "foo\nbar");
+        s =
+                """
+                foo
+                bar
+                """;
+        assertCompact(
+                s,
+                """
+                foo
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+                bar""");
         assertStripped(s, "foo bar");
 
-        s = "foo  \nbar";
-        assertCompact(s, "foo\nbar");
-        assertSeparate(s, "foo\nbar");
+        s =
+                """
+                foo \s
+                bar
+                """;
+        assertCompact(
+                s,
+                """
+                foo
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+                bar""");
         assertStripped(s, "foo bar");
 
-        s = "foo\n___\nbar";
-        assertCompact(s, "foo\n***\nbar");
-        assertSeparate(s, "foo\n\n***\n\nbar");
+        s =
+                """
+                foo
+                ___
+                bar
+                """;
+        assertCompact(
+                s,
+                """
+                foo
+                ***
+                bar""");
+        assertSeparate(
+                s,
+                """
+                foo
+
+                ***
+
+                bar""");
         assertStripped(s, "foo bar");
     }
 
     @Test
     public void textContentHtml() {
         String html =
-                "<table>\n"
-                        + "  <tr>\n"
-                        + "    <td>\n"
-                        + "           foobar\n"
-                        + "    </td>\n"
-                        + "  </tr>\n"
-                        + "</table>";
+                """
+                <table>
+                  <tr>
+                    <td>
+                           foobar
+                    </td>
+                  </tr>
+                </table>""";
         assertCompact(html, html);
         assertSeparate(html, html);
 
@@ -201,10 +536,18 @@ public class TextContentRendererTest {
 
     @Test
     public void testContentNestedLists() {
-        var s = "List:\n" + "1. 2) 3. \n" + "end";
+        var s =
+                """
+                List:
+                1. 2) 3.\s
+                end""";
         assertCompact(s, s);
 
-        var s2 = "1. A\n   1) B\n      1. Test";
+        var s2 =
+                """
+                1. A
+                   1) B
+                      1. Test""";
         assertCompact(s2, s2);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
                     <version>3.14.0</version>
                     <configuration>
                         <release>11</release>
+                        <testRelease>17</testRelease>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Makes tests with multi-line strings much nicer to read. It means tests don't compile on Java < 15 anymore though.

Note that Java 11 is still supported, and hopefully we'd detect any problems via `<release>11</release>`.